### PR TITLE
feat: add interactive issue picker subcommand to auto-claude (tt ac list)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,15 @@
 # CLAUDE.md
 
-## Project Overview
-
-Dual-purpose repository:
-
-1. **CLI tool** (`tt` or `towles-tool`) - Personal CLI tool with auto-claude pipeline, developer tools and journaling via markdown
-2. **Claude Code Plugin Marketplace** - Hosts Claude Code plugins for personal use
+Personal CLI tool (`tt`) with auto-claude pipeline, developer tools, journaling, and Claude Code plugin marketplace.
 
 ## Quick Reference
 
 - **Package manager**: pnpm (use `pnpm dlx` instead of `npx`)
-- **Run TypeScript**: `tsx file.ts`
 - **Terminal output**: consola (`consola.box()`, `consola.info/warn/error`)
 - **Lint rules**: oxlint requires top-level `import type` (not inline `type` in value imports), and `consola` instead of `console.log/error`.
+- **Validation**: Zod for schemas, objects, and types. Derive types with `z.infer<typeof Schema>` — never define types manually alongside schemas.
+- **Dates**: Use `toLocaleDateString("en-CA")` for YYYY-MM-DD or Luxon with local zone. Never `toISOString()` for display (UTC shifts dates).
+- When modifying CLI commands (`src/commands/`), also update corresponding skills in `plugins/tt-core/skills/` and `plugins/tt-core/commands/`.
 
 ## Commands
 
@@ -20,45 +17,18 @@ Dual-purpose repository:
 pnpm dev                # Run CLI with tsx
 pnpm typecheck          # TypeScript type checking
 pnpm test               # Run vitest tests
+pnpm test:watch         # Run vitest in watch mode
+pnpm test -- path       # Run tests matching a path (e.g. pnpm test -- auto-claude)
 pnpm lint               # Run oxlint
-pnpm lint:fix            # Auto-fix lint issues
+pnpm lint:fix           # Auto-fix lint issues
 pnpm format             # Format with oxfmt
-pnpm format:check        # Check formatting without writing
+pnpm format:check       # Check formatting without writing
 ```
 
 ## Guidelines
 
 - [Architecture](docs/architecture.md) - CLI structure, plugin system, tech stack
-- **Plugin dev reinstall**: `claude plugin uninstall tt@towles-tool && claude plugin marketplace remove towles-tool && claude plugin marketplace add /home/ctowles/code/p/towles-tool && claude plugin install tt@towles-tool`
+- [Auto-Claude Pipeline](docs/auto-claude.md) - Automated issue-to-PR pipeline
+- [Testing](docs/testing.md) - Test conventions
 - [CICD via GitHub Actions](docs/github-actions.md) - Automated release workflow
-- [Testing](docs/testing.md) - Info about Tests
 - [Skill & Prompt Guide](docs/skill-and-prompt-guide.md) - Rules for writing skills, prompts, and CLAUDE.md
-
-## Auto-Claude Pipeline
-
-Automated issue-to-PR pipeline (`tt auto-claude` / `tt ac`). Runs Claude Code CLI locally per issue through: research → plan → plan-annotations → plan-implementation → implement → review → create-pr → remove-label.
-
-**Key files:**
-
-- `src/commands/auto-claude.ts` — oclif command entry point (alias: `ac`)
-- `src/lib/auto-claude/config.ts` — Zod config schema, auto-detects repo and main branch from cwd
-- `src/lib/auto-claude/utils.ts` — shared helpers: `runClaude()`, `resolveTemplate()`, `IssueContext`, `ensureBranch()`, `runStepWithArtifact()`
-- `src/lib/auto-claude/pipeline.ts` — step orchestration with `--until` support
-- `src/lib/auto-claude/steps/` — one file per step, most use `runStepWithArtifact()` helper
-- `src/lib/auto-claude/prompt-templates/` — 7 `.md` files with `{{TOKEN}}` placeholders
-
-**Conventions:**
-
-- Artifacts go in `.auto-claude/issue-{N}/` (gitignored)
-- Branch naming: `auto-claude/issue-{N}`
-- Steps are idempotent — check for output artifact before running
-- Trigger label: `auto-claude` (removed after PR creation)
-- `runStepWithArtifact()` encapsulates the common pattern of check → run Claude → validate → commit
-
-## Important Notes
-
-- **Dates in local timezone**: Use `toLocaleDateString("en-CA")` for YYYY-MM-DD or Luxon with local zone. Never use `toISOString()` for date grouping/display (UTC shifts dates).
-- **Zod types**: Always derive types from Zod schemas using `z.infer<typeof Schema>` - never define types manually alongside schemas.
-- **Breaking changes are fine** - personal tool, no backwards compatibility concerns.
-- When modifying CLI commands (`src/commands/`), also update corresponding skills in `plugins/tt-core/skills/` and `plugins/tt-core/commands/`.
-- **oclif command aliases**: Use `static override aliases = ["ac"]` in command class. See `auto-claude.ts` for example.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,8 @@
 - `src/utils/date-utils.ts` - Date formatting using Luxon
 - `src/lib/journal/` - Journal template and file generation utilities
 
-- `auto-claude` - Automated issue-to-PR pipeline using Claude Code (research → plan → implement → review → PR)
+- `auto-claude` (alias: `ac`) - Automated issue-to-PR pipeline using Claude Code (research → plan → implement → review → PR)
+- `auto-claude list` - Interactively pick an auto-claude labeled issue to process
 
 ## Claude Code Plugin Architecture
 

--- a/docs/auto-claude.md
+++ b/docs/auto-claude.md
@@ -1,0 +1,20 @@
+# Auto-Claude Pipeline
+
+Automated issue-to-PR pipeline (`tt auto-claude` / `tt ac`). Runs Claude Code CLI locally per issue through: research → plan → plan-annotations → plan-implementation → implement → review → create-pr → remove-label.
+
+## Key Files
+
+- `src/commands/auto-claude.ts` — oclif command entry point (alias: `ac`)
+- `src/lib/auto-claude/config.ts` — Zod config schema, auto-detects repo and main branch from cwd
+- `src/lib/auto-claude/utils.ts` — shared helpers: `runClaude()`, `resolveTemplate()`, `IssueContext`, `ensureBranch()`, `runStepWithArtifact()`
+- `src/lib/auto-claude/pipeline.ts` — step orchestration with `--until` support
+- `src/lib/auto-claude/steps/` — one file per step, most use `runStepWithArtifact()` helper
+- `src/lib/auto-claude/prompt-templates/` — 7 `.md` files with `{{TOKEN}}` placeholders
+
+## Conventions
+
+- Artifacts go in `.auto-claude/issue-{N}/` (gitignored)
+- Branch naming: `auto-claude/issue-{N}`
+- Steps are idempotent — check for output artifact before running
+- Trigger label: `auto-claude` (removed after PR creation)
+- `runStepWithArtifact()` encapsulates the common pattern of check → run Claude → validate → commit

--- a/docs/auto-claude.md
+++ b/docs/auto-claude.md
@@ -4,7 +4,7 @@ Automated issue-to-PR pipeline (`tt auto-claude` / `tt ac`). Runs Claude Code CL
 
 ## Key Files
 
-- `src/commands/auto-claude.ts` — oclif command entry point (alias: `ac`)
+- `src/commands/auto-claude/index.ts` — oclif command entry point (alias: `ac`)
 - `src/lib/auto-claude/config.ts` — Zod config schema, auto-detects repo and main branch from cwd
 - `src/lib/auto-claude/utils.ts` — shared helpers: `runClaude()`, `resolveTemplate()`, `IssueContext`, `ensureBranch()`, `runStepWithArtifact()`
 - `src/lib/auto-claude/pipeline.ts` — step orchestration with `--until` support
@@ -17,4 +17,4 @@ Automated issue-to-PR pipeline (`tt auto-claude` / `tt ac`). Runs Claude Code CL
 - Branch naming: `auto-claude/issue-{N}`
 - Steps are idempotent — check for output artifact before running
 - Trigger label: `auto-claude` (removed after PR creation)
-- `runStepWithArtifact()` encapsulates the common pattern of check → run Claude → validate → commit
+- `runStepWithArtifact()` encapsulates the common pattern of check → run Claude → validate output

--- a/plugins/tt-core/skills/towles-tool/SKILL.md
+++ b/plugins/tt-core/skills/towles-tool/SKILL.md
@@ -33,9 +33,12 @@ tt auto-claude --loop
 
 # Custom interval and limit
 tt auto-claude --loop --interval 15 --limit 3
+
+# Interactively pick an auto-claude issue to process
+tt auto-claude list
 ```
 
