### PR TITLE
fix: use deploy key for release workflow to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Setup SSH for deploy key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Configure git for SSH
+        run: git remote set-url origin git@github.com:ChrisTowles/towles-tool.git
 
       - uses: ./.github/actions/setup
         with:

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,4 +1,4 @@
-# Releasing
+# GitHub Actions
 
 ## Automated Release
 
@@ -17,3 +17,48 @@ The workflow:
 4. Commits and tags
 5. Creates GitHub release
 6. Publishes to npm
+
+## Branch Protection & Deploy Key Setup
+
+The release workflow needs to push directly to `main`, but branch protection requires CI to pass first. This creates a chicken-and-egg problem since new commits can't pass CI before being pushed.
+
+**Solution:** Deploy key with ruleset bypass.
+
+### How It Works
+
+1. **Deploy Key** - SSH key with write access, stored as `DEPLOY_KEY` secret
+2. **Ruleset** - GitHub ruleset requires CI for all users, but allows deploy keys to bypass
+3. **SSH Authentication** - Release workflow uses `webfactory/ssh-agent` to authenticate via SSH instead of HTTPS
+
+### Setup Steps (if recreating)
+
+```bash
+# 1. Generate deploy key
+ssh-keygen -t ed25519 -C "github-actions@github.com" -N "" -f ./deploy-key
+
+# 2. Add public key to GitHub deploy keys (with write access)
+gh repo deploy-key add ./deploy-key.pub --title "Release Workflow" --allow-write
+
+# 3. Add private key as repository secret
+gh secret set DEPLOY_KEY < ./deploy-key
+
+# 4. Create ruleset with deploy key bypass (via GitHub UI or API)
+# Settings → Rules → Rulesets → Add deploy key to bypass list
+
+# 5. Clean up local key files
+rm ./deploy-key ./deploy-key.pub
+```
+
+### Workflow Configuration
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    persist-credentials: false
+
+- uses: webfactory/ssh-agent@v0.9.0
+  with:
+    ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
+- run: git remote set-url origin git@github.com:OWNER/REPO.git
+```


### PR DESCRIPTION
## Summary
- Switch from GITHUB_TOKEN to deploy key (SSH) for release workflow
- Enables release commits to bypass branch protection rules
- Uses webfactory/ssh-agent action for SSH authentication

## Test Plan
- [x] Deploy key created and added to repository
- [x] DEPLOY_KEY secret configured
- [x] Ruleset created with deploy key bypass
- [ ] Release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)