### PR TITLE
feat: add create-auto-claude-issue command and claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "tt@towles-tool": true
+  }
+}

--- a/plugins/tt-core/.claude-plugin/plugin.json
+++ b/plugins/tt-core/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
-    "name": "tt",
-    "description": "Ralph autonomous task runner, observability (token treemaps), git workflows, and journaling",
-    "version": "0.0.58",
-    "author": {
-        "name": "Chris Towles"
-    }
+  "name": "tt",
+  "description": "Ralph autonomous task runner, observability (token treemaps), git workflows, and journaling",
+  "version": "0.0.58",
+  "author": {
+    "name": "Chris Towles"
+  }
 }

--- a/plugins/tt-core/commands/create-auto-claude-issue.md
+++ b/plugins/tt-core/commands/create-auto-claude-issue.md
@@ -1,0 +1,63 @@
+---
+description: Create a GitHub issue with the auto-claude label for AI-driven work
+allowed-tools: Bash, AskUserQuestion
+---
+
+Create a GitHub issue in the current repository with the `auto-claude` label, designed for work that will be planned and/or implemented by Claude Code.
+
+## Steps
+
+1. **Determine the target repo** by running:
+
+   ```
+   gh repo view --json nameWithOwner --jq '.nameWithOwner'
+   ```
+
+2. **Ensure the `auto-claude` label exists** in the repo. Try to create it — if it already exists the command will fail silently, which is fine:
+
+   ```
+   gh label create "auto-claude" --repo <repo> --description "Issue created or worked by Claude Code" --color "7C3AED" 2>/dev/null || true
+   ```
+
+3. **Fetch existing labels** from the repo:
+
+   ```
+   gh label list --repo <repo> --json name --jq '.[].name'
+   ```
+
+4. **Gather information** using AskUserQuestion. Ask up to 4 questions at a time:
+   - **Title**: What should the issue title be?
+   - **Description**: Describe what needs to be done.
+   - **Extra Labels** (optional, multi-select): Additional labels to apply? Use the labels fetched from the repo as options (exclude `auto-claude` since it's always added).
+
+5. **Create the issue** using `gh issue create`:
+   - Always include the `auto-claude` label
+   - Add any extra labels the user selected
+   - Prefix the title with the conventional type (`feat:`, `fix:`, `refactor:`, `research:`, `chore:`)
+   - Format the body with clear sections
+
+   ```
+   gh issue create --repo <repo> \
+     --title "<type prefix>: <title>" \
+     --label "auto-claude,<extra labels>" \
+     --body "$(cat <<'EOF'
+   ## Summary
+
+   <description>
+
+   ## Type
+
+   <type>
+
+   ## Notes
+
+   This issue was created via Claude Code `/auto-claude` command.
+   EOF
+   )"
+   ```
+
+6. **Support batch creation**: If the user provides multiple issues (e.g. a list of bullets), create all issues in parallel using separate `gh issue create` calls. Choose the appropriate conventional prefix and labels for each based on the title and description.
+
+7. **Report back** with all issue URLs, ideally in a table format.
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- Add `create-auto-claude-issue` plugin command with dynamic label fetching from the repo, batch issue creation support, and table output format
- Add `.claude/settings.json` to enable the `tt` plugin

## Test plan

- [ ] Verify `tt create-auto-claude-issue` skill works with single and batch issue creation
- [ ] Confirm labels are fetched dynamically from the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)