### PR TITLE
feat(auto-claude): add ac status subcommand

### DIFF
--- a/src/commands/auto-claude/status.test.ts
+++ b/src/commands/auto-claude/status.test.ts
@@ -1,0 +1,147 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { Issue } from "../../utils/git/gh-cli-wrapper.js";
+import { LABELS } from "../../lib/auto-claude/utils.js";
+import { checkArtifacts, findAcLabel, formatIssueStatus } from "./status.js";
+
+// ── Test fixtures ──
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    number: 1,
+    title: "Test issue",
+    state: "open",
+    labels: [{ name: "auto-claude", color: "000000" }],
+    ...overrides,
+  };
+}
+
+// ── checkArtifacts ──
+
+describe("checkArtifacts", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ac-status-test-"));
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns all false when no artifacts exist", () => {
+    const result = checkArtifacts(99, tmpDir);
+    expect(result).toHaveLength(4);
+    for (const a of result) {
+      expect(a.exists).toBe(false);
+    }
+  });
+
+  it("detects existing artifacts", () => {
+    const issueDir = join(tmpDir, ".auto-claude/issue-42");
+    mkdirSync(issueDir, { recursive: true });
+    writeFileSync(join(issueDir, "plan.md"), "# Plan");
+    writeFileSync(join(issueDir, "review.md"), "# Review");
+
+    const result = checkArtifacts(42, tmpDir);
+    const planArtifact = result.find((a) => a.name === "plan.md");
+    const reviewArtifact = result.find((a) => a.name === "review.md");
+    const summaryArtifact = result.find((a) => a.name === "completed-summary.md");
+
+    expect(planArtifact?.exists).toBe(true);
+    expect(reviewArtifact?.exists).toBe(true);
+    expect(summaryArtifact?.exists).toBe(false);
+  });
+});
+
+// ── findAcLabel ──
+
+describe("findAcLabel", () => {
+  it("returns specific status label when present", () => {
+    const issue = makeIssue({
+      labels: [
+        { name: "auto-claude", color: "000000" },
+        { name: LABELS.inProgress, color: "ffff00" },
+      ],
+    });
+    expect(findAcLabel(issue)).toBe(LABELS.inProgress);
+  });
+
+  it("falls back to auto-claude when no status label", () => {
+    const issue = makeIssue({
+      labels: [{ name: "auto-claude", color: "000000" }],
+    });
+    expect(findAcLabel(issue)).toBe("auto-claude");
+  });
+
+  it("prefers in-progress over other labels", () => {
+    const issue = makeIssue({
+      labels: [
+        { name: LABELS.inProgress, color: "ffff00" },
+        { name: LABELS.success, color: "00ff00" },
+      ],
+    });
+    expect(findAcLabel(issue)).toBe(LABELS.inProgress);
+  });
+});
+
+// ── formatIssueStatus ──
+
+describe("formatIssueStatus", () => {
+  it("includes issue number and title", () => {
+    const issue = makeIssue({ number: 7, title: "Fix widget" });
+    const artifacts = [
+      { name: "plan.md", exists: false },
+      { name: "completed-summary.md", exists: false },
+      { name: "simplify-summary.md", exists: false },
+      { name: "review.md", exists: false },
+    ];
+    const output = formatIssueStatus(issue, artifacts);
+    expect(output).toContain("#7");
+    expect(output).toContain("Fix widget");
+  });
+
+  it("includes status tag", () => {
+    const issue = makeIssue({
+      labels: [{ name: LABELS.failed, color: "ff0000" }],
+    });
+    const artifacts = [
+      { name: "plan.md", exists: false },
+      { name: "completed-summary.md", exists: false },
+      { name: "simplify-summary.md", exists: false },
+      { name: "review.md", exists: false },
+    ];
+    const output = formatIssueStatus(issue, artifacts);
+    expect(output).toContain("failed");
+  });
+
+  it("shows completed artifacts", () => {
+    const issue = makeIssue();
+    const artifacts = [
+      { name: "plan.md", exists: true },
+      { name: "completed-summary.md", exists: true },
+      { name: "simplify-summary.md", exists: false },
+      { name: "review.md", exists: false },
+    ];
+    const output = formatIssueStatus(issue, artifacts);
+    expect(output).toContain("plan.md");
+    expect(output).toContain("completed-summary.md");
+    expect(output).not.toContain("simplify-summary.md");
+  });
+
+  it("omits artifacts line when none exist", () => {
+    const issue = makeIssue();
+    const artifacts = [
+      { name: "plan.md", exists: false },
+      { name: "completed-summary.md", exists: false },
+      { name: "simplify-summary.md", exists: false },
+      { name: "review.md", exists: false },
+    ];
+    const output = formatIssueStatus(issue, artifacts);
+    expect(output).not.toContain("artifacts:");
+  });
+});