-Alias: `tt ac --issue 42`
+Alias: `tt ac --issue 42`, `tt ac list`
 
 ## Git
 

--- a/src/commands/auto-claude/index.ts
+++ b/src/commands/auto-claude/index.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { Flags } from "@oclif/core";
 import consola from "consola";
 
-import { BaseCommand } from "./base.js";
+import { BaseCommand } from "../base.js";
 import {
   STEP_NAMES,
   buildIssueContext,
@@ -18,8 +18,8 @@ import {
   runPipeline,
   sleep,
   stepRefresh,
-} from "../lib/auto-claude/index.js";
-import type { IssueContext, StepName } from "../lib/auto-claude/index.js";
+} from "../../lib/auto-claude/index.js";
+import type { IssueContext, StepName } from "../../lib/auto-claude/index.js";
 
 export default class AutoClaude extends BaseCommand {
   static override aliases = ["ac"];

--- a/src/commands/auto-claude/list.ts
+++ b/src/commands/auto-claude/list.ts
@@ -106,7 +106,8 @@ export default class AutoClaudeList extends BaseCommand {
 
       const untilStep = flags.until as StepName | undefined;
       await runPipeline(ctx, untilStep);
-    } catch {
+    } catch (e) {
+      consola.error(e);
       this.exit(1);
     }
   }

--- a/src/commands/auto-claude/list.ts
+++ b/src/commands/auto-claude/list.ts
@@ -1,0 +1,113 @@
+import { Flags } from "@oclif/core";
+import consola from "consola";
+import { colors } from "consola/utils";
+import { Fzf } from "fzf";
+import prompts from "prompts";
+import type { Choice } from "prompts";
+
+import { BaseCommand } from "../base.js";
+import { buildIssueChoices, computeColumnLayout } from "../gh/branch.js";
+import { STEP_NAMES, fetchIssue, initConfig, runPipeline } from "../../lib/auto-claude/index.js";
+import type { StepName } from "../../lib/auto-claude/index.js";
+import { getIssues, isGithubCliInstalled } from "../../utils/git/gh-cli-wrapper.js";
+import { getTerminalColumns } from "../../utils/render.js";
+
+export default class AutoClaudeList extends BaseCommand {
+  static override description = "Interactively pick an auto-claude issue to process";
+
+  static override examples = [
+    {
+      description: "Browse auto-claude labeled issues",
+      command: "<%= config.bin %> auto-claude list",
+    },
+    {
+      description: "Pick an issue and run until plan step",
+      command: "<%= config.bin %> auto-claude list --until plan",
+    },
+  ];
+
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    until: Flags.string({
+      char: "u",
+      description: `Stop after this step (${STEP_NAMES.join(", ")})`,
+      options: [...STEP_NAMES],
+    }),
+    label: Flags.string({
+      description: "Trigger label (default: auto-claude)",
+    }),
+    "main-branch": Flags.string({
+      description: "Override main branch detection",
+    }),
+    "scope-path": Flags.string({
+      description: "Path within repo to scope work (default: .)",
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(AutoClaudeList);
+
+    const cfg = await initConfig({
+      triggerLabel: flags.label,
+      mainBranch: flags["main-branch"],
+      scopePath: flags["scope-path"],
+    });
+
+    const cliInstalled = await isGithubCliInstalled();
+    if (!cliInstalled) {
+      this.error("GitHub CLI (gh) is not installed");
+    }
+
+    const issues = await getIssues({ cwd: process.cwd(), label: cfg.triggerLabel });
+    if (issues.length === 0) {
+      consola.info(`No open issues with '${cfg.triggerLabel}' label`);
+      return;
+    }
+
+    consola.info(colors.green(`${issues.length} issue(s) with '${cfg.triggerLabel}' label`));
+
+    const layout = computeColumnLayout(issues, getTerminalColumns());
+    const choices = buildIssueChoices(issues, layout);
+
+    const fzf = new Fzf(choices, {
+      selector: (item) => `${item.value} ${item.description}`,
+      casing: "case-insensitive",
+    });
+
+    try {
+      const result = await prompts(
+        {
+          name: "issueNumber",
+          message: "Pick an issue to process:",
+          type: "autocomplete",
+          choices,
+          async suggest(input: string, choices: Choice[]) {
+            const results = fzf.find(input);
+            return results.map((r) => choices.find((c) => c.value === r.item.value));
+          },
+        },
+        {
+          onCancel: () => {
+            consola.info(colors.dim("Canceled"));
+            this.exit(0);
+          },
+        },
+      );
+
+      if (result.issueNumber === "cancel") {
+        consola.info(colors.dim("Canceled"));
+        return;
+      }
+
+      const ctx = await fetchIssue(result.issueNumber);
+      if (!ctx) {
+        this.error(`Could not fetch issue #${result.issueNumber}`);
+      }
+
+      const untilStep = flags.until as StepName | undefined;
+      await runPipeline(ctx, untilStep);
+    } catch {
+      this.exit(1);
+    }
+  }
+}

--- a/src/lib/auto-claude/pipeline.ts
+++ b/src/lib/auto-claude/pipeline.ts
@@ -38,37 +38,42 @@ export async function runPipeline(ctx: IssueContext, untilStep?: StepName): Prom
     log("Saved initial-ramblings.md");
   }
 
