### PR TITLE
fix: remove additional quotes from gc command commit messages

### DIFF
--- a/src/commands/git-commit.ts
+++ b/src/commands/git-commit.ts
@@ -89,6 +89,10 @@ export async function gitCommitCommand(config: Config, messageArgs?: string[]): 
   if (messageArgs && messageArgs.length > 0) {
     // Join all arguments as the commit message
     commitMessage = messageArgs.join(' ')
+    
+    // Remove any additional quotes on the beginning and end
+    // This handles cases where users accidentally include extra quotes
+    commitMessage = commitMessage.replace(/^["']+|["']+$/g, '')
   } else {
     // Prompt for commit message
     const { message } = await prompts({


### PR DESCRIPTION
Added regex to clean up extraneous leading/trailing quotes that may be accidentally included when users provide commit messages. This resolves the bug where extra quotes at the end of commit messages were preserved instead of being removed.

Fixes #21