--- a/src/commands/auto-claude/status.ts
+++ b/src/commands/auto-claude/status.ts
@@ -13,58 +13,33 @@ import { BaseCommand } from "../base.js";
 /** All labels that indicate an issue is part of the auto-claude pipeline. */
 const ALL_AC_LABELS = ["auto-claude", ...Object.values(LABELS)] as const;
 
-/** Map a label to a color function for display. */
-function colorForLabel(label: string): (text: string) => string {
-  switch (label) {
-    case LABELS.inProgress:
-      return colors.yellow;
-    case LABELS.success:
-      return colors.green;
-    case LABELS.failed:
-      return colors.red;
-    case LABELS.review:
-      return colors.blue;
-    default:
-      return colors.dim;
-  }
-}
+/** Display config per label: short name + color function. */
+const LABEL_DISPLAY: Record<string, { status: string; color: (t: string) => string }> = {
+  [LABELS.inProgress]: { status: "in-progress", color: colors.yellow },
+  [LABELS.success]: { status: "success", color: colors.green },
+  [LABELS.failed]: { status: "failed", color: colors.red },
+  [LABELS.review]: { status: "review", color: colors.blue },
+};
 
-/** Friendly short name for display. */
-function shortStatus(label: string): string {
-  switch (label) {
-    case LABELS.inProgress:
-      return "in-progress";
-    case LABELS.success:
-      return "success";
-    case LABELS.failed:
-      return "failed";
-    case LABELS.review:
-      return "review";
-    default:
-      return "queued";
-  }
-}
+const DEFAULT_DISPLAY = { status: "queued", color: colors.dim };
 
 interface ArtifactStatus {
   name: string;
   exists: boolean;
 }
 
+/** Pipeline artifacts to check, in pipeline order. */
+const CHECKED_ARTIFACTS = [
+  ARTIFACTS.plan,
+  ARTIFACTS.completedSummary,
+  ARTIFACTS.simplifySummary,
+  ARTIFACTS.review,
+] as const;
+
 /** Check which pipeline artifacts exist locally for an issue. */
 export function checkArtifacts(issueNumber: number, cwd: string): ArtifactStatus[] {
   const issueDir = join(cwd, `.auto-claude/issue-${issueNumber}`);
-  return [
-    { name: "plan.md", exists: existsSync(join(issueDir, ARTIFACTS.plan)) },
-    {
-      name: "completed-summary.md",
-      exists: existsSync(join(issueDir, ARTIFACTS.completedSummary)),
-    },
-    {
-      name: "simplify-summary.md",
-      exists: existsSync(join(issueDir, ARTIFACTS.simplifySummary)),
-    },
-    { name: "review.md", exists: existsSync(join(issueDir, ARTIFACTS.review)) },
-  ];
+  return CHECKED_ARTIFACTS.map((name) => ({ name, exists: existsSync(join(issueDir, name)) }));
 }
 
 /** Find the most specific auto-claude label on an issue. */
@@ -78,18 +53,12 @@ export function findAcLabel(issue: Issue): string {
 }
 
 /** Format a single issue for display. */
