### PR TITLE
feat: check and install code-simplifier plugin in doctor/install

### DIFF
--- a/plugins/tt-core/.claude-plugin/plugin.json
+++ b/plugins/tt-core/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
-    "name": "tt",
-    "description": "Ralph autonomous task runner, observability (token treemaps), git workflows, and journaling",
-    "version": "0.0.57",
-    "author": {
-        "name": "Chris Towles"
-    }
+  "name": "tt",
+  "description": "Ralph autonomous task runner, observability (token treemaps), git workflows, and journaling",
+  "version": "0.0.57",
+  "author": {
+    "name": "Chris Towles"
+  }
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -62,8 +62,20 @@ export default class Doctor extends BaseCommand {
       }
     }
 
+    // Claude plugin checks
+    this.log("");
+    const pluginChecks = await this.checkClaudePlugins();
+    for (const check of pluginChecks) {
+      const icon = check.ok ? pc.green("✓") : pc.red("✗");
+      const status = check.ok ? "installed" : "not installed";
+      this.log(`${icon} claude plugin ${check.name}: ${status}`);
+      if (!check.ok && check.installHint) {
+        this.log(`  ${pc.dim(check.installHint)}`);
+      }
+    }
+
     // Summary
-    const allOk = checks.every((c) => c.ok) && ghAuth.ok;
+    const allOk = checks.every((c) => c.ok) && ghAuth.ok && pluginChecks.every((c) => c.ok);
     this.log("");
     if (allOk) {
       this.log(pc.green("All checks passed!"));
@@ -99,6 +111,36 @@ export default class Doctor extends BaseCommand {
       return { ok: result.exitCode === 0 };
     } catch {
       return { ok: false };
+    }
+  }
+
+  private async checkClaudePlugins(): Promise<
+    { name: string; ok: boolean; installHint?: string }[]
+  > {
+    const requiredPlugins = [
+      {
+        id: "code-simplifier@claude-plugins-official",
+        name: "code-simplifier",
+        installCmd: "claude plugin install code-simplifier@claude-plugins-official --scope user",
+      },
+    ];
+
+    try {
+      const result = await x("claude", ["plugin", "list", "--json"]);
+      const plugins: { id: string }[] = JSON.parse(result.stdout);
+      const installedIds = new Set(plugins.map((p) => p.id));
+
+      return requiredPlugins.map((p) => ({
+        name: p.name,
+        ok: installedIds.has(p.id),
+        installHint: installedIds.has(p.id) ? undefined : `Run: ${p.installCmd}`,
+      }));
+    } catch {
+      return requiredPlugins.map((p) => ({
+        name: p.name,
+        ok: false,
+        installHint: `Run: ${p.installCmd}`,
+      }));
     }
   }
 }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -96,35 +96,76 @@ export default class Install extends BaseCommand {
       this.showOtelInstructions();
     }
 
+    // Install Claude plugins
+    this.log(pc.bold("\n📦 Claude Plugins\n"));
+    await this.ensureClaudePlugins();
+
     this.log(pc.bold(pc.green("\n✅ Installation complete!\n")));
+  }
 
-    // Offer to install plugins from marketplace
-    this.log(pc.cyan("To install plugins from the Claude Code marketplace:"));
-    this.log(
-      pc.dim("  claude /plugins marketplace add https://github.com/ChrisTowles/towles-tool"),
-    );
-    this.log("");
+  private async ensureClaudePlugins(): Promise<void> {
+    const { x } = await import("tinyexec");
 
-    const answer = await consola.prompt("Install tt-core plugin from marketplace now?", {
-      type: "confirm",
-      initial: true,
-    });
+    const requiredPlugins = [
+      {
+        id: "tt@towles-tool",
+        name: "tt-core",
+        marketplaceUrl: "https://github.com/ChrisTowles/towles-tool",
+        marketplace: "towles-tool",
+      },
+      {
+        id: "code-simplifier@claude-plugins-official",
+        name: "code-simplifier",
+      },
+    ];
 
-    if (answer) {
-      const { x } = await import("tinyexec");
-      this.log("");
+    // Get installed plugins
+    let installedIds = new Set<string>();
+    try {
+      const result = await x("claude", ["plugin", "list", "--json"]);
+      const plugins: { id: string }[] = JSON.parse(result.stdout);
+      installedIds = new Set(plugins.map((p) => p.id));
+    } catch {
+      this.log(pc.yellow("⚠ Could not list Claude plugins"));
+    }
 
-      const result = await x("claude", ["plugin", "install", "tt@towles-tool", "--scope", "user"]);
-      if (result.stdout) this.log(result.stdout);
-      if (result.stderr) this.log(pc.dim(result.stderr));
-      if (result.exitCode === 0) {
-        this.log(pc.green("✓ tt-core plugin installed"));
-      } else {
-        this.log(pc.yellow(`Command exited with code ${result.exitCode}`));
+    // Ensure marketplaces are added first
+    for (const plugin of requiredPlugins) {
+      if (plugin.marketplaceUrl && !installedIds.has(plugin.id)) {
+        try {
+          await x("claude", ["plugin", "marketplace", "add", plugin.marketplaceUrl]);
+          this.log(pc.dim(`  Added marketplace: ${plugin.marketplace}`));
+        } catch {
+          // marketplace may already be added
+        }
       }
     }
 
-    this.log("");
+    // Install missing plugins
+    for (const plugin of requiredPlugins) {
+      if (installedIds.has(plugin.id)) {
+        this.log(pc.dim(`✓ ${plugin.name} already installed`));
+        continue;
+      }
+
+      const answer = await consola.prompt(`Install ${plugin.name} plugin?`, {
+        type: "confirm",
+        initial: true,
+      });
+
+      if (answer) {
+        const result = await x("claude", ["plugin", "install", plugin.id, "--scope", "user"]);
+        if (result.exitCode === 0) {
+          this.log(pc.green(`✓ ${plugin.name} installed`));
+        } else {
+          if (result.stdout) this.log(result.stdout);
+          if (result.stderr) this.log(pc.dim(result.stderr));
+          this.log(pc.yellow(`⚠ ${plugin.name} install exited with code ${result.exitCode}`));
+        }
+      } else {
+        this.log(pc.dim(`  Skipped ${plugin.name}`));
+      }
+    }
   }
 
   private saveClaudeSettings(settings: ClaudeSettings): void {


### PR DESCRIPTION
## Summary
- **doctor**: Added Claude plugin check for `code-simplifier` — shows installed/not-installed status with install hint
- **install**: Replaced single-plugin prompt with `ensureClaudePlugins()` that checks and installs both `tt-core` and `code-simplifier` plugins
- Fixed plugin.json formatting (4-space → 2-space indent)

## Test plan
- [x] `tt doctor` shows code-simplifier plugin status
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)