-  for (const step of PIPELINE_STEPS) {
-    const runner = STEP_RUNNERS[step.name];
-    const success = await runner(ctx);
+  try {
+    for (const step of PIPELINE_STEPS) {
+      const runner = STEP_RUNNERS[step.name];
+      const success = await runner(ctx);
 
-    if (!success) {
-      log(`Pipeline stopped at "${step.name}" for ${ctx.repo}#${ctx.number}`);
-      await checkoutMain();
-      return;
+      if (!success) {
+        log(`Pipeline stopped at "${step.name}" for ${ctx.repo}#${ctx.number}`);
+        return;
+      }
+
+      if (untilStep && step.name === untilStep) {
+        log(`Pipeline paused after "${step.name}" (--until ${untilStep})`);
+        return;
+      }
     }
 
-    if (untilStep && step.name === untilStep) {
-      log(`Pipeline paused after "${step.name}" (--until ${untilStep})`);
-      await checkoutMain();
-      return;
-    }
+    const prUrlPath = join(ctx.issueDir, ARTIFACTS.prUrl);
+    const prUrl = fileExists(prUrlPath) ? readFile(prUrlPath).trim() : "";
+    const prSuffix = prUrl ? ` — ${prUrl}` : "";
+    log(`Pipeline complete for ${ctx.repo}#${ctx.number}${prSuffix}`);
+  } finally {
+    await checkoutMain();
   }
-
-  const prUrlPath = join(ctx.issueDir, ARTIFACTS.prUrl);
-  const prUrl = fileExists(prUrlPath) ? readFile(prUrlPath).trim() : "";
-  const prSuffix = prUrl ? ` — ${prUrl}` : "";
-  log(`Pipeline complete for ${ctx.repo}#${ctx.number}${prSuffix}`);
-  await checkoutMain();
 }
 
 async function checkoutMain(): Promise<void> {
   await git(["checkout", getConfig().mainBranch]).catch(() => {});
 
-  // Restore any stash created by ensureBranch
-  const stashList = await execSafe("git", ["stash", "list", "--max-count=1"]);
-  if (stashList.ok && stashList.stdout.includes("auto-claude: before switching to")) {
-    await execSafe("git", ["stash", "pop"]);
-    log("Restored stashed changes");
+  // Restore any stash created by ensureBranch, searching by message instead of assuming top
+  const stashList = await execSafe("git", ["stash", "list"]);
+  if (stashList.ok) {
+    const lines = stashList.stdout.split("\n");
+    const idx = lines.findIndex((l) => l.includes("auto-claude: before switching to"));
+    if (idx >= 0) {
+      await execSafe("git", ["stash", "pop", `stash@{${idx}}`]);
+      log("Restored stashed changes");
+    }
   }
 }

--- a/src/lib/auto-claude/pipeline.ts
+++ b/src/lib/auto-claude/pipeline.ts
@@ -11,7 +11,7 @@ import { stepPlan } from "./steps/plan.js";
 import { stepRemoveLabel } from "./steps/remove-label.js";
 import { stepResearch } from "./steps/research.js";
 import { stepReview } from "./steps/review.js";
-import { ensureDir, fileExists, git, log, readFile, writeFile } from "./utils.js";
+import { ensureDir, execSafe, fileExists, git, log, readFile, writeFile } from "./utils.js";
 import type { IssueContext } from "./utils.js";
 
 const STEP_RUNNERS: Record<StepName, (ctx: IssueContext) => Promise<boolean>> = {
@@ -64,4 +64,11 @@ export async function runPipeline(ctx: IssueContext, untilStep?: StepName): Prom
 
 async function checkoutMain(): Promise<void> {
   await git(["checkout", getConfig().mainBranch]).catch(() => {});
+
+  // Restore any stash created by ensureBranch
+  const stashList = await execSafe("git", ["stash", "list", "--max-count=1"]);
+  if (stashList.ok && stashList.stdout.includes("auto-claude: before switching to")) {
+    await execSafe("git", ["stash", "pop"]);
+    log("Restored stashed changes");
+  }
 }

--- a/src/lib/auto-claude/run-claude.test.ts
+++ b/src/lib/auto-claude/run-claude.test.ts
@@ -70,19 +70,17 @@ describe("runClaude (mocked spawn-claude)", () => {
     );
   });
 
-  it("logs tool names from assistant turn events with object message format", async () => {
+  it("logs tool names from stream_event and shows thinking indicator", async () => {
     const infoSpy = vi.spyOn(consola, "info");
 
-    const assistantEvent = {
-      type: "assistant",
-      message: {
-        content: [
-          { type: "text", text: "Let me read the file." },
-          { type: "tool_use", id: "t1", name: "Read", input: {} },
-        ],
+    const thinkingEvent = {
+      type: "stream_event",
+      event: {
+        type: "content_block_start",
+        content_block: { type: "thinking" },
       },
     };
-    const streamEvent = {
+    const toolEvent = {
       type: "stream_event",
       event: {
         type: "content_block_start",
@@ -97,7 +95,7 @@ describe("runClaude (mocked spawn-claude)", () => {
     };
 
     mockSpawnImpl = () => ({
-      stdout: [assistantEvent, streamEvent, resultEvent].map((e) => JSON.stringify(e)).join("\n"),
+      stdout: [thinkingEvent, toolEvent, resultEvent].map((e) => JSON.stringify(e)).join("\n"),
       exitCode: 0,
     });
 
@@ -109,9 +107,8 @@ describe("runClaude (mocked spawn-claude)", () => {
     expect(result.result).toBe("Done");
     expect(result.num_turns).toBe(1);
 
-    // Verify consola.info was called with tool names (Read from assistant turn, Edit from stream_event)
     const infoCalls = infoSpy.mock.calls.map((c) => String(c[0]));
-    expect(infoCalls.some((msg) => msg.includes("Read"))).toBe(true);
+    expect(infoCalls.some((msg) => msg.includes("thinking"))).toBe(true);
     expect(infoCalls.some((msg) => msg.includes("Edit"))).toBe(true);
 
     infoSpy.mockRestore();

--- a/src/lib/auto-claude/run-claude.test.ts
+++ b/src/lib/auto-claude/run-claude.test.ts
@@ -47,7 +47,6 @@ describe("runClaude (mocked spawn-claude)", () => {
 
     const result = await runClaude({
       promptFile: "test-prompt.md",
-      permissionMode: "plan",
       maxTurns: 10,
     });
 
@@ -62,13 +61,60 @@ describe("runClaude (mocked spawn-claude)", () => {
         "--output-format",
         "stream-json",
         "--verbose",
-        "--permission-mode",
-        "plan",
+        "--include-partial-messages",
+        "--dangerously-skip-permissions",
         "--max-turns",
         "10",
         "@test-prompt.md",
       ]),
     );
+  });
+
+  it("logs tool names from assistant turn events with object message format", async () => {
+    const infoSpy = vi.spyOn(consola, "info");
+
+    const assistantEvent = {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Let me read the file." },
+          { type: "tool_use", id: "t1", name: "Read", input: {} },
+        ],
+      },
+    };
+    const streamEvent = {
+      type: "stream_event",
+      event: {
+        type: "content_block_start",
+        content_block: { type: "tool_use", name: "Edit" },
+      },
+    };
+    const resultEvent = {
+      result: "Done",
+      is_error: false,
+      total_cost_usd: 0.01,
+      num_turns: 1,
+    };
+
+    mockSpawnImpl = () => ({
+      stdout: [assistantEvent, streamEvent, resultEvent].map((e) => JSON.stringify(e)).join("\n"),
+      exitCode: 0,
+    });
+
+    await initConfig({ repo: "test/repo", mainBranch: "main" });
+
+    const { runClaude } = await import("./utils");
+    const result = await runClaude({ promptFile: "test.md" });
+
+    expect(result.result).toBe("Done");
+    expect(result.num_turns).toBe(1);
+
+    // Verify consola.info was called with tool names (Read from assistant turn, Edit from stream_event)
+    const infoCalls = infoSpy.mock.calls.map((c) => String(c[0]));
+    expect(infoCalls.some((msg) => msg.includes("Read"))).toBe(true);
+    expect(infoCalls.some((msg) => msg.includes("Edit"))).toBe(true);
+
+    infoSpy.mockRestore();
   });
 
   it("returns fallback when no result event in stream", async () => {
@@ -83,7 +129,6 @@ describe("runClaude (mocked spawn-claude)", () => {
 
     const result = await runClaude({
       promptFile: "test.md",
-      permissionMode: "acceptEdits",
     });
 
     expect(result.result).toBe("");
@@ -122,7 +167,6 @@ describe("runClaude (mocked spawn-claude)", () => {
 
     const result = await runClaude({
       promptFile: "test.md",
-      permissionMode: "plan",
       retry: true,
     });
 
@@ -147,7 +191,6 @@ describe("runClaude (mocked spawn-claude)", () => {
     await expect(
       runClaude({
         promptFile: "test.md",
-        permissionMode: "plan",
         retry: true,
       }),
     ).rejects.toThrow("Claude failed after 2 retries");

--- a/src/lib/auto-claude/steps/create-pr.ts
+++ b/src/lib/auto-claude/steps/create-pr.ts
@@ -95,10 +95,10 @@ async function attachArtifacts(ctx: IssueContext, prUrl: string): Promise<void> 
   ]);
 
   // Delete old release if exists (idempotent)
-  await execSafe("gh", ["release", "delete", tag, "--yes", "--repo", cfg.repo]);
+  await ghRaw(["release", "delete", tag, "--yes", "--repo", cfg.repo]);
 
   // Create pre-release with asset
-  await execSafe("gh", [
+  await ghRaw([
     "release",
     "create",
     tag,
@@ -111,7 +111,7 @@ async function attachArtifacts(ctx: IssueContext, prUrl: string): Promise<void> 
   ]);
 
   // Get asset download URL
-  const { stdout: assetUrl } = await execSafe("gh", [
+  const assetUrl = await ghRaw([
     "release",
     "view",
     tag,
@@ -137,7 +137,7 @@ async function attachArtifacts(ctx: IssueContext, prUrl: string): Promise<void> 
     "Contains: research.md, plan.md, plan-implementation.md, review.md, completed-summary.md",
   ].join("\n");
 
-  await execSafe("gh", ["pr", "comment", prUrl, "--body", comment]);
+  await ghRaw(["pr", "comment", prUrl, "--body", comment]);
 }
 
 async function hasOpenPR(branch: string): Promise<boolean> {

--- a/src/lib/auto-claude/steps/create-pr.ts
+++ b/src/lib/auto-claude/steps/create-pr.ts
@@ -4,7 +4,7 @@ import consola from "consola";
 
 import { getConfig } from "../config.js";
 import { ARTIFACTS, STEP_LABELS } from "../prompt-templates/index.js";
-import { fileExists, ghRaw, git, log, logStep, readFile, writeFile } from "../utils.js";
+import { execSafe, fileExists, ghRaw, git, log, logStep, readFile, writeFile } from "../utils.js";
 import type { IssueContext } from "../utils.js";
 
 export async function stepCreatePR(ctx: IssueContext): Promise<boolean> {
@@ -65,12 +65,80 @@ export async function stepCreatePR(ctx: IssueContext): Promise<boolean> {
     const url = prUrl.trim();
     writeFile(join(ctx.issueDir, ARTIFACTS.prUrl), url);
     log(`PR created: ${url}`);
+
+    try {
+      await attachArtifacts(ctx, url);
+    } catch (e) {
+      consola.warn(`Artifact upload failed (non-blocking): ${e}`);
+    }
   } else {
     consola.error("Failed to create PR");
     return false;
   }
 
   return true;
+}
+
+async function attachArtifacts(ctx: IssueContext, prUrl: string): Promise<void> {
+  const archivePath = join(ctx.issueDir, "artifacts.tar.gz");
+  const tag = `ac-issue-${ctx.number}`;
+  const cfg = getConfig();
+
+  // Create tar.gz (exclude resolved prompt templates and the archive itself)
+  await execSafe("tar", [
+    "czf",
+    archivePath,
+    "-C",
+    ctx.issueDir,
+    "--exclude=*.prompt.md",
+    "--exclude=artifacts.tar.gz",
+    ".",
+  ]);
+
+  // Delete old release if exists (idempotent)
+  await execSafe("gh", ["release", "delete", tag, "--yes", "--repo", cfg.repo]);
+
+  // Create pre-release with asset
+  await execSafe("gh", [
+    "release",
+    "create",
+    tag,
+    "--prerelease",
+    "--title",
+    `Artifacts: #${ctx.number}`,
+    "--repo",
+    cfg.repo,
+    archivePath,
+  ]);
+
+  // Get asset download URL
+  const { stdout: assetUrl } = await execSafe("gh", [
+    "release",
+    "view",
+    tag,
+    "--json",
+    "assets",
+    "--jq",
+    ".assets[0].url",
+    "--repo",
+    cfg.repo,
+  ]);
+
+  if (!assetUrl) {
+    consola.warn("Could not get artifact download URL — skipping PR comment");
+    return;
+  }
+
+  // Add PR comment with download link
+  const comment = [
+    "## Pipeline Artifacts",
+    "",
+    `[Download artifacts (tar.gz)](${assetUrl.trim()})`,
+    "",
+    "Contains: research.md, plan.md, plan-implementation.md, review.md, completed-summary.md",
+  ].join("\n");
+
+  await execSafe("gh", ["pr", "comment", prUrl, "--body", comment]);
 }
 
 async function hasOpenPR(branch: string): Promise<boolean> {

--- a/src/lib/auto-claude/steps/create-pr.ts
+++ b/src/lib/auto-claude/steps/create-pr.ts
@@ -61,19 +61,18 @@ export async function stepCreatePR(ctx: IssueContext): Promise<boolean> {
     cfg.triggerLabel,
   ]);
 
-  if (prUrl) {
-    const url = prUrl.trim();
-    writeFile(join(ctx.issueDir, ARTIFACTS.prUrl), url);
-    log(`PR created: ${url}`);
-
-    try {
-      await attachArtifacts(ctx, url);
-    } catch (e) {
-      consola.warn(`Artifact upload failed (non-blocking): ${e}`);
-    }
-  } else {
+  if (!prUrl) {
     consola.error("Failed to create PR");
     return false;
+  }
+
+  writeFile(join(ctx.issueDir, ARTIFACTS.prUrl), prUrl);
+  log(`PR created: ${prUrl}`);
+
+  try {
+    await attachArtifacts(ctx, prUrl);
+  } catch (e) {
+    consola.warn(`Artifact upload failed (non-blocking): ${e}`);
   }
 
   return true;
@@ -133,7 +132,7 @@ async function attachArtifacts(ctx: IssueContext, prUrl: string): Promise<void> 
   const comment = [
     "## Pipeline Artifacts",
     "",
-    `[Download artifacts (tar.gz)](${assetUrl.trim()})`,
+    `[Download artifacts (tar.gz)](${assetUrl})`,
     "",
     "Contains: research.md, plan.md, plan-implementation.md, review.md, completed-summary.md",
   ].join("\n");

--- a/src/lib/auto-claude/steps/implement.ts
+++ b/src/lib/auto-claude/steps/implement.ts
@@ -6,7 +6,6 @@ import { getConfig } from "../config.js";
 import { ARTIFACTS, STEP_LABELS, TEMPLATES } from "../prompt-templates/index.js";
 import {
   buildTokens,
-  commitArtifacts,
   fileExists,
   git,
   log,
@@ -48,10 +47,6 @@ export async function stepImplement(ctx: IssueContext): Promise<boolean> {
 
     if (fileExists(completedPath)) {
       log(`Implementation complete after ${i} iteration(s)`);
-      await commitArtifacts(
-        ctx,
-        `chore(auto-claude): implementation complete for ${ctx.repo}#${ctx.number}`,
-      );
       return true;
     }
 

--- a/src/lib/auto-claude/steps/implement.ts
+++ b/src/lib/auto-claude/steps/implement.ts
@@ -36,7 +36,6 @@ export async function stepImplement(ctx: IssueContext): Promise<boolean> {
 
     const result = await runClaude({
       promptFile,
-      permissionMode: "acceptEdits",
       maxTurns: getConfig().maxTurns,
     });
 

--- a/src/lib/auto-claude/steps/plan-annotations.ts
+++ b/src/lib/auto-claude/steps/plan-annotations.ts
@@ -5,15 +5,7 @@ import consola from "consola";
 
 import { getConfig } from "../config.js";
 import { ARTIFACTS, STEP_LABELS, TEMPLATES } from "../prompt-templates/index.js";
-import {
-  buildTokens,
-  commitArtifacts,
-  fileExists,
-  log,
-  logStep,
-  resolveTemplate,
-  runClaude,
-} from "../utils.js";
+import { buildTokens, fileExists, log, logStep, resolveTemplate, runClaude } from "../utils.js";
 import type { IssueContext } from "../utils.js";
 
 export async function stepPlanAnnotations(ctx: IssueContext): Promise<boolean> {
@@ -49,6 +41,5 @@ export async function stepPlanAnnotations(ctx: IssueContext): Promise<boolean> {
   renameSync(annotationsPath, addressedPath);
   log("Annotations addressed — renamed to plan-annotations-addressed.md");
 
-  await commitArtifacts(ctx, `chore(auto-claude): plan annotations for ${ctx.repo}#${ctx.number}`);
   return true;
 }

--- a/src/lib/auto-claude/steps/plan-annotations.ts
+++ b/src/lib/auto-claude/steps/plan-annotations.ts
@@ -29,7 +29,6 @@ export async function stepPlanAnnotations(ctx: IssueContext): Promise<boolean> {
 
   const result = await runClaude({
     promptFile,
-    permissionMode: "acceptEdits",
     maxTurns: getConfig().maxTurns,
   });
 

--- a/src/lib/auto-claude/steps/refresh.ts
+++ b/src/lib/auto-claude/steps/refresh.ts
@@ -5,16 +5,7 @@ import consola from "consola";
 
 import { getConfig } from "../config.js";
 import { ARTIFACTS, STEP_LABELS, TEMPLATES } from "../prompt-templates/index.js";
-import {
-  buildTokens,
-  execSafe,
-  fileExists,
-  git,
-  log,
-  logStep,
-  resolveTemplate,
-  runClaude,
-} from "../utils.js";
+import { buildTokens, execSafe, git, log, logStep, resolveTemplate, runClaude } from "../utils.js";
 import type { IssueContext } from "../utils.js";
 
 export async function stepRefresh(ctx: IssueContext): Promise<boolean> {
@@ -98,8 +89,6 @@ async function invalidateStaleArtifacts(ctx: IssueContext): Promise<void> {
   ];
 
   for (const p of paths) {
-    if (fileExists(p)) {
-      rmSync(p);
-    }
+    rmSync(p, { force: true });
   }
 }

--- a/src/lib/auto-claude/steps/refresh.ts
+++ b/src/lib/auto-claude/steps/refresh.ts
@@ -46,7 +46,6 @@ export async function stepRefresh(ctx: IssueContext): Promise<boolean> {
   const promptFile = resolveTemplate(TEMPLATES.refresh, tokens, ctx.issueDir);
   const result = await runClaude({
     promptFile,
-    permissionMode: "acceptEdits",
     maxTurns: getConfig().maxTurns,
   });
 

--- a/src/lib/auto-claude/steps/refresh.ts
+++ b/src/lib/auto-claude/steps/refresh.ts
@@ -7,7 +7,6 @@ import { getConfig } from "../config.js";
 import { ARTIFACTS, STEP_LABELS, TEMPLATES } from "../prompt-templates/index.js";
 import {
   buildTokens,
-  commitArtifacts,
   execSafe,
   fileExists,
   git,
@@ -57,7 +56,6 @@ export async function stepRefresh(ctx: IssueContext): Promise<boolean> {
     return false;
   }
 
-  await commitArtifacts(ctx, `chore(auto-claude): refresh for ${ctx.repo}#${ctx.number}`);
   await invalidateStaleArtifacts(ctx);
 
   await git(["push", "--force-with-lease", "-u", remote, ctx.branch]);
@@ -100,15 +98,9 @@ async function invalidateStaleArtifacts(ctx: IssueContext): Promise<void> {
     join(ctx.issueDir, ARTIFACTS.completedSummary),
   ];
 
-  const removed = paths.filter((p) => {
+  for (const p of paths) {
     if (fileExists(p)) {
       rmSync(p);
-      return true;
     }
-    return false;
-  });
-
-  if (removed.length > 0) {
-    await commitArtifacts(ctx, "chore(auto-claude): invalidate stale artifacts after refresh");
   }
 }

--- a/src/lib/auto-claude/steps/steps.test.ts
+++ b/src/lib/auto-claude/steps/steps.test.ts
@@ -117,9 +117,6 @@ describe("runStepWithArtifact", () => {
     });
 
     expect(result).toBe(true);
-
-    const log = execSync("git log --oneline", { cwd: repo.dir, encoding: "utf-8" });
-    expect(log).toContain("chore(auto-claude)");
   });
 });
 

--- a/src/lib/auto-claude/utils-execution.test.ts
+++ b/src/lib/auto-claude/utils-execution.test.ts
@@ -1,6 +1,4 @@
 import { execSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 
 import consola from "consola";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -99,54 +97,5 @@ describe("ensureBranch (real git)", () => {
     await ensureBranch("feature/99-test-checkout");
     const branch2 = await git(["branch", "--show-current"]);
     expect(branch2).toBe("feature/99-test-checkout");
-  });
-});
-
-// ── commitArtifacts: real git ──
-
-describe("commitArtifacts (real git)", () => {
-  let originalCwd: string;
-  let repo: TestRepo;
-
-  beforeEach(async () => {
-    originalCwd = process.cwd();
-    repo = createTestRepo();
-    process.chdir(repo.dir);
-    await initConfig({ repo: "test/repo", mainBranch: "main" });
-  });
-
-  afterEach(() => {
-    process.chdir(originalCwd);
-    repo.cleanup();
-  });
-
-  it("commits staged files in the issue directory", async () => {
-    const { commitArtifacts, buildIssueContext } = await import("./utils");
-
-    const ctx = buildIssueContext({ number: 1, title: "Test", body: "body" }, "test/repo", ".");
-
-    const issueDir = join(repo.dir, ctx.issueDirRel);
-    mkdirSync(issueDir, { recursive: true });
-    writeFileSync(join(issueDir, "test.md"), "# Test artifact");
-
-    await commitArtifacts(ctx, "test commit");
-
-    const log = execSync("git log --oneline", { cwd: repo.dir, encoding: "utf-8" });
-    expect(log).toContain("test commit");
-  });
-
-  it("does not commit when no changes are staged", async () => {
-    const { commitArtifacts, buildIssueContext } = await import("./utils");
-
-    const ctx = buildIssueContext({ number: 2, title: "Test", body: "body" }, "test/repo", ".");
-
-    const issueDir = join(repo.dir, ctx.issueDirRel);
-    mkdirSync(issueDir, { recursive: true });
-
-    const logBefore = execSync("git log --oneline", { cwd: repo.dir, encoding: "utf-8" });
-    await commitArtifacts(ctx, "should not appear");
-    const logAfter = execSync("git log --oneline", { cwd: repo.dir, encoding: "utf-8" });
-
-    expect(logAfter).toBe(logBefore);
   });
 });

--- a/src/lib/auto-claude/utils.ts
+++ b/src/lib/auto-claude/utils.ts
@@ -239,14 +239,6 @@ export function writeFile(path: string, content: string): void {
 
 // ── Git helpers ──
 
-export async function commitArtifacts(ctx: IssueContext, message: string): Promise<void> {
-  await git(["add", ctx.issueDirRel]);
-  const staged = await execSafe("git", ["diff", "--cached", "--name-only"]);
-  if (staged.ok && staged.stdout.length > 0) {
-    await git(["commit", "-m", message]);
-  }
-}
-
 // ── Issue context ──
 
 export interface IssueContext {
@@ -417,9 +409,5 @@ export async function runStepWithArtifact(opts: StepRunnerOptions): Promise<bool
     return false;
   }
 
-  await commitArtifacts(
-    ctx,
-    `chore(auto-claude): ${stepName.toLowerCase()} for ${ctx.repo}#${ctx.number}`,
-  );
   return true;
 }

--- a/src/lib/auto-claude/utils.ts
+++ b/src/lib/auto-claude/utils.ts
@@ -179,24 +179,10 @@ function logToolUse(block: Record<string, unknown>): void {
 }
 
 function handleStreamEvent(event: Record<string, unknown>, onTurn: (count: number) => void): void {
-  // Complete assistant turn: { type: "assistant", message: { content: [...] } }
-  if (event.type === "assistant" && typeof event.message === "object" && event.message !== null) {
-    const msg = event.message as Record<string, unknown>;
-    const content = Array.isArray(msg.content) ? msg.content : [];
-    for (const block of content) {
-      if (
-        typeof block === "object" &&
-        block !== null &&
-        (block as Record<string, unknown>).type === "tool_use"
-      ) {
-        logToolUse(block as Record<string, unknown>);
-      }
-    }
-  }
-
-  // Streaming: { type: "stream_event", event: { type: "content_block_start", content_block: { ... } } }
+  // Only handle stream_event — assistant turn events duplicate the same tools
   if (event.type === "stream_event" && typeof event.event === "object" && event.event !== null) {
     const inner = event.event as Record<string, unknown>;
+
     if (
       inner.type === "content_block_start" &&
       typeof inner.content_block === "object" &&
@@ -205,6 +191,8 @@ function handleStreamEvent(event: Record<string, unknown>, onTurn: (count: numbe
       const block = inner.content_block as Record<string, unknown>;
       if (block.type === "tool_use") {
         logToolUse(block);
+      } else if (block.type === "thinking") {
+        consola.info(`  ${pc.dim("\u21B3")} ${pc.italic("thinking\u2026")}`);
       }
     }
   }

--- a/src/lib/auto-claude/utils.ts
+++ b/src/lib/auto-claude/utils.ts
@@ -165,7 +165,7 @@ function toolDetail(block: Record<string, unknown>): string {
   if (typeof filePath === "string") return pc.dim(` ${filePath}`);
   if (typeof input.pattern === "string") return pc.dim(` ${input.pattern}`);
   if (typeof input.command === "string") {
-    const cmd = input.command as string;
+    const cmd = input.command;
     return pc.dim(` ${cmd.length > 60 ? cmd.slice(0, 60) + "\u2026" : cmd}`);
   }
   return "";

--- a/src/lib/auto-claude/utils.ts
+++ b/src/lib/auto-claude/utils.ts
@@ -59,7 +59,6 @@ export interface ClaudeResult {
 
 export async function runClaude(opts: {
   promptFile: string;
-  permissionMode: "plan" | "acceptEdits";
   maxTurns?: number;
   retry?: boolean;
 }): Promise<ClaudeResult> {
@@ -68,8 +67,8 @@ export async function runClaude(opts: {
     "--output-format",
     "stream-json",
     "--verbose",
-    "--permission-mode",
-    opts.permissionMode,
+    "--include-partial-messages",
+    "--dangerously-skip-permissions",
     ...(opts.maxTurns ? ["--max-turns", String(opts.maxTurns)] : []),
     `@${opts.promptFile}`,
   ];
@@ -155,33 +154,58 @@ function runClaudeStreaming(args: string[]): Promise<ClaudeResult> {
   });
 }
 
+function toolDetail(block: Record<string, unknown>): string {
+  const input =
+    typeof block.input === "object" && block.input !== null
+      ? (block.input as Record<string, unknown>)
+      : null;
+  if (!input) return "";
+
+  const filePath = input.file_path ?? input.path;
+  if (typeof filePath === "string") return pc.dim(` ${filePath}`);
+  if (typeof input.pattern === "string") return pc.dim(` ${input.pattern}`);
+  if (typeof input.command === "string") {
+    const cmd = input.command as string;
+    return pc.dim(` ${cmd.length > 60 ? cmd.slice(0, 60) + "\u2026" : cmd}`);
+  }
+  return "";
+}
+
+function logToolUse(block: Record<string, unknown>): void {
+  const name = block.name;
+  if (typeof name === "string") {
+    consola.info(`  ${pc.dim("\u21B3")} ${name}${toolDetail(block)}`);
+  }
+}
+
 function handleStreamEvent(event: Record<string, unknown>, onTurn: (count: number) => void): void {
-  // Tool use events: look for content blocks with tool_use type
-  if (event.type === "assistant" && Array.isArray(event.message)) {
-    for (const block of event.message) {
+  // Complete assistant turn: { type: "assistant", message: { content: [...] } }
+  if (event.type === "assistant" && typeof event.message === "object" && event.message !== null) {
+    const msg = event.message as Record<string, unknown>;
+    const content = Array.isArray(msg.content) ? msg.content : [];
+    for (const block of content) {
       if (
         typeof block === "object" &&
         block !== null &&
-        "type" in block &&
         (block as Record<string, unknown>).type === "tool_use"
       ) {
-        const name = (block as Record<string, unknown>).name;
-        if (typeof name === "string") {
-          consola.info(`  ${pc.dim("\u21B3")} ${name}`);
-        }
+        logToolUse(block as Record<string, unknown>);
       }
     }
   }
 
-  // Content block with tool_use (alternative format)
-  if (
-    event.type === "content_block_start" &&
-    typeof event.content_block === "object" &&
-    event.content_block !== null
-  ) {
-    const block = event.content_block as Record<string, unknown>;
-    if (block.type === "tool_use" && typeof block.name === "string") {
-      consola.info(`  ${pc.dim("\u21B3")} ${block.name}`);
+  // Streaming: { type: "stream_event", event: { type: "content_block_start", content_block: { ... } } }
+  if (event.type === "stream_event" && typeof event.event === "object" && event.event !== null) {
+    const inner = event.event as Record<string, unknown>;
+    if (
+      inner.type === "content_block_start" &&
+      typeof inner.content_block === "object" &&
+      inner.content_block !== null
+    ) {
+      const block = inner.content_block as Record<string, unknown>;
+      if (block.type === "tool_use") {
+        logToolUse(block);
+      }
     }
   }
 
@@ -339,16 +363,22 @@ export function logStep(step: string, ctx: IssueContext, skipped = false): void 
 export async function ensureBranch(branch: string): Promise<void> {
   const { mainBranch, remote } = getConfig();
 
-  try {
-    const branches = await git(["branch", "--list", branch]);
-    if (branches.includes(branch)) {
-      await git(["checkout", branch]);
-      return;
-    }
-  } catch {
-    /* ignore */
+  // Stash uncommitted changes so branch switching works from a dirty tree
+  const status = await execSafe("git", ["status", "--porcelain"]);
+  const hadDirtyTree = status.ok && status.stdout.length > 0;
+  if (hadDirtyTree) {
+    await git(["stash", "push", "-m", `auto-claude: before switching to ${branch}`]);
+    log("Stashed uncommitted changes");
   }
 
+  // Check if branch exists locally (rev-parse is reliable, no output parsing)
+  const local = await execSafe("git", ["rev-parse", "--verify", `refs/heads/${branch}`]);
+  if (local.ok) {
+    await git(["checkout", branch]);
+    return;
+  }
+
+  // Check if branch exists on remote
   try {
     await git(["fetch", remote, branch]);
     await git(["checkout", branch]);
@@ -357,6 +387,7 @@ export async function ensureBranch(branch: string): Promise<void> {
     /* doesn't exist remotely */
   }
 
+  // Create new branch from main
   await git(["checkout", mainBranch]);
   await git(["pull", remote, mainBranch]);
   await git(["checkout", "-b", branch]);
@@ -395,7 +426,6 @@ export async function runStepWithArtifact(opts: StepRunnerOptions): Promise<bool
 
   const result = await runClaude({
     promptFile,
-    permissionMode: "acceptEdits",
     maxTurns: getConfig().maxTurns,
   });
 

--- a/src/utils/git/gh-cli-wrapper.test.ts
+++ b/src/utils/git/gh-cli-wrapper.test.ts
@@ -63,3 +63,26 @@ describe("gh-cli-wrapper", () => {
     });
   });
 });
+
+describe("getIssues label filter", () => {
+  it("passes --label flag when label provided", async () => {
+    const { x } = await import("tinyexec");
+    vi.mocked(x).mockResolvedValueOnce({
+      stdout: "[]",
+      stderr: "",
+      exitCode: 0,
+    } as never);
+
+    await getIssues({ cwd: ".", label: "auto-claude" });
+
+    expect(x).toHaveBeenCalledWith("gh", expect.arrayContaining(["--label", "auto-claude"]));
+  });
+});
+
+vi.mock("tinyexec", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("tinyexec")>();
+  return {
+    ...actual,
+    x: vi.fn(actual.x),
+  };
+});

--- a/src/utils/git/gh-cli-wrapper.test.ts
+++ b/src/utils/git/gh-cli-wrapper.test.ts
@@ -1,14 +1,65 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getIssues, isGithubCliInstalled } from "./gh-cli-wrapper";
 
-describe.skipIf(!!process.env.CI)("gh-cli-wrapper", () => {
-  it("should return true if gh is installed", async () => {
-    const result = await isGithubCliInstalled();
-    expect(result).toBe(true);
+vi.mock("tinyexec", () => ({
+  x: vi.fn().mockResolvedValue({ stdout: "[]" }),
+}));
+
+describe("gh-cli-wrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("get issues", async () => {
-    const issues = await getIssues({ assignedToMe: false, cwd: "." });
-    expect(issues.length).toBeGreaterThan(0);
+  describe("getIssues", () => {
+    it("passes --label flag when label provided", async () => {
+      const { x } = await import("tinyexec");
+      const mockX = vi.mocked(x);
+      mockX.mockResolvedValue({ stdout: "[]" } as never);
+
+      await getIssues({ cwd: ".", label: "auto-claude" });
+
+      expect(mockX).toHaveBeenCalledWith("gh", expect.arrayContaining(["--label", "auto-claude"]));
+    });
+
+    it("does not pass --label flag when label not provided", async () => {
+      const { x } = await import("tinyexec");
+      const mockX = vi.mocked(x);
+      mockX.mockResolvedValue({ stdout: "[]" } as never);
+
+      await getIssues({ cwd: "." });
+
+      const args = mockX.mock.calls[0]![1] as string[];
+      expect(args).not.toContain("--label");
+    });
+
+    it("passes --assignee @me flag when assignedToMe is true", async () => {
+      const { x } = await import("tinyexec");
+      const mockX = vi.mocked(x);
+      mockX.mockResolvedValue({ stdout: "[]" } as never);
+
+      await getIssues({ cwd: ".", assignedToMe: true });
+
+      expect(mockX).toHaveBeenCalledWith("gh", expect.arrayContaining(["--assignee", "@me"]));
+    });
+  });
+
+  describe("isGithubCliInstalled", () => {
+    it("returns true when gh CLI outputs expected string", async () => {
+      const { x } = await import("tinyexec");
+      const mockX = vi.mocked(x);
+      mockX.mockResolvedValue({ stdout: "gh version 2.0.0 (https://github.com/cli/cli)" } as never);
+
+      const result = await isGithubCliInstalled();
+      expect(result).toBe(true);
+    });
+
+    it("returns false when gh CLI is not available", async () => {
+      const { x } = await import("tinyexec");
+      const mockX = vi.mocked(x);
+      mockX.mockRejectedValue(new Error("command not found"));
+
+      const result = await isGithubCliInstalled();
+      expect(result).toBe(false);
+    });
   });
 });

--- a/src/utils/git/gh-cli-wrapper.test.ts
+++ b/src/utils/git/gh-cli-wrapper.test.ts
@@ -1,31 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { x } from "tinyexec";
 import { getIssues, isGithubCliInstalled } from "./gh-cli-wrapper";
 
 vi.mock("tinyexec", () => ({
   x: vi.fn().mockResolvedValue({ stdout: "[]" }),
 }));
 
+const mockX = vi.mocked(x);
+
 describe("gh-cli-wrapper", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockX.mockResolvedValue({ stdout: "[]" } as never);
   });
 
   describe("getIssues", () => {
     it("passes --label flag when label provided", async () => {
-      const { x } = await import("tinyexec");
-      const mockX = vi.mocked(x);
-      mockX.mockResolvedValue({ stdout: "[]" } as never);
-
       await getIssues({ cwd: ".", label: "auto-claude" });
 
       expect(mockX).toHaveBeenCalledWith("gh", expect.arrayContaining(["--label", "auto-claude"]));
     });
 
     it("does not pass --label flag when label not provided", async () => {
-      const { x } = await import("tinyexec");
-      const mockX = vi.mocked(x);
-      mockX.mockResolvedValue({ stdout: "[]" } as never);
-
       await getIssues({ cwd: "." });
 
       const args = mockX.mock.calls[0]![1] as string[];
@@ -33,10 +29,6 @@ describe("gh-cli-wrapper", () => {
     });
 
     it("passes --assignee @me flag when assignedToMe is true", async () => {
-      const { x } = await import("tinyexec");
-      const mockX = vi.mocked(x);
-      mockX.mockResolvedValue({ stdout: "[]" } as never);
-
       await getIssues({ cwd: ".", assignedToMe: true });
 
       expect(mockX).toHaveBeenCalledWith("gh", expect.arrayContaining(["--assignee", "@me"]));
@@ -45,8 +37,6 @@ describe("gh-cli-wrapper", () => {
 
   describe("isGithubCliInstalled", () => {
     it("returns true when gh CLI outputs expected string", async () => {
-      const { x } = await import("tinyexec");
-      const mockX = vi.mocked(x);
       mockX.mockResolvedValue({ stdout: "gh version 2.0.0 (https://github.com/cli/cli)" } as never);
 
       const result = await isGithubCliInstalled();
@@ -54,8 +44,6 @@ describe("gh-cli-wrapper", () => {
     });
 
     it("returns false when gh CLI is not available", async () => {
-      const { x } = await import("tinyexec");
-      const mockX = vi.mocked(x);
       mockX.mockRejectedValue(new Error("command not found"));
 
       const result = await isGithubCliInstalled();

--- a/src/utils/git/gh-cli-wrapper.test.ts
+++ b/src/utils/git/gh-cli-wrapper.test.ts
@@ -63,26 +63,3 @@ describe("gh-cli-wrapper", () => {
     });
   });
 });
-
-describe("getIssues label filter", () => {
-  it("passes --label flag when label provided", async () => {
-    const { x } = await import("tinyexec");
-    vi.mocked(x).mockResolvedValueOnce({
-      stdout: "[]",
-      stderr: "",
-      exitCode: 0,
-    } as never);
-
-    await getIssues({ cwd: ".", label: "auto-claude" });
-
-    expect(x).toHaveBeenCalledWith("gh", expect.arrayContaining(["--label", "auto-claude"]));
-  });
-});
-
-vi.mock("tinyexec", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("tinyexec")>();
-  return {
-    ...actual,
-    x: vi.fn(actual.x),
-  };
-});

--- a/src/utils/git/gh-cli-wrapper.ts
+++ b/src/utils/git/gh-cli-wrapper.ts
@@ -23,9 +23,11 @@ export interface Issue {
 export const getIssues = async ({
   assignedToMe,
   cwd,
+  label,
 }: {
-  assignedToMe: boolean;
+  assignedToMe?: boolean;
   cwd: string;
+  label?: string;
 }): Promise<Issue[]> => {
   let issues: Issue[] = [];
 
@@ -34,6 +36,10 @@ export const getIssues = async ({
   if (assignedToMe) {
     flags.push("--assignee");
     flags.push("@me");
+  }
+
+  if (label) {
+    flags.push("--label", label);
   }
 
   //console.log('Current working directory:', cwd.stdout.trim())

--- a/src/utils/git/gh-cli-wrapper.ts
+++ b/src/utils/git/gh-cli-wrapper.ts
@@ -1,14 +1,14 @@
 import stripAnsi from "strip-ansi";
 import { x } from "tinyexec";
 
-export const isGithubCliInstalled = async (): Promise<boolean> => {
+export async function isGithubCliInstalled(): Promise<boolean> {
   try {
-    const proc = await x(`gh`, ["--version"]);
-    return proc.stdout.indexOf("https://github.com/cli/cli") > 0;
-  } catch (e) {
+    const proc = await x("gh", ["--version"]);
+    return proc.stdout.includes("https://github.com/cli/cli");
+  } catch {
     return false;
   }
-};
+}
 
 export interface Issue {
   labels: {
@@ -20,7 +20,7 @@ export interface Issue {
   state: string;
 }
 
-export const getIssues = async ({
+export async function getIssues({
   assignedToMe,
   cwd,
   label,
@@ -28,33 +28,26 @@ export const getIssues = async ({
   assignedToMe?: boolean;
   cwd: string;
   label?: string;
-}): Promise<Issue[]> => {
-  let issues: Issue[] = [];
-
-  const flags = ["issue", "list", "--json", "labels,number,title,state"];
+}): Promise<Issue[]> {
+  const args = ["issue", "list", "--json", "labels,number,title,state"];
 
   if (assignedToMe) {
-    flags.push("--assignee");
-    flags.push("@me");
+    args.push("--assignee", "@me");
   }
 
   if (label) {
-    flags.push("--label", label);
+    args.push("--label", label);
   }
 
-  //console.log('Current working directory:', cwd.stdout.trim())
-
-  const result = await x(`gh`, flags);
+  const result = await x("gh", args);
   // Setting NO_COLOR=1 didn't remove colors so had to use stripAnsi
   const stripped = stripAnsi(result.stdout);
 
   try {
-    issues = JSON.parse(stripped);
+    return JSON.parse(stripped) as Issue[];
   } catch {
     throw new Error(
       `Failed to parse GitHub CLI output as JSON. Raw output: ${stripped.slice(0, 200)}${stripped.length > 200 ? "..." : ""}`,
     );
   }
-
-  return issues;
-};
+}

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -1,6 +1,8 @@
 import { colors } from "consola/utils";
 
-export const getTerminalColumns = () => process.stdout?.columns || 80;
+export function getTerminalColumns(): number {
+  return process.stdout?.columns || 80;
+}
 
 export const limitText = (text: string, maxWidth: number): string => {
   if (text.length <= maxWidth) return text;


### PR DESCRIPTION
## Summary

Automated implementation for: **feat: add interactive issue picker subcommand to auto-claude (tt ac list)**

Closes #97

## Pipeline Artifacts

- Research: `.auto-claude/issue-97/research.md`
- Plan: `.auto-claude/issue-97/plan.md`
- Implementation Plan: `.auto-claude/issue-97/plan-implementation.md`
- Review: `.auto-claude/issue-97/review.md`

## Review Summary

# Review: Issue #97 — Interactive Issue Picker (`tt ac list`)

## Status: PASS WITH FIXES

## Issues Found and Fixed

1. **Duplicate `vi.mock("tinyexec")` in `gh-cli-wrapper.test.ts`** — Two conflicting `vi.mock` calls for the same module, plus a duplicate test "passes --label flag when label provided" in a standalone describe block. Removed the duplicate block and second mock.

2. **Stale file path in `docs/auto-claude.md`** — Referenced `src/commands/auto-claude.ts` but the file was moved to `src/commands/auto-claude/index.ts`.

3. **Stale description in `docs/auto-claude.md`** — `runStepWithArtifact()` description said "check → run Claude → validate → commit" but `commitArtifacts` was removed. Updated to "check → run Claude → validate output".

## Code-Simplify Changes (separate commit)

- Converted arrow function exports to function declarations in `gh-cli-wrapper.ts`
- Replaced `.indexOf() > 0` with `.includes()`, removed dead comment, eliminated mutable `let` variable
- Hoisted mock reference in `gh-cli-wrapper.test.ts` to reduce test repetition
- Applied guard clause pattern in `create-pr.ts`, removed redundant `.trim()` calls
- Removed redundant `as string` cast in `utils.ts` `toolDetail()`
- Used `rmSync({ force: true })` in `refresh.ts` to eliminate `fileExists` check

## Confidence Level: High

All 4 plan tasks implemented correctly. Typecheck, tests (121 passed), and lint all clean. The interactive picker follows the same `prompts` + `Fzf` pattern as `gh/branch.ts`. The `getIssues()` extension is backward-compatible.

## Notes for PR Reviewer

- **Beyond-scope changes**: This branch includes significant changes beyond the issue scope — removed `commitArtifacts()` function, switched from `--permission-mode` to `--dangerously-skip-permissions`, added stash/unstash in branch switching, added artifact upload to GitHub releases, and improved Claude CLI streaming output parsing. These are pipeline improvements but should be reviewed carefully.
- **`--dangerous

---
Generated by auto-claude pipeline