### PR TITLE
feat: 85 new tests + CLI output visibility improvements

### DIFF
--- a/src/commands/auto-claude/index.ts
+++ b/src/commands/auto-claude/index.ts
@@ -137,6 +137,7 @@ export default class AutoClaude extends BaseCommand {
         throw e;
       }
 
+      log("Fetching labeled issues…");
       let contexts: IssueContext[];
       if (flags.issue) {
         const ctx = await fetchIssue(flags.issue);
@@ -151,10 +152,14 @@ export default class AutoClaude extends BaseCommand {
         log(`Processing ${contexts.length} issue(s)...\n`);
 
         for (const ctx of contexts) {
+          const issueStart = Date.now();
           try {
             await runPipeline(ctx, untilStep);
           } catch (e) {
             consola.error(`Pipeline error for ${ctx.repo}#${ctx.number}:`, e);
+          } finally {
+            const elapsed = ((Date.now() - issueStart) / 1000).toFixed(1);
+            log(`Completed ${ctx.repo}#${ctx.number} in ${elapsed}s`);
           }
         }
       }

--- a/src/commands/graph/analyzer.test.ts
+++ b/src/commands/graph/analyzer.test.ts
@@ -1,0 +1,454 @@
+import { describe, expect, it } from "vitest";
+import type { ContentBlock, JournalEntry } from "./types";
+import {
+  aggregateSessionTools,
+  analyzeSession,
+  extractProjectName,
+  extractSessionLabel,
+  extractToolData,
+  extractToolDetail,
+  getModelName,
+  getPrimaryModel,
+  sanitizeString,
+  truncateDetail,
+} from "./analyzer";
+
+// ── Helpers ──
+
+function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
+  return {
+    type: "assistant",
+    sessionId: "test-session",
+    timestamp: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeAssistantEntry(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  content?: ContentBlock[],
+  extra?: Partial<JournalEntry["message"]>,
+): JournalEntry {
+  return makeEntry({
+    type: "assistant",
+    message: {
+      role: "assistant",
+      model,
+      usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+      content: content ?? [{ type: "text", text: "response" }],
+      ...extra,
+    },
+  });
+}
+
+// ── analyzeSession ──
+
+describe("analyzeSession", () => {
+  it("returns zeros for empty entries", () => {
+    const result = analyzeSession([]);
+    expect(result.inputTokens).toBe(0);
+    expect(result.outputTokens).toBe(0);
+    expect(result.opusTokens).toBe(0);
+    expect(result.sonnetTokens).toBe(0);
+    expect(result.haikuTokens).toBe(0);
+    expect(result.cacheHitRate).toBe(0);
+    expect(result.repeatedReads).toBe(0);
+    expect(result.modelEfficiency).toBe(0);
+  });
+
+  it("counts tokens by model", () => {
+    const entries = [
+      makeAssistantEntry("claude-opus-4", 100, 50),
+      makeAssistantEntry("claude-sonnet-4", 200, 100),
+      makeAssistantEntry("claude-haiku-3", 50, 25),
+    ];
+    const result = analyzeSession(entries);
+    expect(result.inputTokens).toBe(350);
+    expect(result.outputTokens).toBe(175);
+    expect(result.opusTokens).toBe(150);
+    expect(result.sonnetTokens).toBe(300);
+    expect(result.haikuTokens).toBe(75);
+  });
+
+  it("calculates cache hit rate", () => {
+    const entries = [
+      makeEntry({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4",
+          usage: { input_tokens: 1000, output_tokens: 0, cache_read_input_tokens: 800 },
+          content: [{ type: "text", text: "hi" }],
+        },
+      }),
+    ];
+    const result = analyzeSession(entries);
+    expect(result.cacheHitRate).toBe(0.8);
+  });
+
+  it("counts repeated file reads", () => {
+    const content: ContentBlock[] = [
+      { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
+      { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
+      { type: "tool_use", name: "Read", input: { file_path: "/b.ts" } },
+    ];
+    const entries = [makeAssistantEntry("claude-opus-4", 100, 50, content)];
+    const result = analyzeSession(entries);
+    expect(result.repeatedReads).toBe(1); // /a.ts read twice => 1 repeated
+  });
+
+  it("calculates model efficiency as opus fraction", () => {
+    const entries = [
+      makeAssistantEntry("claude-opus-4", 400, 100), // 500 opus
+      makeAssistantEntry("claude-sonnet-4", 400, 100), // 500 sonnet
+    ];
+    const result = analyzeSession(entries);
+    expect(result.modelEfficiency).toBe(0.5);
+  });
+
+  it("skips entries without usage", () => {
+    const entries = [makeEntry({ message: { role: "assistant", content: "text" } })];
+    const result = analyzeSession(entries);
+    expect(result.inputTokens).toBe(0);
+  });
+});
+
+// ── extractSessionLabel ──
+
+describe("extractSessionLabel", () => {
+  it("uses first user text message", () => {
+    const entries = [
+      makeEntry({
+        type: "user",
+        message: { role: "user", content: "Fix the bug in parser" },
+      }),
+    ];
+    expect(extractSessionLabel(entries, "abc12345")).toBe("Fix the bug in parser");
+  });
+
+  it("skips UUID-only user messages", () => {
+    const entries = [
+      makeEntry({
+        type: "user",
+        message: { role: "user", content: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" },
+      }),
+      makeEntry({
+        type: "user",
+        message: { role: "user", content: "Real message" },
+      }),
+    ];
+    expect(extractSessionLabel(entries, "abc12345")).toBe("Real message");
+  });
+
+  it("extracts text from array content blocks", () => {
+    const entries = [
+      makeEntry({
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Array content message" }],
+        },
+      }),
+    ];
+    expect(extractSessionLabel(entries, "abc12345")).toBe("Array content message");
+  });
+
+  it("falls back to assistant text", () => {
+    const entries = [
+      makeEntry({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "I'll help you with that" }],
+        },
+      }),
+    ];
+    expect(extractSessionLabel(entries, "abc12345")).toBe("I'll help you with that");
+  });
+
+  it("falls back to gitBranch", () => {
+    const entries = [makeEntry({ type: "user" }) as any];
+    (entries[0] as any).gitBranch = "feat/new-feature";
+    expect(extractSessionLabel(entries, "abc12345")).toBe("feat/new-feature");
+  });
+
+  it("falls back to short session ID", () => {
+    expect(extractSessionLabel([], "abc12345-long-id")).toBe("abc12345");
+  });
+
+  it("removes /command prefixes", () => {
+    const entries = [
+      makeEntry({
+        type: "user",
+        message: { role: "user", content: "/review Fix the parser" },
+      }),
+    ];
+    expect(extractSessionLabel(entries, "abc12345")).toBe("Fix the parser");
+  });
+
+  it("removes XML tags", () => {
+    const entries = [
+      makeEntry({
+        type: "user",
+        message: { role: "user", content: "<tag>content</tag> Real text" },
+      }),
+    ];
+    expect(extractSessionLabel(entries, "abc12345")).toBe("Real text");
+  });
+
+  it("truncates labels longer than 80 chars", () => {
+    const longText = "A".repeat(100);
+    const entries = [
+      makeEntry({
+        type: "user",
+        message: { role: "user", content: longText },
+      }),
+    ];
+    const label = extractSessionLabel(entries, "abc12345");
+    expect(label.length).toBe(80);
+    expect(label.endsWith("...")).toBe(true);
+  });
+
+  it("uses slug fallback for short labels after cleanup", () => {
+    const entries = [makeEntry() as any];
+    (entries[0] as any).slug = "my-slug";
+    expect(extractSessionLabel(entries, "abc12345")).toBe("my-slug");
+  });
+});
+
+// ── sanitizeString ──
+
+describe("sanitizeString", () => {
+  it("replaces control characters with space", () => {
+    expect(sanitizeString("hello\nworld\ttab")).toBe("hello world tab");
+  });
+
+  it("trims result", () => {
+    expect(sanitizeString("  hello  ")).toBe("hello");
+  });
+
+  it("collapses multiple control chars", () => {
+    expect(sanitizeString("a\n\n\nb")).toBe("a b");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeString("")).toBe("");
+  });
+});
+
+// ── truncateDetail ──
+
+describe("truncateDetail", () => {
+  it("returns undefined for undefined input", () => {
+    expect(truncateDetail(undefined)).toBeUndefined();
+  });
+
+  it("returns short strings unchanged", () => {
+    expect(truncateDetail("hello")).toBe("hello");
+  });
+
+  it("truncates long strings with ellipsis", () => {
+    const long = "A".repeat(40);
+    const result = truncateDetail(long, 30);
+    expect(result?.length).toBe(30);
+    expect(result?.endsWith("...")).toBe(true);
+  });
+
+  it("extracts filename from paths", () => {
+    expect(truncateDetail("/home/user/project/file.ts")).toBe("file.ts");
+  });
+
+  it("truncates long filenames", () => {
+    const longFile = "/path/" + "A".repeat(40) + ".ts";
+    const result = truncateDetail(longFile, 30);
+    expect(result?.length).toBe(30);
+    expect(result?.endsWith("...")).toBe(true);
+  });
+});
+
+// ── extractToolDetail ──
+
+describe("extractToolDetail", () => {
+  it("returns undefined when no input", () => {
+    expect(extractToolDetail("Read")).toBeUndefined();
+  });
+
+  it("extracts file_path for Read", () => {
+    expect(extractToolDetail("Read", { file_path: "/src/index.ts" })).toBe("index.ts");
+  });
+
+  it("extracts file_path for Write", () => {
+    expect(extractToolDetail("Write", { file_path: "/src/utils.ts" })).toBe("utils.ts");
+  });
+
+  it("extracts file_path for Edit", () => {
+    expect(extractToolDetail("Edit", { file_path: "/src/edit.ts" })).toBe("edit.ts");
+  });
+
+  it("extracts command for Bash", () => {
+    expect(extractToolDetail("Bash", { command: "pnpm test" })).toBe("pnpm test");
+  });
+
+  it("extracts pattern for Glob", () => {
+    // Pattern contains "/" so truncateDetail extracts the last segment
+    expect(extractToolDetail("Glob", { pattern: "**/*.ts" })).toBe("*.ts");
+  });
+
+  it("extracts pattern for Grep", () => {
+    expect(extractToolDetail("Grep", { pattern: "TODO" })).toBe("TODO");
+  });
+
+  it("returns undefined for unknown tools", () => {
+    expect(extractToolDetail("CustomTool", { foo: "bar" })).toBeUndefined();
+  });
+});
+
+// ── extractToolData ──
+
+describe("extractToolData", () => {
+  it("returns empty for undefined content", () => {
+    expect(extractToolData(undefined, 100, 50)).toEqual([]);
+  });
+
+  it("returns empty for string content", () => {
+    expect(extractToolData("text", 100, 50)).toEqual([]);
+  });
+
+  it("returns empty when no tool_use blocks", () => {
+    const content: ContentBlock[] = [{ type: "text", text: "hello" }];
+    expect(extractToolData(content, 100, 50)).toEqual([]);
+  });
+
+  it("extracts tool calls and distributes tokens", () => {
+    const content: ContentBlock[] = [
+      { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
+      { type: "tool_use", name: "Bash", input: { command: "ls" } },
+    ];
+    const result = extractToolData(content, 200, 100);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Read");
+    expect(result[0].inputTokens).toBe(100);
+    expect(result[0].outputTokens).toBe(50);
+    expect(result[1].name).toBe("Bash");
+    expect(result[1].inputTokens).toBe(100);
+  });
+});
+
+// ── aggregateSessionTools ──
+
+describe("aggregateSessionTools", () => {
+  it("returns empty for no entries", () => {
+    expect(aggregateSessionTools([])).toEqual([]);
+  });
+
+  it("aggregates tools across entries", () => {
+    const entries = [
+      makeAssistantEntry("claude-opus-4", 100, 50, [
+        { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
+      ]),
+      makeAssistantEntry("claude-opus-4", 200, 100, [
+        { type: "tool_use", name: "Read", input: { file_path: "/b.ts" } },
+        { type: "tool_use", name: "Bash", input: { command: "ls" } },
+      ]),
+    ];
+    const result = aggregateSessionTools(entries);
+    const readTool = result.find((t) => t.name === "Read");
+    expect(readTool).toBeDefined();
+    expect(readTool?.detail).toBe("2x");
+  });
+
+  it("sorts by total token usage descending", () => {
+    const entries = [
+      makeAssistantEntry("claude-opus-4", 100, 50, [
+        { type: "tool_use", name: "Bash", input: { command: "ls" } },
+      ]),
+      makeAssistantEntry("claude-opus-4", 1000, 500, [
+        { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
+      ]),
+    ];
+    const result = aggregateSessionTools(entries);
+    expect(result[0].name).toBe("Read");
+  });
+});
+
+// ── getPrimaryModel ──
+
+describe("getPrimaryModel", () => {
+  it("returns Opus when opus has most tokens", () => {
+    expect(getPrimaryModel({ opusTokens: 100, sonnetTokens: 50, haikuTokens: 10 })).toBe("Opus");
+  });
+
+  it("returns Sonnet when sonnet dominates", () => {
+    expect(getPrimaryModel({ opusTokens: 10, sonnetTokens: 500, haikuTokens: 10 })).toBe("Sonnet");
+  });
+
+  it("returns Haiku when haiku dominates", () => {
+    expect(getPrimaryModel({ opusTokens: 0, sonnetTokens: 0, haikuTokens: 100 })).toBe("Haiku");
+  });
+
+  it("returns Opus on tie between opus and sonnet", () => {
+    expect(getPrimaryModel({ opusTokens: 100, sonnetTokens: 100, haikuTokens: 0 })).toBe("Opus");
+  });
+
+  it("returns Opus when all zero", () => {
+    expect(getPrimaryModel({ opusTokens: 0, sonnetTokens: 0, haikuTokens: 0 })).toBe("Opus");
+  });
+});
+
+// ── getModelName ──
+
+describe("getModelName", () => {
+  it("returns 'unknown' for undefined", () => {
+    expect(getModelName()).toBe("unknown");
+  });
+
+  it("returns Opus for opus models", () => {
+    expect(getModelName("claude-opus-4-20250514")).toBe("Opus");
+  });
+
+  it("returns Sonnet for sonnet models", () => {
+    expect(getModelName("claude-sonnet-4-20250514")).toBe("Sonnet");
+  });
+
+  it("returns Haiku for haiku models", () => {
+    expect(getModelName("claude-3-haiku")).toBe("Haiku");
+  });
+
+  it("returns first segment for unknown models", () => {
+    expect(getModelName("gpt-4-turbo")).toBe("gpt");
+  });
+
+  it("returns 'unknown' for empty string", () => {
+    expect(getModelName("")).toBe("unknown");
+  });
+});
+
+// ── extractProjectName ──
+
+describe("extractProjectName", () => {
+  it("extracts project name after path markers", () => {
+    expect(extractProjectName("-home-ctowles-code-p-towles-tool")).toBe("towles-tool");
+  });
+
+  it("handles 'projects' marker", () => {
+    expect(extractProjectName("-home-user-projects-my-app")).toBe("my-app");
+  });
+
+  it("handles 'src' marker", () => {
+    expect(extractProjectName("-home-user-src-cool-lib")).toBe("cool-lib");
+  });
+
+  it("uses last two parts when no marker found", () => {
+    expect(extractProjectName("-foo-bar-baz")).toBe("bar-baz");
+  });
+
+  it("handles single segment after marker", () => {
+    expect(extractProjectName("-home-user-code-myproject")).toBe("myproject");
+  });
+
+  it("uses last marker when multiple exist", () => {
+    expect(extractProjectName("-home-code-old-src-new-project")).toBe("new-project");
+  });
+});

--- a/src/commands/graph/parser.test.ts
+++ b/src/commands/graph/parser.test.ts
@@ -1,0 +1,150 @@
+import * as fs from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+
+import { calculateCutoffMs, filterByDays, parseJsonl, quickTokenCount } from "./parser";
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+}));
+
+const mockedReadFileSync = vi.mocked(fs.readFileSync);
+
+// ── Pure functions (no mocking needed) ──
+
+describe("calculateCutoffMs", () => {
+  it("returns 0 for days <= 0", () => {
+    expect(calculateCutoffMs(0)).toBe(0);
+    expect(calculateCutoffMs(-1)).toBe(0);
+  });
+
+  it("returns a timestamp in the past for positive days", () => {
+    const now = Date.now();
+    const cutoff = calculateCutoffMs(7);
+    const expectedApprox = now - 7 * 24 * 60 * 60 * 1000;
+    // Allow 100ms tolerance for execution time
+    expect(Math.abs(cutoff - expectedApprox)).toBeLessThan(100);
+  });
+
+  it("returns larger cutoff for more days", () => {
+    const cutoff7 = calculateCutoffMs(7);
+    const cutoff30 = calculateCutoffMs(30);
+    expect(cutoff30).toBeLessThan(cutoff7); // Further in the past
+  });
+});
+
+describe("filterByDays", () => {
+  const now = Date.now();
+  const items = [
+    { mtime: now - 1 * 24 * 60 * 60 * 1000, name: "1-day-ago" },
+    { mtime: now - 5 * 24 * 60 * 60 * 1000, name: "5-days-ago" },
+    { mtime: now - 10 * 24 * 60 * 60 * 1000, name: "10-days-ago" },
+    { mtime: now - 20 * 24 * 60 * 60 * 1000, name: "20-days-ago" },
+  ];
+
+  it("returns all items when days <= 0", () => {
+    expect(filterByDays(items, 0)).toEqual(items);
+    expect(filterByDays(items, -5)).toEqual(items);
+  });
+
+  it("filters items older than cutoff", () => {
+    const result = filterByDays(items, 7);
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => i.name)).toEqual(["1-day-ago", "5-days-ago"]);
+  });
+
+  it("returns empty array when all items are too old", () => {
+    const result = filterByDays(items, 0.001); // ~86ms
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns all items when cutoff is very large", () => {
+    const result = filterByDays(items, 365);
+    expect(result).toHaveLength(4);
+  });
+
+  it("handles empty array", () => {
+    expect(filterByDays([], 7)).toEqual([]);
+  });
+});
+
+// ── parseJsonl and quickTokenCount (require fs mock) ──
+
+describe("parseJsonl", () => {
+  it("parses valid JSONL lines", () => {
+    mockedReadFileSync.mockReturnValue(
+      '{"type":"user","sessionId":"s1","timestamp":"2025-01-01T00:00:00Z"}\n{"type":"assistant","sessionId":"s1","timestamp":"2025-01-01T00:01:00Z"}\n',
+    );
+    const entries = parseJsonl("/fake/path.jsonl");
+    expect(entries).toHaveLength(2);
+    expect(entries[0].type).toBe("user");
+    expect(entries[1].type).toBe("assistant");
+  });
+
+  it("skips empty lines", () => {
+    mockedReadFileSync.mockReturnValue(
+      '{"type":"user","sessionId":"s1","timestamp":"t"}\n\n\n{"type":"assistant","sessionId":"s1","timestamp":"t"}\n',
+    );
+    const entries = parseJsonl("/fake/path.jsonl");
+    expect(entries).toHaveLength(2);
+  });
+
+  it("skips invalid JSON lines", () => {
+    mockedReadFileSync.mockReturnValue(
+      '{"type":"user","sessionId":"s1","timestamp":"t"}\nnot-json\n{"type":"assistant","sessionId":"s1","timestamp":"t"}\n',
+    );
+    const entries = parseJsonl("/fake/path.jsonl");
+    expect(entries).toHaveLength(2);
+  });
+
+  it("returns empty array for empty file", () => {
+    mockedReadFileSync.mockReturnValue("");
+    const entries = parseJsonl("/fake/path.jsonl");
+    expect(entries).toHaveLength(0);
+  });
+});
+
+describe("quickTokenCount", () => {
+  it("sums input and output tokens from entries with usage", () => {
+    const lines = [
+      JSON.stringify({
+        message: { usage: { input_tokens: 100, output_tokens: 50 } },
+      }),
+      JSON.stringify({
+        message: { usage: { input_tokens: 200, output_tokens: 75 } },
+      }),
+    ].join("\n");
+    mockedReadFileSync.mockReturnValue(lines);
+    expect(quickTokenCount("/fake/path.jsonl")).toBe(425);
+  });
+
+  it("skips entries without usage", () => {
+    const lines = [
+      JSON.stringify({ message: { content: "text" } }),
+      JSON.stringify({ message: { usage: { input_tokens: 100, output_tokens: 50 } } }),
+    ].join("\n");
+    mockedReadFileSync.mockReturnValue(lines);
+    expect(quickTokenCount("/fake/path.jsonl")).toBe(150);
+  });
+
+  it("returns 0 for unreadable files", () => {
+    mockedReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(quickTokenCount("/missing/file.jsonl")).toBe(0);
+  });
+
+  it("handles entries with partial usage (only input_tokens)", () => {
+    const lines = JSON.stringify({
+      message: { usage: { input_tokens: 100 } },
+    });
+    mockedReadFileSync.mockReturnValue(lines);
+    expect(quickTokenCount("/fake/path.jsonl")).toBe(100);
+  });
+
+  it("skips invalid JSON lines gracefully", () => {
+    mockedReadFileSync.mockReturnValue(
+      '{"message":{"usage":{"input_tokens":50,"output_tokens":50}}}\nbadline\n',
+    );
+    expect(quickTokenCount("/fake/path.jsonl")).toBe(100);
+  });
+});