-export function formatIssueStatus(
-  issue: Issue,
-  artifacts: ArtifactStatus[],
-): string {
+export function formatIssueStatus(issue: Issue, artifacts: ArtifactStatus[]): string {
   const label = findAcLabel(issue);
-  const colorFn = colorForLabel(label);
-  const status = shortStatus(label);
-  const statusTag = colorFn(`[${status}]`);
+  const { status, color } = LABEL_DISPLAY[label] ?? DEFAULT_DISPLAY;
+  const statusTag = color(`[${status}]`);
 
-  const parts: string[] = [
-    `#${issue.number} ${issue.title} ${statusTag}`,
-  ];
+  const parts: string[] = [`#${issue.number} ${issue.title} ${statusTag}`];
 
   const completedSteps = artifacts.filter((a) => a.exists).map((a) => a.name);
   if (completedSteps.length > 0) {
@@ -103,9 +72,7 @@ export function formatIssueStatus(
 export async function fetchAllAcIssues(cwd: string): Promise<Issue[]> {
   const issueMap = new Map<number, Issue>();
 
-  const results = await Promise.all(
-    ALL_AC_LABELS.map((label) => getIssues({ cwd, label })),
-  );
+  const results = await Promise.all(ALL_AC_LABELS.map((label) => getIssues({ cwd, label })));
 
   for (const issues of results) {
     for (const issue of issues) {

--- a/src/commands/auto-claude/status.ts
+++ b/src/commands/auto-claude/status.ts
@@ -1,0 +1,156 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import consola from "consola";
+import { colors } from "consola/utils";
+
+import type { Issue } from "../../utils/git/gh-cli-wrapper.js";
+import { getIssues, isGithubCliInstalled } from "../../utils/git/gh-cli-wrapper.js";
+import { ARTIFACTS } from "../../lib/auto-claude/prompt-templates/index.js";
+import { LABELS } from "../../lib/auto-claude/utils.js";
+import { BaseCommand } from "../base.js";
+
+/** All labels that indicate an issue is part of the auto-claude pipeline. */
+const ALL_AC_LABELS = ["auto-claude", ...Object.values(LABELS)] as const;
+
+/** Map a label to a color function for display. */
+function colorForLabel(label: string): (text: string) => string {
+  switch (label) {
+    case LABELS.inProgress:
+      return colors.yellow;
+    case LABELS.success:
+      return colors.green;
+    case LABELS.failed:
+      return colors.red;
+    case LABELS.review:
+      return colors.blue;
+    default:
+      return colors.dim;
+  }
+}
+
+/** Friendly short name for display. */
+function shortStatus(label: string): string {
+  switch (label) {
+    case LABELS.inProgress:
+      return "in-progress";
+    case LABELS.success:
+      return "success";
+    case LABELS.failed:
+      return "failed";
+    case LABELS.review:
+      return "review";
+    default:
+      return "queued";
+  }
+}
+
+interface ArtifactStatus {
+  name: string;
+  exists: boolean;
+}
+
+/** Check which pipeline artifacts exist locally for an issue. */
+export function checkArtifacts(issueNumber: number, cwd: string): ArtifactStatus[] {
+  const issueDir = join(cwd, `.auto-claude/issue-${issueNumber}`);
+  return [
+    { name: "plan.md", exists: existsSync(join(issueDir, ARTIFACTS.plan)) },
+    {
+      name: "completed-summary.md",
+      exists: existsSync(join(issueDir, ARTIFACTS.completedSummary)),
+    },
+    {
+      name: "simplify-summary.md",
+      exists: existsSync(join(issueDir, ARTIFACTS.simplifySummary)),
+    },
+    { name: "review.md", exists: existsSync(join(issueDir, ARTIFACTS.review)) },
+  ];
+}
+
+/** Find the most specific auto-claude label on an issue. */
+export function findAcLabel(issue: Issue): string {
+  const labelNames = issue.labels.map((l) => l.name);
+  // Prefer the most specific status label; fall back to generic "auto-claude"
+  for (const label of Object.values(LABELS)) {
+    if (labelNames.includes(label)) return label;
+  }
+  return "auto-claude";
+}
+
+/** Format a single issue for display. */
+export function formatIssueStatus(
+  issue: Issue,
+  artifacts: ArtifactStatus[],
+): string {
+  const label = findAcLabel(issue);
+  const colorFn = colorForLabel(label);
+  const status = shortStatus(label);
+  const statusTag = colorFn(`[${status}]`);
+
+  const parts: string[] = [
+    `#${issue.number} ${issue.title} ${statusTag}`,
+  ];
+
+  const completedSteps = artifacts.filter((a) => a.exists).map((a) => a.name);
+  if (completedSteps.length > 0) {
+    parts.push(colors.dim(`  artifacts: ${completedSteps.join(", ")}`));
+  }
+
+  return parts.join("\n");
+}
+
+/** Fetch issues across all auto-claude labels, deduplicating by issue number. */
+export async function fetchAllAcIssues(cwd: string): Promise<Issue[]> {
+  const issueMap = new Map<number, Issue>();
+
+  const results = await Promise.all(
+    ALL_AC_LABELS.map((label) => getIssues({ cwd, label })),
+  );
+
+  for (const issues of results) {
+    for (const issue of issues) {
+      if (!issueMap.has(issue.number)) {
+        issueMap.set(issue.number, issue);
+      }
+    }
+  }
+
+  // Sort by issue number ascending
+  return [...issueMap.values()].sort((a, b) => a.number - b.number);
+}
+
+export default class AutoClaudeStatus extends BaseCommand {
+  static override description = "Show pipeline status for auto-claude issues";
+
+  static override aliases = ["ac:status"];
+
+  static override examples = [
+    {
+      description: "Show status of all auto-claude issues",
+      command: "<%= config.bin %> auto-claude status",
+    },
+  ];
+
+  async run(): Promise<void> {
+    const cliInstalled = await isGithubCliInstalled();
+    if (!cliInstalled) {
+      this.error("GitHub CLI (gh) is not installed");
+    }
+
+    const cwd = process.cwd();
+    const issues = await fetchAllAcIssues(cwd);
+
+    if (issues.length === 0) {
+      consola.info("No auto-claude issues found");
+      return;
+    }
+
+    consola.info(colors.bold(`Auto-Claude Pipeline Status (${issues.length} issue(s))`));
+    consola.log("");
+
+    for (const issue of issues) {
+      const artifacts = checkArtifacts(issue.number, cwd);
+      consola.log(formatIssueStatus(issue, artifacts));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New `tt auto-claude status` / `tt ac status` subcommand
- Shows pipeline status for all auto-claude issues (queued, in-progress, success, failed, review)
- Color-coded labels, local artifact completion display
- Fetches across all 5 auto-claude labels in parallel, deduplicates

## Test plan

- [x] 9 new tests (checkArtifacts, findAcLabel, formatIssueStatus)
- [x] 132 total tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)