### PR TITLE
refactor: improve auto-claude pipeline UI with colored banners

### DIFF
--- a/plugins/tt-core/.claude-plugin/plugin.json
+++ b/plugins/tt-core/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
-    "name": "tt",
-    "description": "Ralph autonomous task runner, observability (token treemaps), git workflows, and journaling",
-    "version": "0.0.55",
-    "author": {
-        "name": "Chris Towles"
-    }
+  "name": "tt",
+  "description": "Ralph autonomous task runner, observability (token treemaps), git workflows, and journaling",
+  "version": "0.0.55",
+  "author": {
+    "name": "Chris Towles"
+  }
 }

--- a/src/commands/auto-claude.ts
+++ b/src/commands/auto-claude.ts
@@ -14,6 +14,7 @@ import {
   git,
   initConfig,
   log,
+  logBanner,
   runPipeline,
   sleep,
   stepRefresh,
@@ -140,7 +141,7 @@ export default class AutoClaude extends BaseCommand {
       iteration++;
 
       if (loopMode) {
-        consola.box({ title: `Iteration #${iteration}`, message: new Date().toISOString() });
+        logBanner(`Iteration #${iteration} — ${new Date().toISOString()}`);
       }
 
       try {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -30,6 +30,7 @@ export default class Doctor extends BaseCommand {
       this.checkCommand("gh", ["--version"], /gh version ([\d.]+)/),
       this.checkCommand("node", ["--version"], /v?([\d.]+)/),
       this.checkCommand("bun", ["--version"], /([\d.]+)/),
+      this.checkCommand("pnpm", ["--version"], /([\d.]+)/),
     ]);
 
     // Display results

--- a/src/lib/auto-claude/index.ts
+++ b/src/lib/auto-claude/index.ts
@@ -10,5 +10,6 @@ export {
   ensureBranch,
   git,
   log,
+  logBanner,
   sleep,
 } from "./utils.js";

--- a/src/lib/auto-claude/pipeline.ts
+++ b/src/lib/auto-claude/pipeline.ts
@@ -11,7 +11,7 @@ import { stepPlan } from "./steps/plan.js";
 import { stepRemoveLabel } from "./steps/remove-label.js";
 import { stepResearch } from "./steps/research.js";
 import { stepReview } from "./steps/review.js";
-import { ensureDir, fileExists, git, log, writeFile } from "./utils.js";
+import { ensureDir, fileExists, git, log, readFile, writeFile } from "./utils.js";
 import type { IssueContext } from "./utils.js";
 
 const STEP_RUNNERS: Record<StepName, (ctx: IssueContext) => Promise<boolean>> = {
@@ -55,7 +55,10 @@ export async function runPipeline(ctx: IssueContext, untilStep?: StepName): Prom
     }
   }
 
-  log(`Pipeline complete for ${ctx.repo}#${ctx.number}`);
+  const prUrlPath = join(ctx.issueDir, ARTIFACTS.prUrl);
+  const prUrl = fileExists(prUrlPath) ? readFile(prUrlPath).trim() : "";
+  const prSuffix = prUrl ? ` — ${prUrl}` : "";
+  log(`Pipeline complete for ${ctx.repo}#${ctx.number}${prSuffix}`);
   await checkoutMain();
 }
 

--- a/src/lib/auto-claude/prompt-templates/index.test.ts
+++ b/src/lib/auto-claude/prompt-templates/index.test.ts
@@ -134,12 +134,13 @@ describe("ARTIFACTS", () => {
       "planImplementation",
       "completedSummary",
       "review",
+      "prUrl",
     ]);
   });
 
-  it("all values should be .md filenames", () => {
+  it("all values should be valid filenames", () => {
     for (const filename of Object.values(ARTIFACTS)) {
-      expect(filename).toMatch(/^[\w-]+\.md$/);
+      expect(filename).toMatch(/^[\w-]+\.\w+$/);
     }
   });
 });

--- a/src/lib/auto-claude/prompt-templates/index.ts
+++ b/src/lib/auto-claude/prompt-templates/index.ts
@@ -41,4 +41,5 @@ export const ARTIFACTS = {
   planImplementation: "plan-implementation.md",
   completedSummary: "completed-summary.md",
   review: "review.md",
+  prUrl: "pr-url.txt",
 } as const;

--- a/src/lib/auto-claude/steps/create-pr.ts
+++ b/src/lib/auto-claude/steps/create-pr.ts
@@ -4,7 +4,7 @@ import consola from "consola";
 
 import { getConfig } from "../config.js";
 import { ARTIFACTS, STEP_LABELS } from "../prompt-templates/index.js";