--- a/src/lib/auto-claude/claude-cli.ts
+++ b/src/lib/auto-claude/claude-cli.ts
@@ -37,11 +37,15 @@ export async function runClaude(opts: {
     `@${opts.promptFile}`,
   ];
 
+  consola.info(
+    `${pc.dim("▶")} Calling Claude${opts.maxTurns ? ` (max ${opts.maxTurns} turns)` : ""}…`,
+  );
+
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= PROCESS_RETRIES; attempt++) {
     try {
       const result = await runClaudeStreaming(args);
-      consola.success(`Done — ${result.num_turns} turns`);
+      consola.success(`Done — ${result.num_turns} turns, $${result.total_cost_usd.toFixed(4)}`);
       if (result.result) {
         consola.log(result.result);
       }

--- a/src/lib/auto-claude/labels.test.ts
+++ b/src/lib/auto-claude/labels.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { execSafe } from "../../utils/git/exec.js";
+import { ensureLabelsExist, LABELS, removeLabel, setLabel } from "./labels";
+
+vi.mock("../../utils/git/exec.js", () => ({
+  execSafe: vi.fn().mockResolvedValue({ stdout: "", ok: true }),
+}));
+
+const mockedExecSafe = vi.mocked(execSafe);
+
+describe("LABELS", () => {
+  it("has expected label values", () => {
+    expect(LABELS.inProgress).toBe("auto-claude-in-progress");
+    expect(LABELS.review).toBe("auto-claude-review");
+    expect(LABELS.failed).toBe("auto-claude-failed");
+    expect(LABELS.success).toBe("auto-claude-success");
+  });
+
+  it("has exactly 4 labels", () => {
+    expect(Object.keys(LABELS)).toHaveLength(4);
+  });
+});
+
+describe("ensureLabelsExist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates all labels with --force", async () => {
+    await ensureLabelsExist("owner/repo");
+
+    expect(mockedExecSafe).toHaveBeenCalledTimes(4);
+    for (const label of Object.values(LABELS)) {
+      expect(mockedExecSafe).toHaveBeenCalledWith("gh", [
+        "label",
+        "create",
+        label,
+        "--repo",
+        "owner/repo",
+        "--force",
+      ]);
+    }
+  });
+});
+
+describe("setLabel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls gh issue edit with --add-label", async () => {
+    await setLabel("owner/repo", 42, "auto-claude-in-progress");
+
+    expect(mockedExecSafe).toHaveBeenCalledWith("gh", [
+      "issue",
+      "edit",
+      "42",
+      "--repo",
+      "owner/repo",
+      "--add-label",
+      "auto-claude-in-progress",
+    ]);
+  });
+});
+
+describe("removeLabel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls gh issue edit with --remove-label", async () => {
+    await removeLabel("owner/repo", 42, "auto-claude-failed");
+
+    expect(mockedExecSafe).toHaveBeenCalledWith("gh", [
+      "issue",
+      "edit",
+      "42",
+      "--repo",
+      "owner/repo",
+      "--remove-label",
+      "auto-claude-failed",
+    ]);
+  });
+});

