### PR TITLE
fix: skip npm publish if version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,13 @@ jobs:
           git push --tags --force
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          if npm view @towles/tool@$VERSION version 2>/dev/null; then
+            echo "Version $VERSION already published — skipping"
+          else
+            npm publish --access public --provenance
+          fi
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary
- Check npm registry before publishing to avoid "cannot publish over existing version" errors
- Makes the release workflow fully idempotent on reruns

## Test plan
- [ ] Merge and trigger release — should skip publish if version exists, succeed otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)