### PR TITLE
fix: allow workflow_dispatch to bypass release commit skip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ concurrency:
 
 jobs:
   ci:
-    # Skip release commits to avoid infinite loop
-    if: "!startsWith(github.event.head_commit.message, 'chore: release')"
+    # Skip release commits to avoid infinite loop (only applies to push events)
+    if: "github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore: release')"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/plugins/tt-core/.claude-plugin/plugin.json
+++ b/plugins/tt-core/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
-    "name": "tt",
-    "description": "Ralph autonomous task runner, observability (token treemaps), git workflows, and journaling",
-    "version": "0.0.56",
-    "author": {
-        "name": "Chris Towles"
-    }
+  "name": "tt",
+  "description": "Ralph autonomous task runner, observability (token treemaps), git workflows, and journaling",
+  "version": "0.0.56",
+  "author": {
+    "name": "Chris Towles"
+  }
 }


### PR DESCRIPTION
## Summary
- Updated the `if` condition on the CI job in `release.yml` so that `workflow_dispatch` events always run, even when the skip-release-commit guard would otherwise block them.

## Test plan
- [x] Verify `workflow_dispatch` triggers run CI regardless of commit message
- [x] Verify push events still skip `chore: release` commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)