--- a/src/lib/auto-claude/steps/create-pr.ts
+++ b/src/lib/auto-claude/steps/create-pr.ts
@@ -82,6 +82,7 @@ async function attachArtifacts(ctx: IssueContext, prUrl: string): Promise<void> 
   const tag = `ac-issue-${ctx.number}`;
   const cfg = getConfig();
 
+  log("Archiving pipeline artifacts…");
   await execSafe("tar", [
     "czf",
     archivePath,
@@ -92,6 +93,7 @@ async function attachArtifacts(ctx: IssueContext, prUrl: string): Promise<void> 
     ".",
   ]);
 
+  log("Uploading artifacts to GitHub release…");
   await ghRaw(["release", "delete", tag, "--yes", "--repo", cfg.repo]);
 
   await ghRaw([

--- a/src/lib/auto-claude/templates.test.ts
+++ b/src/lib/auto-claude/templates.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { resolveTemplate } from "./templates";
+import type { TokenValues } from "./templates";
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+const mockedMkdirSync = vi.mocked(mkdirSync);
+
+describe("resolveTemplate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const tokens: TokenValues = {
+    SCOPE_PATH: "/home/user/project",
+    ISSUE_DIR: "/tmp/issues/42",
+    MAIN_BRANCH: "main",
+  };
+
+  it("replaces all token placeholders in template", () => {
+    mockedReadFileSync.mockReturnValue(
+      "Scope: {{SCOPE_PATH}}\nDir: {{ISSUE_DIR}}\nBranch: {{MAIN_BRANCH}}",
+    );
+
+    resolveTemplate("plan.md", tokens, "/tmp/issues/42");
+
+    const writtenContent = mockedWriteFileSync.mock.calls[0][1];
+    expect(writtenContent).toContain("/home/user/project");
+    expect(writtenContent).toContain("/tmp/issues/42");
+    expect(writtenContent).toContain("main");
+    expect(writtenContent).not.toContain("{{");
+  });
+
+  it("replaces REVIEW_FEEDBACK token when provided", () => {
+    const tokensWithFeedback: TokenValues = {
+      ...tokens,
+      REVIEW_FEEDBACK: "Needs more tests",
+    };
+    mockedReadFileSync.mockReturnValue("Feedback: {{REVIEW_FEEDBACK}}");
+
+    resolveTemplate("review.md", tokensWithFeedback, "/tmp/issues/42");
+
+    const writtenContent = mockedWriteFileSync.mock.calls[0][1];
+    expect(writtenContent).toContain("Needs more tests");
+  });
+
+  it("creates output directory recursively", () => {
+    mockedReadFileSync.mockReturnValue("template content");
+
+    resolveTemplate("plan.md", tokens, "/tmp/issues/42");
+
+    expect(mockedMkdirSync).toHaveBeenCalledWith("/tmp/issues/42", { recursive: true });
+  });
+
+  it("writes resolved template to issue dir", () => {
+    mockedReadFileSync.mockReturnValue("simple content");
+
+    resolveTemplate("plan.md", tokens, "/tmp/issues/42");
+
+    expect(mockedWriteFileSync).toHaveBeenCalledWith(
+      "/tmp/issues/42/plan.md",
+      "simple content",
+      "utf-8",
+    );
+  });
+
+  it("returns relative path from cwd", () => {
+    mockedReadFileSync.mockReturnValue("content");
+
+    const result = resolveTemplate("plan.md", tokens, "/tmp/issues/42");
+    // Should be a relative path (not starting with /)
+    expect(result).not.toMatch(/^\/tmp/);
+  });
+
+  it("handles multiple occurrences of the same token", () => {
+    mockedReadFileSync.mockReturnValue("{{MAIN_BRANCH}} and {{MAIN_BRANCH}} again");
+
+    resolveTemplate("plan.md", tokens, "/tmp/issues/42");
+
+    const writtenContent = mockedWriteFileSync.mock.calls[0][1];
+    expect(writtenContent).toBe("main and main again");
+  });
+});


### PR DESCRIPTION
## Summary
- Added 85 unit tests across 4 new test files (222 total, up from 137)
- Improved CLI visibility: startup messages, cost display, per-issue timing, artifact progress

## Test plan
- [x] All 222 vitest tests pass
- [x] Typecheck passes
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)