### PR TITLE
feat(auto-claude): add ac retry subcommand

### DIFF
--- a/src/commands/auto-claude/retry.test.ts
+++ b/src/commands/auto-claude/retry.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import consola from "consola";
+import { x } from "tinyexec";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { LABELS } from "../../lib/auto-claude/utils.js";
+import { retryIssues } from "./retry.js";
+
+// Suppress consola output during tests
+consola.level = -999;
+
+// Mock tinyexec so setLabel/removeLabel (which use execSafe -> x) work
+vi.mock("tinyexec", () => ({
+  x: vi.fn().mockResolvedValue({ stdout: "", exitCode: 0, stderr: "" }),
+}));
+
+function getGhEditCalls() {
+  return vi.mocked(x).mock.calls
+    .filter(([cmd, args]) => cmd === "gh" && args?.[0] === "issue" && args?.[1] === "edit")
+    .map(([, args]) => args as string[]);
+}
+
+describe("retryIssues", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes failed label and adds trigger label for each issue", async () => {
+    const issues = [
+      { number: 42, title: "Fix bug", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+    ];
+
+    const count = await retryIssues("owner/repo", "auto-claude", issues, issues, false);
+
+    expect(count).toBe(1);
+    const editCalls = getGhEditCalls();
+    expect(editCalls.length).toBe(2);
+    expect(editCalls[0]).toEqual(
+      expect.arrayContaining(["42", "--repo", "owner/repo", "--remove-label", LABELS.failed]),
+    );
+    expect(editCalls[1]).toEqual(
+      expect.arrayContaining(["42", "--repo", "owner/repo", "--add-label", "auto-claude"]),
+    );
+  });
+
+  it("retries multiple issues", async () => {
+    const issues = [
+      { number: 10, title: "Issue A", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+      { number: 20, title: "Issue B", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+    ];
+
+    const count = await retryIssues("owner/repo", "auto-claude", issues, issues, false);
+
+    expect(count).toBe(2);
+    const editCalls = getGhEditCalls();
+    // 2 issues * 2 label ops = 4
+    expect(editCalls.length).toBe(4);
+  });
+
+  it("returns 0 when given empty selection", async () => {
+    const count = await retryIssues("owner/repo", "auto-claude", [], [], false);
+    expect(count).toBe(0);
+    expect(getGhEditCalls().length).toBe(0);
+  });
+
+  it("cleans artifact directory when clean=true", async () => {
+    const tmpDir = join(tmpdir(), `retry-test-${Date.now()}`);
+    const issueDir = join(tmpDir, ".auto-claude", "issue-42");
+    mkdirSync(issueDir, { recursive: true });
+    writeFileSync(join(issueDir, "test.txt"), "data");
+
+    const originalCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    try {
+      const issues = [
+        { number: 42, title: "Fix bug", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+      ];
+
+      await retryIssues("owner/repo", "auto-claude", issues, issues, true);
+      expect(existsSync(issueDir)).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it("does not clean artifacts when clean=false", async () => {
+    const tmpDir = join(tmpdir(), `retry-test-${Date.now()}`);
+    const issueDir = join(tmpDir, ".auto-claude", "issue-42");
+    mkdirSync(issueDir, { recursive: true });
+    writeFileSync(join(issueDir, "test.txt"), "data");
+
+    const originalCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    try {
+      const issues = [
+        { number: 42, title: "Fix bug", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+      ];
+
+      await retryIssues("owner/repo", "auto-claude", issues, issues, false);
+      expect(existsSync(issueDir)).toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/src/commands/auto-claude/retry.test.ts
+++ b/src/commands/auto-claude/retry.test.ts
@@ -18,8 +18,11 @@ vi.mock("tinyexec", () => ({
 }));
 
 function getGhEditCalls() {
-  return vi.mocked(x).mock.calls
-    .filter(([cmd, args]) => cmd === "gh" && args?.[0] === "issue" && args?.[1] === "edit")
+  return vi
+    .mocked(x)
+    .mock.calls.filter(
+      ([cmd, args]) => cmd === "gh" && args?.[0] === "issue" && args?.[1] === "edit",
+    )
     .map(([, args]) => args as string[]);
 }
 
@@ -30,10 +33,15 @@ describe("retryIssues", () => {
 
   it("removes failed label and adds trigger label for each issue", async () => {
     const issues = [
-      { number: 42, title: "Fix bug", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+      {
+        number: 42,
+        title: "Fix bug",
+        state: "OPEN",
+        labels: [{ name: LABELS.failed, color: "red" }],
+      },
     ];
 
-    const count = await retryIssues("owner/repo", "auto-claude", issues, issues, false);
+    const count = await retryIssues("owner/repo", "auto-claude", issues, false);
 
     expect(count).toBe(1);
     const editCalls = getGhEditCalls();
@@ -48,11 +56,21 @@ describe("retryIssues", () => {
 
   it("retries multiple issues", async () => {
     const issues = [
-      { number: 10, title: "Issue A", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
-      { number: 20, title: "Issue B", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+      {
+        number: 10,
+        title: "Issue A",
+        state: "OPEN",
+        labels: [{ name: LABELS.failed, color: "red" }],
+      },
+      {
+        number: 20,
+        title: "Issue B",
+        state: "OPEN",
+        labels: [{ name: LABELS.failed, color: "red" }],
+      },
     ];
 
-    const count = await retryIssues("owner/repo", "auto-claude", issues, issues, false);
+    const count = await retryIssues("owner/repo", "auto-claude", issues, false);
 
     expect(count).toBe(2);
     const editCalls = getGhEditCalls();
@@ -61,7 +79,7 @@ describe("retryIssues", () => {
   });
 
   it("returns 0 when given empty selection", async () => {
-    const count = await retryIssues("owner/repo", "auto-claude", [], [], false);
+    const count = await retryIssues("owner/repo", "auto-claude", [], false);
     expect(count).toBe(0);
     expect(getGhEditCalls().length).toBe(0);
   });
@@ -77,10 +95,15 @@ describe("retryIssues", () => {
 
     try {
       const issues = [
-        { number: 42, title: "Fix bug", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+        {
+          number: 42,
+          title: "Fix bug",
+          state: "OPEN",
+          labels: [{ name: LABELS.failed, color: "red" }],
+        },
       ];
 
-      await retryIssues("owner/repo", "auto-claude", issues, issues, true);
+      await retryIssues("owner/repo", "auto-claude", issues, true);
       expect(existsSync(issueDir)).toBe(false);
     } finally {
       process.chdir(originalCwd);
@@ -98,10 +121,15 @@ describe("retryIssues", () => {
 
     try {
       const issues = [
-        { number: 42, title: "Fix bug", state: "OPEN", labels: [{ name: LABELS.failed, color: "red" }] },
+        {
+          number: 42,
+          title: "Fix bug",
+          state: "OPEN",
+          labels: [{ name: LABELS.failed, color: "red" }],
+        },
       ];
 
-      await retryIssues("owner/repo", "auto-claude", issues, issues, false);
+      await retryIssues("owner/repo", "auto-claude", issues, false);
       expect(existsSync(issueDir)).toBe(true);
     } finally {
       process.chdir(originalCwd);

--- a/src/commands/auto-claude/retry.ts
+++ b/src/commands/auto-claude/retry.ts
@@ -1,0 +1,145 @@
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { Flags } from "@oclif/core";
+import consola from "consola";
+import { colors } from "consola/utils";
+import prompts from "prompts";
+
+import { BaseCommand } from "../base.js";
+import { initConfig } from "../../lib/auto-claude/index.js";
+import { LABELS, removeLabel, setLabel } from "../../lib/auto-claude/utils.js";
+import { getIssues, isGithubCliInstalled } from "../../utils/git/gh-cli-wrapper.js";
+import type { Issue } from "../../utils/git/gh-cli-wrapper.js";
+
+export interface RetryOptions {
+  issueNumber?: number;
+  clean: boolean;
+}
+
+/**
+ * Core retry logic: swap labels on failed issues to re-trigger the pipeline.
+ * Extracted for testability.
+ */
+export async function retryIssues(
+  repo: string,
+  triggerLabel: string,
+  failedIssues: Issue[],
+  selected: Issue[],
+  clean: boolean,
+): Promise<number> {
+  for (const issue of selected) {
+    consola.info(`Retrying issue #${issue.number}: ${issue.title}`);
+
+    await removeLabel(repo, issue.number, LABELS.failed);
+    consola.success(`  Removed '${LABELS.failed}' label`);
+
+    await setLabel(repo, issue.number, triggerLabel);
+    consola.success(`  Added '${triggerLabel}' label`);
+
+    if (clean) {
+      const artifactDir = join(process.cwd(), `.auto-claude/issue-${issue.number}`);
+      try {
+        rmSync(artifactDir, { recursive: true, force: true });
+        consola.success(`  Cleaned artifacts: ${artifactDir}`);
+      } catch {
+        consola.warn(`  Could not clean artifacts: ${artifactDir}`);
+      }
+    }
+  }
+
+  return selected.length;
+}
+
+export default class AutoClaudeRetry extends BaseCommand {
+  static override description = "Retry failed auto-claude issues by swapping labels";
+
+  static override examples = [
+    {
+      description: "Interactively pick failed issues to retry",
+      command: "<%= config.bin %> auto-claude retry",
+    },
+    {
+      description: "Retry a specific issue",
+      command: "<%= config.bin %> auto-claude retry --issue 42",
+    },
+    {
+      description: "Retry and clean local artifacts",
+      command: "<%= config.bin %> auto-claude retry --issue 42 --clean",
+    },
+  ];
+
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    issue: Flags.integer({
+      char: "i",
+      description: "Issue number to retry",
+    }),
+    clean: Flags.boolean({
+      description: "Delete local .auto-claude/issue-{N}/ artifacts",
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(AutoClaudeRetry);
+
+    const cfg = await initConfig();
+
+    const cliInstalled = await isGithubCliInstalled();
+    if (!cliInstalled) {
+      this.error("GitHub CLI (gh) is not installed");
+    }
+
+    const failedIssues = await getIssues({ cwd: process.cwd(), label: LABELS.failed });
+
+    let selected: Issue[];
+
+    if (flags.issue) {
+      const match = failedIssues.find((i) => i.number === flags.issue);
+      if (!match) {
+        this.error(`Issue #${flags.issue} not found with '${LABELS.failed}' label`);
+      }
+      selected = [match];
+    } else {
+      if (failedIssues.length === 0) {
+        consola.info(`No open issues with '${LABELS.failed}' label`);
+        return;
+      }
+
+      consola.info(colors.yellow(`${failedIssues.length} failed issue(s) found`));
+
+      const choices = failedIssues.map((issue) => ({
+        title: `#${issue.number} ${issue.title}`,
+        value: issue.number,
+      }));
+
+      const result = await prompts(
+        {
+          name: "selected",
+          message: "Select issues to retry:",
+          type: "multiselect",
+          choices,
+          instructions: false,
+          hint: "- Space to select, Enter to confirm",
+        },
+        {
+          onCancel: () => {
+            consola.info(colors.dim("Canceled"));
+            this.exit(0);
+          },
+        },
+      );
+
+      if (!result.selected || result.selected.length === 0) {
+        consola.info(colors.dim("No issues selected"));
+        return;
+      }
+
+      selected = failedIssues.filter((i) => result.selected.includes(i.number));
+    }
+
+    const count = await retryIssues(cfg.repo, cfg.triggerLabel, failedIssues, selected, flags.clean);
+    consola.box(`Retried ${count} issue(s)`);
+  }
+}

--- a/src/commands/auto-claude/retry.ts
+++ b/src/commands/auto-claude/retry.ts
@@ -12,11 +12,6 @@ import { LABELS, removeLabel, setLabel } from "../../lib/auto-claude/utils.js";
 import { getIssues, isGithubCliInstalled } from "../../utils/git/gh-cli-wrapper.js";
 import type { Issue } from "../../utils/git/gh-cli-wrapper.js";
 
-export interface RetryOptions {
-  issueNumber?: number;
-  clean: boolean;
-}
-
 /**
  * Core retry logic: swap labels on failed issues to re-trigger the pipeline.
  * Extracted for testability.
@@ -24,7 +19,6 @@ export interface RetryOptions {
 export async function retryIssues(
   repo: string,
   triggerLabel: string,
-  failedIssues: Issue[],
   selected: Issue[],
   clean: boolean,
 ): Promise<number> {
@@ -139,7 +133,7 @@ export default class AutoClaudeRetry extends BaseCommand {
       selected = failedIssues.filter((i) => result.selected.includes(i.number));
     }
 
-    const count = await retryIssues(cfg.repo, cfg.triggerLabel, failedIssues, selected, flags.clean);
+    const count = await retryIssues(cfg.repo, cfg.triggerLabel, selected, flags.clean);
     consola.box(`Retried ${count} issue(s)`);
   }
 }


### PR DESCRIPTION
## Summary

- New `tt auto-claude retry` / `tt ac retry` subcommand
- Retries failed auto-claude issues by swapping `auto-claude-failed` → `auto-claude` label
- `--issue` / `-i` flag to target specific issue, or interactive multi-select
- `--clean` flag to delete local artifacts before retry

## Test plan

- [x] 5 new tests (label swap, multi-issue, empty selection, clean flag, no-clean)
- [x] 130 total tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)