-import { fileExists, ghRaw, git, log, logStep, readFile } from "../utils.js";
+import { fileExists, ghRaw, git, log, logStep, readFile, writeFile } from "../utils.js";
 import type { IssueContext } from "../utils.js";
 
 export async function stepCreatePR(ctx: IssueContext): Promise<boolean> {
@@ -62,7 +62,9 @@ export async function stepCreatePR(ctx: IssueContext): Promise<boolean> {
   ]);
 
   if (prUrl) {
-    log(`PR created: ${prUrl}`);
+    const url = prUrl.trim();
+    writeFile(join(ctx.issueDir, ARTIFACTS.prUrl), url);
+    log(`PR created: ${url}`);
   } else {
     consola.error("Failed to create PR");
     return false;

--- a/src/lib/auto-claude/utils.ts
+++ b/src/lib/auto-claude/utils.ts
@@ -3,6 +3,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import consola from "consola";
+import pc from "picocolors";
 import { x } from "tinyexec";
 
 import { getConfig } from "./config.js";
@@ -251,13 +252,16 @@ export function logBanner(label: string, width = 60): void {
   const totalDashes = Math.max(0, width - inner.length - 2);
   const left = Math.ceil(totalDashes / 2);
   const right = Math.floor(totalDashes / 2);
-  consola.log(`#${"-".repeat(left)}${inner}${"-".repeat(right)}#`);
+  const dashes = pc.cyan;
+  consola.log(
+    `${dashes("#" + "-".repeat(left))}${pc.bold(inner)}${dashes("-".repeat(right) + "#")}`,
+  );
 }
 
 export function logStep(step: string, ctx: IssueContext, skipped = false): void {
-  const tag = skipped ? "SKIP" : "RUN";
+  const tag = skipped ? pc.yellow("SKIP") : pc.green("RUN");
   logBanner(`[${tag}] ${step}`);
-  consola.log(`${ctx.repo}#${ctx.number} — ${ctx.title}`);
+  consola.log(pc.dim(`${ctx.repo}#${ctx.number} — ${ctx.title}`));
 }
 
 // ── Git branch helpers ──

--- a/src/lib/auto-claude/utils.ts
+++ b/src/lib/auto-claude/utils.ts
@@ -83,15 +83,15 @@ export async function runClaude(opts: {
 
       try {
         const parsed = JSON.parse(stdout) as ClaudeResult;
-        consola.success(`Done — $${parsed.total_cost_usd.toFixed(4)} | ${parsed.num_turns} turns`);
+        consola.success(`Done — ${parsed.num_turns} turns`);
         if (parsed.result) {
-          consola.box(parsed.result);
+          consola.log(parsed.result);
         }
         return parsed;
       } catch {
         consola.warn("Done — failed to parse Claude output");
         if (stdout.trim()) {
-          consola.box(stdout.trim());
+          consola.log(stdout.trim());
         }
         return { result: stdout.trim(), is_error: false, total_cost_usd: 0, num_turns: 0 };
       }
@@ -246,9 +246,18 @@ export function log(msg: string): void {
   consola.info(`[auto-claude] ${msg}`);
 }
 
+export function logBanner(label: string, width = 60): void {
+  const inner = `  ${label}  `;
+  const totalDashes = Math.max(0, width - inner.length - 2);
+  const left = Math.ceil(totalDashes / 2);
+  const right = Math.floor(totalDashes / 2);
+  consola.log(`#${"-".repeat(left)}${inner}${"-".repeat(right)}#`);
+}
+
 export function logStep(step: string, ctx: IssueContext, skipped = false): void {
   const tag = skipped ? "SKIP" : "RUN";
-  consola.box({ title: `[${tag}] ${step}`, message: `${ctx.repo}#${ctx.number} — ${ctx.title}` });
+  logBanner(`[${tag}] ${step}`);
+  consola.log(`${ctx.repo}#${ctx.number} — ${ctx.title}`);
 }
 
 // ── Git branch helpers ──


### PR DESCRIPTION
## Summary
- Replace `consola.box()` calls with colored banner output using `picocolors` for cleaner, more readable pipeline logs
- Remove cost display from Claude run output (`total_cost_usd`)
- Persist PR URL to `pr-url.txt` artifact and display it in pipeline completion message
- Add `pnpm` to `doctor` command dependency checks

## Test plan
- [ ] Run `tt auto-claude` and verify colored banners render correctly
- [ ] Verify PR URL appears in pipeline completion message
- [ ] Run `tt doctor` and confirm pnpm version is checked
- [ ] Run `pnpm test` to ensure artifact tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)