### PR TITLE
fix: agentboard safety guards, lifecycle improvements, and code cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ pnpm test               # Run vitest (222 tests, needs dev server running)
 pnpm build              # Build for production
 pnpm db:generate        # Generate Drizzle migration
 pnpm db:migrate         # Apply migrations
+
+# AgentBoard CLI
+tt ag                   # Start AgentBoard (localhost only)
+tt ag --lan             # Start with LAN access (0.0.0.0)
+tt ag reset             # Delete DB and start fresh
+tt ag attach <cardId>   # Attach to card's tmux session
 ```
 
 ## AgentBoard Plugin (`plugins/tt-agentboard/`)
@@ -52,6 +58,14 @@ pnpm db:migrate         # Apply migrations
 - **GitHub integration uses `gh` CLI** (not Octokit/GITHUB_TOKEN) — requires `gh auth login`
 - **Agent completion**: detected via Claude Code HTTP Stop hooks, not tmux polling
 - **Shared server utils**: `server/utils/params.ts` (getCardId, requireCard), `server/utils/hook-writer.ts`, `server/utils/workflow-helpers.ts`
+- **pnpm workspace**: root `pnpm install` installs for agentboard too (configured in `pnpm-workspace.yaml`)
+- **DB auto-migrates on startup** — no need to run `pnpm db:migrate` manually. `tt ag reset` to wipe DB.
+- **`gh` CLI gotcha**: `gh issue create` and `gh pr create` do NOT support `--json` flag — parse URL from stdout instead. `gh list` commands DO support `--json`.
+- **Agent executor flow**: checkout main → pull → clean working tree → create branch → install deps → write hooks → spawn claude in tmux
+- **Auto-commit safety net**: Stop hook auto-commits uncommitted changes after agent finishes. System prompt also tells agent to commit.
+- **`claude -p` needs `--max-turns 50`** — without it, print mode exits after 1 turn. Agent also needs `--append-system-prompt` telling it to work autonomously and commit.
+- **Card lifecycle hooks**: Stop → complete (review_ready), StopFailure → failure, Notification → waiting_input
+- **ttyd**: requires top-level ES module import (not `require()`), starts on port 7700+
 
 ## Guidelines
 

--- a/plugins/tt-agentboard/app/components/board/KanbanCard.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanCard.vue
@@ -12,14 +12,15 @@ const emit = defineEmits<{
   selected: [cardId: number];
 }>();
 
+const cardRef = computed(() => props.card);
+const { issueUrl, prUrl } = useCardUrls(cardRef);
+
 const borderClass = computed(
   () => STATUS_BORDER_CLASSES[props.card.status as CardStatus] ?? "border-zinc-700",
 );
 
 const elapsedTime = computed(() => {
   if (props.card.status === "idle") return null;
-  // Running cards: show time since last status change (updatedAt)
-  // Other non-idle cards: show time since creation
   const ref = props.card.status === "running" ? props.card.updatedAt : props.card.createdAt;
   const start = new Date(ref).getTime();
   const now = Date.now();
@@ -63,28 +64,6 @@ watch(
   },
   { immediate: true },
 );
-
-const prUrl = computed(() => {
-  if (!props.card.githubPrNumber) return null;
-  if (props.card.repo?.githubUrl) {
-    return `${props.card.repo.githubUrl}/pull/${props.card.githubPrNumber}`;
-  }
-  if (props.card.repo?.org && props.card.repo?.name) {
-    return `https://github.com/${props.card.repo.org}/${props.card.repo.name}/pull/${props.card.githubPrNumber}`;
-  }
-  return null;
-});
-
-const issueUrl = computed(() => {
-  if (!props.card.githubIssueNumber) return null;
-  if (props.card.repo?.githubUrl) {
-    return `${props.card.repo.githubUrl}/issues/${props.card.githubIssueNumber}`;
-  }
-  if (props.card.repo?.org && props.card.repo?.name) {
-    return `https://github.com/${props.card.repo.org}/${props.card.repo.name}/issues/${props.card.githubIssueNumber}`;
-  }
-  return null;
-});
 </script>
 
 <template>

--- a/plugins/tt-agentboard/app/components/card/CardDetail.vue
+++ b/plugins/tt-agentboard/app/components/card/CardDetail.vue
@@ -14,39 +14,8 @@ const emit = defineEmits<{
 }>();
 
 const agentInput = ref("");
-
-const branchUrl = computed(() => {
-  if (!props.card.branch) return null;
-  if (props.card.repo?.githubUrl) {
-    return `${props.card.repo.githubUrl}/tree/${props.card.branch}`;
-  }
-  if (props.card.repo?.org && props.card.repo?.name) {
-    return `https://github.com/${props.card.repo.org}/${props.card.repo.name}/tree/${props.card.branch}`;
-  }
-  return null;
-});
-
-const issueUrl = computed(() => {
-  if (!props.card.githubIssueNumber) return null;
-  if (props.card.repo?.githubUrl) {
-    return `${props.card.repo.githubUrl}/issues/${props.card.githubIssueNumber}`;
-  }
-  if (props.card.repo?.org && props.card.repo?.name) {
-    return `https://github.com/${props.card.repo.org}/${props.card.repo.name}/issues/${props.card.githubIssueNumber}`;
-  }
-  return null;
-});
-
-const prUrl = computed(() => {
-  if (!props.card.githubPrNumber) return null;
-  if (props.card.repo?.githubUrl) {
-    return `${props.card.repo.githubUrl}/pull/${props.card.githubPrNumber}`;
-  }
-  if (props.card.repo?.org && props.card.repo?.name) {
-    return `https://github.com/${props.card.repo.org}/${props.card.repo.name}/pull/${props.card.githubPrNumber}`;
-  }
-  return null;
-});
+const cardRef = computed(() => props.card);
+const { branchUrl, issueUrl, prUrl } = useCardUrls(cardRef);
 
 function sendResponse() {
   if (!agentInput.value.trim()) return;
@@ -80,12 +49,12 @@ function sendResponse() {
       {{ card.description }}
     </p>
 
-    <div v-if="card.repo && !compact" class="mb-4">
+    <div v-if="card.repo" class="mb-4">
       <SharedRepoBadge :name="card.repo.name" :org="card.repo.org" />
     </div>
 
     <div
-      v-if="(card.githubIssueNumber || card.githubPrNumber || card.branch) && !compact"
+      v-if="card.githubIssueNumber || card.githubPrNumber || card.branch"
       class="mb-4 space-y-1.5"
     >
       <!-- Branch -->

--- a/plugins/tt-agentboard/app/components/card/CardDetail.vue
+++ b/plugins/tt-agentboard/app/components/card/CardDetail.vue
@@ -49,12 +49,12 @@ function sendResponse() {
       {{ card.description }}
     </p>
 
-    <div v-if="card.repo" class="mb-4">
+    <div v-if="card.repo && !compact" class="mb-4">
       <SharedRepoBadge :name="card.repo.name" :org="card.repo.org" />
     </div>
 
     <div
-      v-if="card.githubIssueNumber || card.githubPrNumber || card.branch"
+      v-if="(card.githubIssueNumber || card.githubPrNumber || card.branch) && !compact"
       class="mb-4 space-y-1.5"
     >
       <!-- Branch -->

--- a/plugins/tt-agentboard/app/components/workspace/SlotCard.vue
+++ b/plugins/tt-agentboard/app/components/workspace/SlotCard.vue
@@ -75,16 +75,11 @@ async function resetToMain() {
   }
 }
 
-let pollTimer: ReturnType<typeof setInterval> | undefined;
-
 onMounted(() => {
   fetchGitInfo();
-  pollTimer = setInterval(fetchGitInfo, 10_000);
 });
 
-onUnmounted(() => {
-  if (pollTimer) clearInterval(pollTimer);
-});
+watch(() => props.slot.status, fetchGitInfo);
 </script>
 
 <template>

--- a/plugins/tt-agentboard/app/components/workspace/SlotCard.vue
+++ b/plugins/tt-agentboard/app/components/workspace/SlotCard.vue
@@ -10,6 +10,13 @@ export interface Slot {
   createdAt: string;
 }
 
+interface GitInfo {
+  branch: string | null;
+  ahead: number | null;
+  behind: number | null;
+  dirty: boolean | null;
+}
+
 const props = defineProps<{
   slot: Slot;
   repoName?: string;
@@ -18,6 +25,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   lock: [slotId: number, locked: boolean];
   remove: [slotId: number];
+  refresh: [];
 }>();
 
 const statusColors: Record<string, string> = {
@@ -26,6 +34,10 @@ const statusColors: Record<string, string> = {
   locked: "text-amber-400 bg-amber-500/10 border-amber-500/30",
 };
 
+const gitInfo = ref<GitInfo | null>(null);
+const resetting = ref(false);
+const releasing = ref(false);
+
 const parsedPorts = computed(() => {
   if (!props.slot.portConfig) return null;
   try {
@@ -33,6 +45,45 @@ const parsedPorts = computed(() => {
   } catch {
     return null;
   }
+});
+
+async function fetchGitInfo() {
+  try {
+    gitInfo.value = await $fetch<GitInfo>(`/api/slots/${props.slot.id}/git-info`);
+  } catch {
+    gitInfo.value = null;
+  }
+}
+
+async function releaseSlot() {
+  releasing.value = true;
+  try {
+    await $fetch(`/api/slots/${props.slot.id}/release`, { method: "POST" });
+    emit("refresh");
+  } finally {
+    releasing.value = false;
+  }
+}
+
+async function resetToMain() {
+  resetting.value = true;
+  try {
+    await $fetch(`/api/slots/${props.slot.id}/reset`, { method: "POST" });
+    await fetchGitInfo();
+  } finally {
+    resetting.value = false;
+  }
+}
+
+let pollTimer: ReturnType<typeof setInterval> | undefined;
+
+onMounted(() => {
+  fetchGitInfo();
+  pollTimer = setInterval(fetchGitInfo, 10_000);
+});
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer);
 });
 </script>
 
@@ -55,6 +106,34 @@ const parsedPorts = computed(() => {
           </span>
         </div>
         <p class="mt-1 font-mono text-xs text-zinc-500 break-all">{{ slot.path }}</p>
+
+        <!-- Git info -->
+        <div v-if="gitInfo" class="mt-1 flex flex-wrap items-center gap-2">
+          <span
+            v-if="gitInfo.branch"
+            class="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] font-mono text-zinc-400"
+          >
+            {{ gitInfo.branch }}
+          </span>
+          <span
+            v-if="gitInfo.ahead !== null && gitInfo.ahead > 0"
+            class="rounded bg-emerald-500/10 px-1 py-0.5 text-[10px] font-mono text-emerald-400"
+          >
+            ↑{{ gitInfo.ahead }}
+          </span>
+          <span
+            v-if="gitInfo.behind !== null && gitInfo.behind > 0"
+            class="rounded bg-amber-500/10 px-1 py-0.5 text-[10px] font-mono text-amber-400"
+          >
+            ↓{{ gitInfo.behind }}
+          </span>
+          <span
+            v-if="gitInfo.dirty"
+            class="rounded bg-red-500/10 px-1 py-0.5 text-[10px] font-mono text-red-400"
+          >
+            dirty
+          </span>
+        </div>
       </div>
     </div>
 
@@ -92,6 +171,22 @@ const parsedPorts = computed(() => {
         @click="emit('lock', slot.id, false)"
       >
         Unlock
+      </button>
+      <button
+        v-if="slot.status === 'claimed'"
+        :disabled="releasing"
+        class="rounded border border-orange-500/30 bg-orange-500/10 px-2 py-1 text-[11px] font-medium text-orange-400 transition-colors hover:bg-orange-500/20 disabled:opacity-40"
+        @click="releaseSlot"
+      >
+        {{ releasing ? "Freeing..." : "Free" }}
+      </button>
+      <button
+        v-if="slot.status === 'available' || slot.status === 'locked'"
+        :disabled="resetting"
+        class="rounded border border-cyan-500/30 bg-cyan-500/10 px-2 py-1 text-[11px] font-medium text-cyan-400 transition-colors hover:bg-cyan-500/20 disabled:opacity-40"
+        @click="resetToMain"
+      >
+        {{ resetting ? "Resetting..." : "Reset to Main" }}
       </button>
       <button
         v-if="slot.status !== 'claimed'"

--- a/plugins/tt-agentboard/app/components/workspace/SlotRegistry.vue
+++ b/plugins/tt-agentboard/app/components/workspace/SlotRegistry.vue
@@ -268,6 +268,7 @@ onMounted(fetchData);
         :repo-name="repoName(s.repoId)"
         @lock="toggleLock"
         @remove="removeSlot"
+        @refresh="fetchData"
       />
     </div>
 

--- a/plugins/tt-agentboard/app/composables/useCardUrls.ts
+++ b/plugins/tt-agentboard/app/composables/useCardUrls.ts
@@ -1,0 +1,31 @@
+import type { Card } from "~/composables/useCards";
+
+export function useCardUrls(card: Ref<Card> | ComputedRef<Card>) {
+  function buildGithubUrl(path: string) {
+    const c = toValue(card);
+    if (c.repo?.githubUrl) return `${c.repo.githubUrl}/${path}`;
+    if (c.repo?.org && c.repo?.name)
+      return `https://github.com/${c.repo.org}/${c.repo.name}/${path}`;
+    return null;
+  }
+
+  const branchUrl = computed(() => {
+    const c = toValue(card);
+    if (!c.branch) return null;
+    return buildGithubUrl(`tree/${c.branch}`);
+  });
+
+  const issueUrl = computed(() => {
+    const c = toValue(card);
+    if (!c.githubIssueNumber) return null;
+    return buildGithubUrl(`issues/${c.githubIssueNumber}`);
+  });
+
+  const prUrl = computed(() => {
+    const c = toValue(card);
+    if (!c.githubPrNumber) return null;
+    return buildGithubUrl(`pull/${c.githubPrNumber}`);
+  });
+
+  return { branchUrl, issueUrl, prUrl };
+}

--- a/plugins/tt-agentboard/docs/system-flow.md
+++ b/plugins/tt-agentboard/docs/system-flow.md
@@ -4,14 +4,14 @@ AgentBoard is a Nuxt 4 app that manages autonomous Claude Code agents via a Kanb
 
 ## Core Concepts
 
-| Concept | Description |
-|---------|-------------|
-| **Board** | Kanban board with columns: backlog, ready, in_progress, review, done |
-| **Card** | A task with title, description, repo, status, optional workflow and GitHub issue link |
-| **Repository** | A registered Git repo (org, name, default branch, GitHub URL) |
-| **Workspace Slot** | A directory (git worktree) tied to a repo. Each running agent needs one slot. |
-| **Workflow** | Multi-step YAML pipeline loaded from `.agentboard/workflows/*.yaml` in a repo |
-| **Plan** | Groups cards with shared PR granularity (per_card or per_plan) |
+| Concept            | Description                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| **Board**          | Kanban board with columns: backlog, ready, in_progress, review, done                  |
+| **Card**           | A task with title, description, repo, status, optional workflow and GitHub issue link |
+| **Repository**     | A registered Git repo (org, name, default branch, GitHub URL)                         |
+| **Workspace Slot** | A directory (git worktree) tied to a repo. Each running agent needs one slot.         |
+| **Workflow**       | Multi-step YAML pipeline loaded from `.agentboard/workflows/*.yaml` in a repo         |
+| **Plan**           | Groups cards with shared PR granularity (per_card or per_plan)                        |
 
 ## Card Lifecycle
 
@@ -40,13 +40,13 @@ stateDiagram-v2
 
 **Column/status mapping:**
 
-| Column | Statuses |
-|--------|----------|
-| backlog | idle, blocked |
-| ready | idle, queued |
+| Column      | Statuses               |
+| ----------- | ---------------------- |
+| backlog     | idle, blocked          |
+| ready       | idle, queued           |
 | in_progress | running, waiting_input |
-| review | review_ready |
-| done | done |
+| review      | review_ready           |
+| done        | done                   |
 
 ## Agent Execution Flow
 
@@ -100,19 +100,31 @@ Card moved to in_progress
 
 ### Hook Callback Endpoints
 
-| Endpoint | Hook | Effect |
-|----------|------|--------|
-| `POST /api/agents/{cardId}/complete` | Stop | Auto-commit uncommitted changes, kill tmux, release slot, move card to review |
-| `POST /api/agents/{cardId}/step-complete` | Stop (workflow) | Resolves pending step promise so workflow-runner proceeds to next step |
-| `POST /api/agents/{cardId}/notification` | Notification | Set card status to waiting_input |
+| Endpoint                                  | Hook            | Effect                                                                        |
+| ----------------------------------------- | --------------- | ----------------------------------------------------------------------------- |
+| `POST /api/agents/{cardId}/complete`      | Stop            | Auto-commit uncommitted changes, kill tmux, release slot, move card to review |
+| `POST /api/agents/{cardId}/step-complete` | Stop (workflow) | Resolves pending step promise so workflow-runner proceeds to next step        |
+| `POST /api/agents/{cardId}/notification`  | Notification    | Set card status to waiting_input                                              |
 
 The hooks are written to `.claude/settings.local.json` in the slot directory:
 
 ```json
 {
   "hooks": {
-    "Stop": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://localhost:4200/api/agents/{cardId}/complete" }] }],
-    "Notification": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://localhost:4200/api/agents/{cardId}/notification" }] }]
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [{ "type": "http", "url": "http://localhost:4200/api/agents/{cardId}/complete" }]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "http", "url": "http://localhost:4200/api/agents/{cardId}/notification" }
+        ]
+      }
+    ]
   }
 }
 ```
@@ -131,11 +143,13 @@ graph LR
 **Slot statuses:** available | claimed | locked
 
 **Lifecycle:**
+
 1. **Claim** (`slot-allocator.claimSlot`): finds first available slot for the repo, sets status=claimed, claimedByCardId=cardId
 2. **Use**: agent runs in the slot directory (git ops, claude CLI)
 3. **Release** (`slot-allocator.releaseSlot`): sets status=available, claimedByCardId=null, emits `slot:released`
 
 **Concurrency control:**
+
 - `MAX_CONCURRENT_AGENTS` (env var, default 3) limits total running agents
 - Each repo can run as many agents as it has available slots
 - When no slot is available, the card is set to `queued` in the `ready` column
@@ -177,6 +191,7 @@ graph TB
 **Server side:** All services emit events on the shared `eventBus` (Node EventEmitter). The WebSocket handler (`server/routes/ws.ts`) forwards every event to connected clients.
 
 **Event types:**
+
 - `card:moved` -- column change
 - `card:status-changed` -- status change
 - `step:started/completed/failed` -- workflow step progress
@@ -192,28 +207,28 @@ graph TB
 
 ## Key Services
 
-| Service | File | Purpose |
-|---------|------|---------|
-| **tmux-manager** | `services/tmux-manager.ts` | Create/kill tmux sessions, send commands, poll terminal output via capture-pane |
-| **agent-executor** | `services/agent-executor.ts` | Single-prompt execution: slot claim, branch setup, deps install, spawn claude CLI |
-| **workflow-runner** | `services/workflow-runner.ts` | Multi-step pipeline: iterate steps, wait for callbacks, check artifacts/pass conditions, retry |
-| **workflow-loader** | `services/workflow-loader.ts` | Load YAML workflow definitions from `.agentboard/workflows/`, watch for changes with chokidar |
-| **context-bundler** | `services/context-bundler.ts` | Build step prompts: template vars, previous artifacts, dependency diffs, CLAUDE.md |
-| **slot-allocator** | `services/slot-allocator.ts` | Claim/release workspace slots per repo |
-| **dependency-resolver** | `services/dependency-resolver.ts` | Track card dependencies (dependsOn field), unblock cards when deps complete |
-| **github-service** | `services/github-service.ts` | GitHub operations via `gh` CLI: list issues, create PRs, manage labels, poll for trigger labels |
-| **ttyd-manager** | `services/ttyd-manager.ts` | Spawn ttyd processes to expose tmux sessions as web terminals (port 7700+) |
+| Service                 | File                              | Purpose                                                                                         |
+| ----------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **tmux-manager**        | `services/tmux-manager.ts`        | Create/kill tmux sessions, send commands, poll terminal output via capture-pane                 |
+| **agent-executor**      | `services/agent-executor.ts`      | Single-prompt execution: slot claim, branch setup, deps install, spawn claude CLI               |
+| **workflow-runner**     | `services/workflow-runner.ts`     | Multi-step pipeline: iterate steps, wait for callbacks, check artifacts/pass conditions, retry  |
+| **workflow-loader**     | `services/workflow-loader.ts`     | Load YAML workflow definitions from `.agentboard/workflows/`, watch for changes with chokidar   |
+| **context-bundler**     | `services/context-bundler.ts`     | Build step prompts: template vars, previous artifacts, dependency diffs, CLAUDE.md              |
+| **slot-allocator**      | `services/slot-allocator.ts`      | Claim/release workspace slots per repo                                                          |
+| **dependency-resolver** | `services/dependency-resolver.ts` | Track card dependencies (dependsOn field), unblock cards when deps complete                     |
+| **github-service**      | `services/github-service.ts`      | GitHub operations via `gh` CLI: list issues, create PRs, manage labels, poll for trigger labels |
+| **ttyd-manager**        | `services/ttyd-manager.ts`        | Spawn ttyd processes to expose tmux sessions as web terminals (port 7700+)                      |
 
 ## Nitro Plugins (Startup)
 
-| Plugin | File | Purpose |
-|--------|------|---------|
-| **seed** | `plugins/seed.ts` | Ensure default board exists |
-| **session-reconnect** | `plugins/session-reconnect.ts` | On startup: reconcile running cards with live tmux sessions, kill orphans, resume captures |
-| **queue-manager** | `plugins/queue-manager.ts` | Auto-start queued/ready cards when slots become available |
-| **dependency-watcher** | `plugins/dependency-watcher.ts` | When a card completes, unblock dependent cards and move them to ready |
-| **github-poll** | `plugins/github-poll.ts` | Poll GitHub issues with trigger labels, auto-create cards |
-| **github-label-sync** | `plugins/github-label-sync.ts` | Sync card status to GitHub issue labels (in_progress/success/failure) |
+| Plugin                 | File                            | Purpose                                                                                    |
+| ---------------------- | ------------------------------- | ------------------------------------------------------------------------------------------ |
+| **seed**               | `plugins/seed.ts`               | Ensure default board exists                                                                |
+| **session-reconnect**  | `plugins/session-reconnect.ts`  | On startup: reconcile running cards with live tmux sessions, kill orphans, resume captures |
+| **queue-manager**      | `plugins/queue-manager.ts`      | Auto-start queued/ready cards when slots become available                                  |
+| **dependency-watcher** | `plugins/dependency-watcher.ts` | When a card completes, unblock dependent cards and move them to ready                      |
+| **github-poll**        | `plugins/github-poll.ts`        | Poll GitHub issues with trigger labels, auto-create cards                                  |
+| **github-label-sync**  | `plugins/github-label-sync.ts`  | Sync card status to GitHub issue labels (in_progress/success/failure)                      |
 
 ## Database Schema
 

--- a/plugins/tt-agentboard/docs/system-flow.md
+++ b/plugins/tt-agentboard/docs/system-flow.md
@@ -1,0 +1,230 @@
+# AgentBoard System Flow
+
+AgentBoard is a Nuxt 4 app that manages autonomous Claude Code agents via a Kanban board UI. Cards represent tasks; each card can be assigned to a repo, given a prompt, and executed by spawning Claude Code in a tmux session. Completion is detected via Claude Code HTTP lifecycle hooks, not polling.
+
+## Core Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Board** | Kanban board with columns: backlog, ready, in_progress, review, done |
+| **Card** | A task with title, description, repo, status, optional workflow and GitHub issue link |
+| **Repository** | A registered Git repo (org, name, default branch, GitHub URL) |
+| **Workspace Slot** | A directory (git worktree) tied to a repo. Each running agent needs one slot. |
+| **Workflow** | Multi-step YAML pipeline loaded from `.agentboard/workflows/*.yaml` in a repo |
+| **Plan** | Groups cards with shared PR granularity (per_card or per_plan) |
+
+## Card Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> backlog_idle: Card created
+    backlog_idle --> ready_idle: Moved to ready (manual or dependency resolved)
+    backlog_idle --> blocked: Has unmet dependsOn
+    blocked --> ready_idle: All dependencies done
+
+    ready_idle --> ready_queued: No slot available
+    ready_idle --> in_progress_running: Slot claimed, agent starts
+
+    ready_queued --> in_progress_running: Slot released, queue picks it up
+
+    in_progress_running --> review_ready: Stop hook fires (success)
+    in_progress_running --> waiting_input: Notification hook fires
+    in_progress_running --> failed: StopFailure / timeout / error
+
+    waiting_input --> in_progress_running: User responds
+    waiting_input --> review_ready: Stop hook fires
+
+    review_ready --> done: Archived by user
+    failed --> in_progress_running: Rerun triggered
+```
+
+**Column/status mapping:**
+
+| Column | Statuses |
+|--------|----------|
+| backlog | idle, blocked |
+| ready | idle, queued |
+| in_progress | running, waiting_input |
+| review | review_ready |
+| done | done |
+
+## Agent Execution Flow
+
+Two execution paths depending on whether the card has a `workflowId`:
+
+### Single-Prompt Execution (`agent-executor.ts`)
+
+Used when a card has no workflow or the workflow is not found.
+
+```
+Card moved to in_progress
+  1. Claim workspace slot (or queue if none available)
+  2. Write .claude/settings.local.json with Stop/Notification hooks
+  3. Create tmux session (card-{id}) in slot directory
+  4. Git branch handling:
+     - Reuse branch from previous run if exists (rerun case)
+     - Or: checkout main, pull, create agentboard/card-{id}
+     - Or: stay on current branch (branchMode=current)
+  5. Install dependencies (pnpm/bun/npm based on lockfile)
+  6. Create workflow_runs DB record
+  7. Build claude CLI command:
+     claude --dangerously-skip-permissions --max-turns 50 \
+       --append-system-prompt "..." -p "<card description>"
+  8. Send command to tmux session
+  9. Start tmux capture (polling capture-pane every 500ms)
+```
+
+Completion is async -- the Stop hook POSTs to `/api/agents/{cardId}/complete`.
+
+### Workflow Execution (`workflow-runner.ts`)
+
+Used when a card has a valid `workflowId`. Runs multiple Claude invocations in sequence.
+
+```
+Card moved to in_progress
+  1. Init context: fetch card, repo, workflow definition
+  2. Claim slot, create tmux session, start output capture
+  3. Create git branch from workflow.branch_template
+  4. For each step in workflow.steps:
+     a. Write hooks pointing to /api/agents/{cardId}/step-complete
+     b. Build prompt via context-bundler (template + previous artifacts + CLAUDE.md)
+     c. Send claude -p command to tmux
+     d. Wait for step-complete callback (10min timeout)
+     e. Check artifact exists at step.artifact path
+     f. Check pass_condition against artifact content
+     g. On failure: retry up to step.max_retries, or follow on_fail goto
+  5. Run post_steps (push branch, create PR via gh CLI)
+  6. Move card to review/review_ready
+  Finally: kill tmux, release slot (triggers queue-manager)
+```
+
+### Hook Callback Endpoints
+
+| Endpoint | Hook | Effect |
+|----------|------|--------|
+| `POST /api/agents/{cardId}/complete` | Stop | Auto-commit uncommitted changes, kill tmux, release slot, move card to review |
+| `POST /api/agents/{cardId}/step-complete` | Stop (workflow) | Resolves pending step promise so workflow-runner proceeds to next step |
+| `POST /api/agents/{cardId}/notification` | Notification | Set card status to waiting_input |
+
+The hooks are written to `.claude/settings.local.json` in the slot directory:
+
+```json
+{
+  "hooks": {
+    "Stop": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://localhost:4200/api/agents/{cardId}/complete" }] }],
+    "Notification": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://localhost:4200/api/agents/{cardId}/notification" }] }]
+  }
+}
+```
+
+## Workspace Slot System
+
+Slots are git worktrees registered in the DB, each tied to a repository.
+
+```mermaid
+graph LR
+    Repo["Repository (e.g. my-app)"] --> Slot1["Slot 1: ~/worktrees/my-app-1"]
+    Repo --> Slot2["Slot 2: ~/worktrees/my-app-2"]
+    Repo --> Slot3["Slot 3: ~/worktrees/my-app-3"]
+```
+
+**Slot statuses:** available | claimed | locked
+
+**Lifecycle:**
+1. **Claim** (`slot-allocator.claimSlot`): finds first available slot for the repo, sets status=claimed, claimedByCardId=cardId
+2. **Use**: agent runs in the slot directory (git ops, claude CLI)
+3. **Release** (`slot-allocator.releaseSlot`): sets status=available, claimedByCardId=null, emits `slot:released`
+
+**Concurrency control:**
+- `MAX_CONCURRENT_AGENTS` (env var, default 3) limits total running agents
+- Each repo can run as many agents as it has available slots
+- When no slot is available, the card is set to `queued` in the `ready` column
+
+## Queue Manager
+
+The queue-manager plugin listens for `slot:released` and `card:status-changed` events:
+
+1. When a slot is released: find the next queued or ready/idle card for that repo
+2. Pre-claim the slot for the card to prevent races
+3. Move card to in_progress, start execution
+4. Respects MAX_CONCURRENT_AGENTS before starting
+
+Ready/idle cards auto-start when a slot becomes available (no manual move to in_progress needed).
+
+## Real-time Updates
+
+```mermaid
+graph TB
+    subgraph Server
+        EB[EventBus<br>Node EventEmitter]
+        WS[WebSocket Handler<br>server/routes/ws.ts]
+        Services[Services & Hooks]
+    end
+
+    subgraph Client
+        WSC[useWebSocket composable]
+        Cards[useCards composable]
+        UI[Board UI]
+    end
+
+    Services -->|emit events| EB
+    EB -->|forward all events| WS
+    WS -->|JSON messages| WSC
+    WSC -->|bindCards| Cards
+    Cards -->|reactive updates| UI
+```
+
+**Server side:** All services emit events on the shared `eventBus` (Node EventEmitter). The WebSocket handler (`server/routes/ws.ts`) forwards every event to connected clients.
+
+**Event types:**
+- `card:moved` -- column change
+- `card:status-changed` -- status change
+- `step:started/completed/failed` -- workflow step progress
+- `slot:claimed/released` -- slot lifecycle
+- `agent:output` -- tmux terminal output
+- `agent:waiting` -- agent needs input
+- `workflow:completed` -- workflow finished
+- `github:issue-found` -- new issue detected by poller
+
+**Client side:** `useWebSocket` composable manages a singleton WebSocket connection with auto-reconnect. `bindCards` wires events to reactive card state updates. Terminal output is subscription-based: clients send `subscribe-terminal` message to start receiving tmux capture output for a specific card.
+
+**Terminal streaming:** tmux `capture-pane` is polled every 500ms (server-side). Output is emitted as `agent:output` events, forwarded via WebSocket only to clients subscribed to that card's channel.
+
+## Key Services
+
+| Service | File | Purpose |
+|---------|------|---------|
+| **tmux-manager** | `services/tmux-manager.ts` | Create/kill tmux sessions, send commands, poll terminal output via capture-pane |
+| **agent-executor** | `services/agent-executor.ts` | Single-prompt execution: slot claim, branch setup, deps install, spawn claude CLI |
+| **workflow-runner** | `services/workflow-runner.ts` | Multi-step pipeline: iterate steps, wait for callbacks, check artifacts/pass conditions, retry |
+| **workflow-loader** | `services/workflow-loader.ts` | Load YAML workflow definitions from `.agentboard/workflows/`, watch for changes with chokidar |
+| **context-bundler** | `services/context-bundler.ts` | Build step prompts: template vars, previous artifacts, dependency diffs, CLAUDE.md |
+| **slot-allocator** | `services/slot-allocator.ts` | Claim/release workspace slots per repo |
+| **dependency-resolver** | `services/dependency-resolver.ts` | Track card dependencies (dependsOn field), unblock cards when deps complete |
+| **github-service** | `services/github-service.ts` | GitHub operations via `gh` CLI: list issues, create PRs, manage labels, poll for trigger labels |
+| **ttyd-manager** | `services/ttyd-manager.ts` | Spawn ttyd processes to expose tmux sessions as web terminals (port 7700+) |
+
+## Nitro Plugins (Startup)
+
+| Plugin | File | Purpose |
+|--------|------|---------|
+| **seed** | `plugins/seed.ts` | Ensure default board exists |
+| **session-reconnect** | `plugins/session-reconnect.ts` | On startup: reconcile running cards with live tmux sessions, kill orphans, resume captures |
+| **queue-manager** | `plugins/queue-manager.ts` | Auto-start queued/ready cards when slots become available |
+| **dependency-watcher** | `plugins/dependency-watcher.ts` | When a card completes, unblock dependent cards and move them to ready |
+| **github-poll** | `plugins/github-poll.ts` | Poll GitHub issues with trigger labels, auto-create cards |
+| **github-label-sync** | `plugins/github-label-sync.ts` | Sync card status to GitHub issue labels (in_progress/success/failure) |
+
+## Database Schema
+
+SQLite via Drizzle ORM. Key tables:
+
+- **repositories** -- registered repos (name, org, defaultBranch, githubUrl)
+- **workspace_slots** -- worktree directories per repo (path, status, claimedByCardId)
+- **boards** -- kanban boards (just a name)
+- **cards** -- tasks (title, description, column, status, repoId, workflowId, dependsOn, githubIssueNumber, etc.)
+- **plans** -- card groupings with PR granularity
+- **workflow_runs** -- execution records (cardId, workflowId, slotId, tmuxSession, branch, status)
+- **step_runs** -- per-step execution records within a workflow run
+- **card_events** -- audit log of all card lifecycle events
+- **agent_logs** -- captured agent output per workflow run

--- a/plugins/tt-agentboard/nuxt.config.ts
+++ b/plugins/tt-agentboard/nuxt.config.ts
@@ -2,6 +2,11 @@ export default defineNuxtConfig({
   compatibilityDate: "2025-01-01",
   devtools: { enabled: true },
   modules: ["@nuxtjs/tailwindcss"],
+  vite: {
+    optimizeDeps: {
+      include: ["vuedraggable", "@xterm/xterm", "@xterm/addon-fit", "@vueuse/core"],
+    },
+  },
   nitro: {
     experimental: {
       websocket: true,

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/complete.post.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/complete.post.ts
@@ -104,7 +104,10 @@ export default defineEventHandler(async (event) => {
   // Kill tmux session and release slot so next card can start
   const sessionName = `card-${cardId}`;
   tmuxManager.stopCapture(sessionName);
-  tmuxManager.killSession(sessionName);
+  const killed = tmuxManager.killSession(sessionName);
+  if (killed) {
+    await logCardEvent(cardId, "tmux_session_killed", `session=${sessionName}`);
+  }
 
   // Release slot
   for (const slot of claimedSlots) {
@@ -112,6 +115,7 @@ export default defineEventHandler(async (event) => {
       .update(workspaceSlots)
       .set({ status: "available", claimedByCardId: null })
       .where(eq(workspaceSlots.id, slot.id));
+    await logCardEvent(cardId, "slot_released", `slotId=${slot.id}`);
     eventBus.emit("slot:released", { slotId: slot.id });
   }
 

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/diff.get.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/diff.get.ts
@@ -89,13 +89,18 @@ export default defineEventHandler(async (event) => {
       timeout: 5000,
     });
 
-    // If no uncommitted changes, try branch diff against main
+    // If no uncommitted changes, try branch diff against origin/main
     if (!raw.trim()) {
-      raw = execSync("git diff main...HEAD", {
-        cwd: slot.path,
-        encoding: "utf-8",
-        timeout: 5000,
-      });
+      try {
+        raw = execSync("git diff origin/main...HEAD", {
+          cwd: slot.path,
+          encoding: "utf-8",
+          timeout: 5000,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch {
+        // origin/main may not exist — ignore
+      }
     }
   } catch {
     return { hasDiff: false, files: [], raw: "" };

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/failure.post.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/failure.post.ts
@@ -5,6 +5,7 @@ import { tmuxManager } from "~~/server/services/tmux-manager";
 import { eventBus } from "~~/server/utils/event-bus";
 import { logger } from "~~/server/utils/logger";
 import { getCardId, requireCard } from "~~/server/utils/params";
+import { logCardEvent } from "~~/server/utils/card-events";
 
 /**
  * Callback endpoint for Claude Code StopFailure hook.
@@ -36,6 +37,8 @@ export default defineEventHandler(async (event) => {
   // Stop capture but keep session alive for debugging
   const sessionName = `card-${cardId}`;
   tmuxManager.stopCapture(sessionName);
+
+  await logCardEvent(cardId, "agent_failed", `session=${sessionName} preserved for debugging`);
 
   eventBus.emit("card:status-changed", { cardId, status: "failed" });
   eventBus.emit("workflow:completed", { cardId, status: "failed" });

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/open-vscode.get.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/open-vscode.get.ts
@@ -1,6 +1,6 @@
 import { db } from "~~/server/db";
-import { workspaceSlots } from "~~/server/db/schema";
-import { eq } from "drizzle-orm";
+import { workspaceSlots, workflowRuns } from "~~/server/db/schema";
+import { eq, desc } from "drizzle-orm";
 import { execSync } from "node:child_process";
 import { logger } from "~~/server/utils/logger";
 import { getCardId } from "~~/server/utils/params";
@@ -8,20 +8,42 @@ import { getCardId } from "~~/server/utils/params";
 /**
  * GET /api/agents/:cardId/open-vscode
  * Opens the card's workspace slot directory in VS Code.
+ * Checks currently claimed slot first, then falls back to the last workflow run's slot.
  */
 export default defineEventHandler(async (event) => {
   const cardId = getCardId(event);
 
-  const slots = await db
+  // Try currently claimed slot
+  const claimed = await db
     .select()
     .from(workspaceSlots)
-    .where(eq(workspaceSlots.claimedByCardId, cardId));
+    .where(eq(workspaceSlots.claimedByCardId, cardId))
+    .limit(1);
 
-  if (slots.length === 0) {
-    throw createError({ statusCode: 404, statusMessage: "No workspace slot found for this card" });
+  let slotPath = claimed[0]?.path ?? null;
+
+  // Fallback: look up slot from the most recent workflow run
+  if (!slotPath) {
+    const runs = await db
+      .select({ slotId: workflowRuns.slotId })
+      .from(workflowRuns)
+      .where(eq(workflowRuns.cardId, cardId))
+      .orderBy(desc(workflowRuns.id))
+      .limit(1);
+
+    if (runs[0]?.slotId) {
+      const slot = await db
+        .select()
+        .from(workspaceSlots)
+        .where(eq(workspaceSlots.id, runs[0].slotId))
+        .limit(1);
+      slotPath = slot[0]?.path ?? null;
+    }
   }
 
-  const slotPath = slots[0]!.path;
+  if (!slotPath) {
+    throw createError({ statusCode: 404, statusMessage: "No workspace slot found for this card" });
+  }
 
   try {
     execSync(`code ${JSON.stringify(slotPath)}`, { stdio: "ignore" });

--- a/plugins/tt-agentboard/server/api/cards/[id].delete.ts
+++ b/plugins/tt-agentboard/server/api/cards/[id].delete.ts
@@ -1,7 +1,8 @@
 import { db } from "~~/server/db";
-import { cards, cardEvents, workflowRuns, stepRuns } from "~~/server/db/schema";
+import { cards, cardEvents, workflowRuns, stepRuns, workspaceSlots } from "~~/server/db/schema";
 import { eq } from "drizzle-orm";
 import { tmuxManager } from "~~/server/services/tmux-manager";
+import { eventBus } from "~~/server/utils/event-bus";
 
 export default defineEventHandler(async (event) => {
   const id = Number(getRouterParam(event, "id"));
@@ -10,6 +11,19 @@ export default defineEventHandler(async (event) => {
   const sessionName = `card-${id}`;
   tmuxManager.stopCapture(sessionName);
   tmuxManager.killSession(sessionName);
+
+  // Release any claimed workspace slots
+  const claimedSlots = await db
+    .select()
+    .from(workspaceSlots)
+    .where(eq(workspaceSlots.claimedByCardId, id));
+  for (const slot of claimedSlots) {
+    await db
+      .update(workspaceSlots)
+      .set({ status: "available", claimedByCardId: null })
+      .where(eq(workspaceSlots.id, slot.id));
+    eventBus.emit("slot:released", { slotId: slot.id });
+  }
 
   // Delete related records (foreign key constraints)
   await db.delete(cardEvents).where(eq(cardEvents.cardId, id));

--- a/plugins/tt-agentboard/server/api/cards/[id].get.ts
+++ b/plugins/tt-agentboard/server/api/cards/[id].get.ts
@@ -1,5 +1,5 @@
 import { db } from "~~/server/db";
-import { cards, workflowRuns } from "~~/server/db/schema";
+import { cards, repositories, workflowRuns } from "~~/server/db/schema";
 import { eq, desc } from "drizzle-orm";
 
 export default defineEventHandler(async (event) => {
@@ -7,6 +7,17 @@ export default defineEventHandler(async (event) => {
   const result = await db.select().from(cards).where(eq(cards.id, id));
   if (result.length === 0) {
     throw createError({ statusCode: 404, statusMessage: "Card not found" });
+  }
+
+  const card = result[0];
+
+  // Fetch repo if linked
+  let repo: { name: string; org: string | null; githubUrl: string | null } | null = null;
+  if (card.repoId) {
+    const repos = await db.select().from(repositories).where(eq(repositories.id, card.repoId));
+    if (repos.length > 0) {
+      repo = { name: repos[0].name, org: repos[0].org, githubUrl: repos[0].githubUrl };
+    }
   }
 
   const runs = await db
@@ -17,7 +28,8 @@ export default defineEventHandler(async (event) => {
     .limit(1);
 
   return {
-    ...result[0],
+    ...card,
     branch: runs[0]?.branch ?? null,
+    repo,
   };
 });

--- a/plugins/tt-agentboard/server/api/cards/index.get.ts
+++ b/plugins/tt-agentboard/server/api/cards/index.get.ts
@@ -39,6 +39,6 @@ export default defineEventHandler(async (event) => {
   return rows.map((card) => ({
     ...card,
     branch: branches.get(card.id) ?? null,
-    repo: card.repoId ? repoMap.get(card.repoId) ?? null : null,
+    repo: card.repoId ? (repoMap.get(card.repoId) ?? null) : null,
   }));
 });

--- a/plugins/tt-agentboard/server/api/cards/index.get.ts
+++ b/plugins/tt-agentboard/server/api/cards/index.get.ts
@@ -1,6 +1,6 @@
 import { db } from "~~/server/db";
-import { cards, workflowRuns } from "~~/server/db/schema";
-import { eq, desc } from "drizzle-orm";
+import { cards, repositories, workflowRuns } from "~~/server/db/schema";
+import { eq, desc, inArray } from "drizzle-orm";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -12,10 +12,19 @@ export default defineEventHandler(async (event) => {
     .where(eq(cards.boardId, boardId))
     .orderBy(cards.position);
 
+  // Batch-fetch repos for cards that have a repoId
+  const repoIds = [...new Set(rows.map((c) => c.repoId).filter((id): id is number => id !== null))];
+  const repoMap = new Map<number, { name: string; org: string | null; githubUrl: string | null }>();
+  if (repoIds.length > 0) {
+    const repos = await db.select().from(repositories).where(inArray(repositories.id, repoIds));
+    for (const r of repos) {
+      repoMap.set(r.id, { name: r.name, org: r.org, githubUrl: r.githubUrl });
+    }
+  }
+
   // Batch-fetch latest branch from workflowRuns for all cards
-  const cardIds = rows.map((c) => c.id);
   const branches = new Map<number, string>();
-  if (cardIds.length > 0) {
+  if (rows.length > 0) {
     const runs = await db
       .select({ cardId: workflowRuns.cardId, branch: workflowRuns.branch })
       .from(workflowRuns)
@@ -30,5 +39,6 @@ export default defineEventHandler(async (event) => {
   return rows.map((card) => ({
     ...card,
     branch: branches.get(card.id) ?? null,
+    repo: card.repoId ? repoMap.get(card.repoId) ?? null : null,
   }));
 });

--- a/plugins/tt-agentboard/server/api/slots/[id]/git-info.get.ts
+++ b/plugins/tt-agentboard/server/api/slots/[id]/git-info.get.ts
@@ -1,0 +1,44 @@
+import { db } from "~~/server/db";
+import { workspaceSlots } from "~~/server/db/schema";
+import { eq } from "drizzle-orm";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+async function gitCommand(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  const id = Number(getRouterParam(event, "id"));
+  const rows = await db.select().from(workspaceSlots).where(eq(workspaceSlots.id, id));
+  if (rows.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: "Slot not found" });
+  }
+
+  const slot = rows[0];
+  const cwd = slot.path;
+
+  const [branch, aheadStr, behindStr, porcelain] = await Promise.all([
+    gitCommand(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]),
+    gitCommand(cwd, ["rev-list", "origin/main..HEAD", "--count"]),
+    gitCommand(cwd, ["rev-list", "HEAD..origin/main", "--count"]),
+    gitCommand(cwd, ["status", "--porcelain"]),
+  ]);
+
+  return {
+    branch,
+    ahead: aheadStr !== null ? Number(aheadStr) : null,
+    behind: behindStr !== null ? Number(behindStr) : null,
+    dirty: porcelain !== null ? porcelain.length > 0 : null,
+  };
+});

--- a/plugins/tt-agentboard/server/api/slots/[id]/git-info.get.ts
+++ b/plugins/tt-agentboard/server/api/slots/[id]/git-info.get.ts
@@ -1,22 +1,7 @@
 import { db } from "~~/server/db";
-import { workspaceSlots } from "~~/server/db/schema";
+import { repositories, workspaceSlots } from "~~/server/db/schema";
 import { eq } from "drizzle-orm";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
-
-async function gitCommand(cwd: string, args: string[]): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync("git", args, {
-      cwd,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    return stdout.trim();
-  } catch {
-    return null;
-  }
-}
+import { gitQuery } from "~~/server/utils/git";
 
 export default defineEventHandler(async (event) => {
   const id = Number(getRouterParam(event, "id"));
@@ -28,11 +13,14 @@ export default defineEventHandler(async (event) => {
   const slot = rows[0];
   const cwd = slot.path;
 
+  const repos = await db.select().from(repositories).where(eq(repositories.id, slot.repoId));
+  const defaultBranch = repos[0]?.defaultBranch ?? "main";
+
   const [branch, aheadStr, behindStr, porcelain] = await Promise.all([
-    gitCommand(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]),
-    gitCommand(cwd, ["rev-list", "origin/main..HEAD", "--count"]),
-    gitCommand(cwd, ["rev-list", "HEAD..origin/main", "--count"]),
-    gitCommand(cwd, ["status", "--porcelain"]),
+    gitQuery(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]),
+    gitQuery(cwd, ["rev-list", `origin/${defaultBranch}..HEAD`, "--count"]),
+    gitQuery(cwd, ["rev-list", `HEAD..origin/${defaultBranch}`, "--count"]),
+    gitQuery(cwd, ["status", "--porcelain"]),
   ]);
 
   return {

--- a/plugins/tt-agentboard/server/api/slots/[id]/release.post.ts
+++ b/plugins/tt-agentboard/server/api/slots/[id]/release.post.ts
@@ -1,0 +1,24 @@
+import { db } from "~~/server/db";
+import { workspaceSlots } from "~~/server/db/schema";
+import { eq } from "drizzle-orm";
+import { eventBus } from "~~/server/utils/event-bus";
+
+export default defineEventHandler(async (event) => {
+  const id = Number(getRouterParam(event, "id"));
+
+  const result = await db
+    .update(workspaceSlots)
+    .set({
+      status: "available",
+      claimedByCardId: null,
+    })
+    .where(eq(workspaceSlots.id, id))
+    .returning();
+
+  if (result.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: "Slot not found" });
+  }
+
+  eventBus.emit("slot:released", { slotId: id });
+  return result[0];
+});

--- a/plugins/tt-agentboard/server/api/slots/[id]/release.post.ts
+++ b/plugins/tt-agentboard/server/api/slots/[id]/release.post.ts
@@ -2,9 +2,25 @@ import { db } from "~~/server/db";
 import { workspaceSlots } from "~~/server/db/schema";
 import { eq } from "drizzle-orm";
 import { eventBus } from "~~/server/utils/event-bus";
+import { tmuxManager, cardSessionName } from "~~/server/services/tmux-manager";
 
 export default defineEventHandler(async (event) => {
   const id = Number(getRouterParam(event, "id"));
+
+  const [slot] = await db.select().from(workspaceSlots).where(eq(workspaceSlots.id, id));
+  if (!slot) {
+    throw createError({ statusCode: 404, statusMessage: "Slot not found" });
+  }
+
+  if (slot.status === "claimed" && slot.claimedByCardId) {
+    const sessionName = cardSessionName(slot.claimedByCardId);
+    if (tmuxManager.sessionExists(sessionName)) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: "Slot has an active agent session. Stop the agent first.",
+      });
+    }
+  }
 
   const result = await db
     .update(workspaceSlots)
@@ -14,10 +30,6 @@ export default defineEventHandler(async (event) => {
     })
     .where(eq(workspaceSlots.id, id))
     .returning();
-
-  if (result.length === 0) {
-    throw createError({ statusCode: 404, statusMessage: "Slot not found" });
-  }
 
   eventBus.emit("slot:released", { slotId: id });
   return result[0];

--- a/plugins/tt-agentboard/server/api/slots/[id]/reset.post.ts
+++ b/plugins/tt-agentboard/server/api/slots/[id]/reset.post.ts
@@ -1,38 +1,44 @@
 import { db } from "~~/server/db";
-import { workspaceSlots } from "~~/server/db/schema";
+import { repositories, workspaceSlots } from "~~/server/db/schema";
 import { eq } from "drizzle-orm";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
-
-async function gitRun(cwd: string, args: string[]): Promise<void> {
-  await execFileAsync("git", args, {
-    cwd,
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-}
+import { gitRun } from "~~/server/utils/git";
 
 export default defineEventHandler(async (event) => {
   const id = Number(getRouterParam(event, "id"));
+  const query = getQuery(event);
+  const force = query.force === "true";
 
-  const rows = await db.select().from(workspaceSlots).where(eq(workspaceSlots.id, id));
-  if (rows.length === 0) {
+  const [slot] = await db.select().from(workspaceSlots).where(eq(workspaceSlots.id, id));
+  if (!slot) {
     throw createError({ statusCode: 404, statusMessage: "Slot not found" });
   }
-
-  const slot = rows[0];
   if (slot.status === "claimed") {
     throw createError({ statusCode: 409, statusMessage: "Cannot reset a claimed slot" });
   }
 
   const cwd = slot.path;
 
+  const porcelain = await gitRun(cwd, ["status", "--porcelain"]);
+  if (porcelain.length > 0 && !force) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: "Slot has uncommitted changes. Use ?force=true to override.",
+    });
+  }
+
+  let defaultBranch = "main";
+  if (slot.repoId) {
+    const [repo] = await db.select().from(repositories).where(eq(repositories.id, slot.repoId));
+    if (repo?.defaultBranch) {
+      defaultBranch = repo.defaultBranch;
+    }
+  }
+
   try {
     await gitRun(cwd, ["stash", "--include-untracked"]);
     await gitRun(cwd, ["fetch", "origin"]);
-    await gitRun(cwd, ["checkout", "main"]);
-    await gitRun(cwd, ["reset", "--hard", "origin/main"]);
+    await gitRun(cwd, ["checkout", defaultBranch]);
+    await gitRun(cwd, ["reset", "--hard", `origin/${defaultBranch}`]);
   } catch (err) {
     throw createError({
       statusCode: 500,

--- a/plugins/tt-agentboard/server/api/slots/[id]/reset.post.ts
+++ b/plugins/tt-agentboard/server/api/slots/[id]/reset.post.ts
@@ -1,0 +1,44 @@
+import { db } from "~~/server/db";
+import { workspaceSlots } from "~~/server/db/schema";
+import { eq } from "drizzle-orm";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+async function gitRun(cwd: string, args: string[]): Promise<void> {
+  await execFileAsync("git", args, {
+    cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+export default defineEventHandler(async (event) => {
+  const id = Number(getRouterParam(event, "id"));
+
+  const rows = await db.select().from(workspaceSlots).where(eq(workspaceSlots.id, id));
+  if (rows.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: "Slot not found" });
+  }
+
+  const slot = rows[0];
+  if (slot.status === "claimed") {
+    throw createError({ statusCode: 409, statusMessage: "Cannot reset a claimed slot" });
+  }
+
+  const cwd = slot.path;
+
+  try {
+    await gitRun(cwd, ["stash", "--include-untracked"]);
+    await gitRun(cwd, ["fetch", "origin"]);
+    await gitRun(cwd, ["checkout", "main"]);
+    await gitRun(cwd, ["reset", "--hard", "origin/main"]);
+  } catch (err) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: `Git reset failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  return { success: true };
+});

--- a/plugins/tt-agentboard/server/plugins/queue-manager.ts
+++ b/plugins/tt-agentboard/server/plugins/queue-manager.ts
@@ -8,13 +8,7 @@ import { logCardEvent } from "../utils/card-events";
 
 const MAX_CONCURRENT = Number(process.env.MAX_CONCURRENT_AGENTS) || 3;
 
-async function tryAutoStartNext(slotId: number): Promise<void> {
-  // Find which repo this slot belongs to
-  const slotRows = await db.select().from(workspaceSlots).where(eq(workspaceSlots.id, slotId));
-
-  if (slotRows.length === 0) return;
-  const slot = slotRows[0]!;
-
+async function tryAutoStartNext(slot: { id: number; repoId: number | null }): Promise<boolean> {
   // Check current running count across all repos
   const runningCards = await db.select().from(cards).where(eq(cards.status, "running"));
 
@@ -22,7 +16,7 @@ async function tryAutoStartNext(slotId: number): Promise<void> {
     logger.info(
       `Queue: ${runningCards.length}/${MAX_CONCURRENT} agents running, skipping auto-start`,
     );
-    return;
+    return false;
   }
 
   // Find next queued card (any column — queued cards may be in "ready" column)
@@ -47,7 +41,7 @@ async function tryAutoStartNext(slotId: number): Promise<void> {
 
   if (queued.length === 0) {
     logger.info(`Queue: no queued or ready cards for repo ${slot.repoId}`);
-    return;
+    return false;
   }
 
   const nextCard = queued[0]!;
@@ -60,7 +54,7 @@ async function tryAutoStartNext(slotId: number): Promise<void> {
   await db
     .update(workspaceSlots)
     .set({ status: "claimed", claimedByCardId: nextCard.id })
-    .where(eq(workspaceSlots.id, slotId));
+    .where(eq(workspaceSlots.id, slot.id));
 
   // Move card to in_progress
   await db
@@ -78,7 +72,7 @@ async function tryAutoStartNext(slotId: number): Promise<void> {
     await logCardEvent(
       nextCard.id,
       "auto_started",
-      `Auto-promoted from ready column (slot ${slotId} became available)`,
+      `Auto-promoted from ready column (slot ${slot.id} became available)`,
     );
   }
 
@@ -86,12 +80,19 @@ async function tryAutoStartNext(slotId: number): Promise<void> {
     logger.error(`Queue: failed to start card ${nextCard.id}:`, err);
     eventBus.emit("card:status-changed", { cardId: nextCard.id, status: "failed" });
   });
+
+  return true;
 }
 
 export default defineNitroPlugin(() => {
   eventBus.on("slot:released", async (data: { slotId: number }) => {
     try {
-      await tryAutoStartNext(data.slotId);
+      const [slot] = await db
+        .select()
+        .from(workspaceSlots)
+        .where(eq(workspaceSlots.id, data.slotId));
+      if (!slot) return;
+      await tryAutoStartNext(slot);
     } catch (err) {
       logger.error("Queue: error processing slot:released:", err);
     }
@@ -115,13 +116,12 @@ export default defineNitroPlugin(() => {
         .from(workspaceSlots)
         .where(eq(workspaceSlots.status, "available"));
 
+      let started = 0;
       for (const slot of availableSlots) {
-        // Re-check running count after each start
-        const currentRunning = await db.select().from(cards).where(eq(cards.status, "running"));
+        if (runningCards.length + started >= MAX_CONCURRENT) break;
 
-        if (currentRunning.length >= MAX_CONCURRENT) break;
-
-        await tryAutoStartNext(slot.id);
+        const didStart = await tryAutoStartNext(slot);
+        if (didStart) started++;
       }
     } catch (err) {
       logger.error("Queue: error processing card:status-changed for auto-start:", err);

--- a/plugins/tt-agentboard/server/plugins/queue-manager.ts
+++ b/plugins/tt-agentboard/server/plugins/queue-manager.ts
@@ -4,71 +4,127 @@ import { eq, and } from "drizzle-orm";
 import { agentExecutor } from "../services/agent-executor";
 import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
+import { logCardEvent } from "../utils/card-events";
 
 const MAX_CONCURRENT = Number(process.env.MAX_CONCURRENT_AGENTS) || 3;
+
+async function tryAutoStartNext(slotId: number): Promise<void> {
+  // Find which repo this slot belongs to
+  const slotRows = await db.select().from(workspaceSlots).where(eq(workspaceSlots.id, slotId));
+
+  if (slotRows.length === 0) return;
+  const slot = slotRows[0]!;
+
+  // Check current running count across all repos
+  const runningCards = await db.select().from(cards).where(eq(cards.status, "running"));
+
+  if (runningCards.length >= MAX_CONCURRENT) {
+    logger.info(
+      `Queue: ${runningCards.length}/${MAX_CONCURRENT} agents running, skipping auto-start`,
+    );
+    return;
+  }
+
+  // Find next queued card (any column — queued cards may be in "ready" column)
+  let queued = await db
+    .select()
+    .from(cards)
+    .where(and(eq(cards.repoId, slot.repoId), eq(cards.status, "queued")))
+    .orderBy(cards.position)
+    .limit(1);
+
+  // Fall back to idle cards in the "ready" column
+  if (queued.length === 0) {
+    queued = await db
+      .select()
+      .from(cards)
+      .where(
+        and(eq(cards.repoId, slot.repoId), eq(cards.column, "ready"), eq(cards.status, "idle")),
+      )
+      .orderBy(cards.position)
+      .limit(1);
+  }
+
+  if (queued.length === 0) {
+    logger.info(`Queue: no queued or ready cards for repo ${slot.repoId}`);
+    return;
+  }
+
+  const nextCard = queued[0]!;
+  const isReadyCard = nextCard.status === "idle" && nextCard.column === "ready";
+  logger.info(
+    `Queue: auto-starting card ${nextCard.id} (${isReadyCard ? "ready/idle" : "queued"}) for repo ${slot.repoId}`,
+  );
+
+  // Pre-claim the released slot for this card to avoid race conditions
+  await db
+    .update(workspaceSlots)
+    .set({ status: "claimed", claimedByCardId: nextCard.id })
+    .where(eq(workspaceSlots.id, slotId));
+
+  // Move card to in_progress
+  await db
+    .update(cards)
+    .set({ column: "in_progress", updatedAt: new Date() })
+    .where(eq(cards.id, nextCard.id));
+
+  eventBus.emit("card:moved", {
+    cardId: nextCard.id,
+    fromColumn: nextCard.column,
+    toColumn: "in_progress",
+  });
+
+  if (isReadyCard) {
+    await logCardEvent(
+      nextCard.id,
+      "auto_started",
+      `Auto-promoted from ready column (slot ${slotId} became available)`,
+    );
+  }
+
+  agentExecutor.startExecution(nextCard.id).catch((err) => {
+    logger.error(`Queue: failed to start card ${nextCard.id}:`, err);
+    eventBus.emit("card:status-changed", { cardId: nextCard.id, status: "failed" });
+  });
+}
 
 export default defineNitroPlugin(() => {
   eventBus.on("slot:released", async (data: { slotId: number }) => {
     try {
-      // Find which repo this slot belongs to
-      const slotRows = await db
-        .select()
-        .from(workspaceSlots)
-        .where(eq(workspaceSlots.id, data.slotId));
-
-      if (slotRows.length === 0) return;
-      const slot = slotRows[0]!;
-
-      // Check current running count across all repos
-      const runningCards = await db.select().from(cards).where(eq(cards.status, "running"));
-
-      if (runningCards.length >= MAX_CONCURRENT) {
-        logger.info(
-          `Queue: ${runningCards.length}/${MAX_CONCURRENT} agents running, skipping auto-start`,
-        );
-        return;
-      }
-
-      // Find next queued card (any column — queued cards may be in "ready" column)
-      const queued = await db
-        .select()
-        .from(cards)
-        .where(and(eq(cards.repoId, slot.repoId), eq(cards.status, "queued")))
-        .orderBy(cards.position)
-        .limit(1);
-
-      if (queued.length === 0) {
-        logger.info(`Queue: no queued cards for repo ${slot.repoId}`);
-        return;
-      }
-
-      const nextCard = queued[0]!;
-      logger.info(`Queue: auto-starting card ${nextCard.id} for repo ${slot.repoId}`);
-
-      // Pre-claim the released slot for this card to avoid race conditions
-      await db
-        .update(workspaceSlots)
-        .set({ status: "claimed", claimedByCardId: nextCard.id })
-        .where(eq(workspaceSlots.id, data.slotId));
-
-      // Move card to in_progress
-      await db
-        .update(cards)
-        .set({ column: "in_progress", updatedAt: new Date() })
-        .where(eq(cards.id, nextCard.id));
-
-      eventBus.emit("card:moved", {
-        cardId: nextCard.id,
-        fromColumn: nextCard.column,
-        toColumn: "in_progress",
-      });
-
-      agentExecutor.startExecution(nextCard.id).catch((err) => {
-        logger.error(`Queue: failed to start card ${nextCard.id}:`, err);
-        eventBus.emit("card:status-changed", { cardId: nextCard.id, status: "failed" });
-      });
+      await tryAutoStartNext(data.slotId);
     } catch (err) {
       logger.error("Queue: error processing slot:released:", err);
+    }
+  });
+
+  // When a card completes or fails, check if ready cards can be auto-started
+  eventBus.on("card:status-changed", async (data: { cardId: number; status: string }) => {
+    if (data.status !== "review_ready" && data.status !== "done" && data.status !== "failed") {
+      return;
+    }
+
+    try {
+      // Check current running count
+      const runningCards = await db.select().from(cards).where(eq(cards.status, "running"));
+
+      if (runningCards.length >= MAX_CONCURRENT) return;
+
+      // Find all available slots
+      const availableSlots = await db
+        .select()
+        .from(workspaceSlots)
+        .where(eq(workspaceSlots.status, "available"));
+
+      for (const slot of availableSlots) {
+        // Re-check running count after each start
+        const currentRunning = await db.select().from(cards).where(eq(cards.status, "running"));
+
+        if (currentRunning.length >= MAX_CONCURRENT) break;
+
+        await tryAutoStartNext(slot.id);
+      }
+    } catch (err) {
+      logger.error("Queue: error processing card:status-changed for auto-start:", err);
     }
   });
 

--- a/plugins/tt-agentboard/server/plugins/session-reconnect.ts
+++ b/plugins/tt-agentboard/server/plugins/session-reconnect.ts
@@ -54,7 +54,11 @@ export default defineNitroPlugin(async () => {
         `Session reconnect: card ${cardId} status is "${card.status}", killing stale session`,
       );
       tmuxManager.killSession(sessionName);
-      await logCardEvent(cardId, "tmux_session_orphaned_killed", `session=${sessionName}, status=${card.status}`);
+      await logCardEvent(
+        cardId,
+        "tmux_session_orphaned_killed",
+        `session=${sessionName}, status=${card.status}`,
+      );
       continue;
     }
 
@@ -78,7 +82,11 @@ export default defineNitroPlugin(async () => {
         .set({ status: "failed", endedAt: new Date() })
         .where(eq(workflowRuns.cardId, cardId));
 
-      await logCardEvent(cardId, "agent_failed", `session ${sessionName} died between list and check`);
+      await logCardEvent(
+        cardId,
+        "agent_failed",
+        `session ${sessionName} died between list and check`,
+      );
       eventBus.emit("card:status-changed", { cardId, status: "failed" });
     }
   }

--- a/plugins/tt-agentboard/server/plugins/session-reconnect.ts
+++ b/plugins/tt-agentboard/server/plugins/session-reconnect.ts
@@ -4,6 +4,7 @@ import { eq, inArray } from "drizzle-orm";
 import { tmuxManager } from "../services/tmux-manager";
 import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
+import { logCardEvent } from "../utils/card-events";
 
 export default defineNitroPlugin(async () => {
   if (!tmuxManager.isAvailable()) {
@@ -53,12 +54,14 @@ export default defineNitroPlugin(async () => {
         `Session reconnect: card ${cardId} status is "${card.status}", killing stale session`,
       );
       tmuxManager.killSession(sessionName);
+      await logCardEvent(cardId, "tmux_session_orphaned_killed", `session=${sessionName}, status=${card.status}`);
       continue;
     }
 
     // Card is running and session exists — resume capture
     if (tmuxManager.sessionExists(sessionName)) {
       logger.info(`Session reconnect: resuming capture for card ${cardId}`);
+      await logCardEvent(cardId, "tmux_session_reconnected", `session=${sessionName}`);
       tmuxManager.startCapture(sessionName, (output) => {
         eventBus.emit("agent:output", { cardId, content: output });
       });
@@ -75,6 +78,7 @@ export default defineNitroPlugin(async () => {
         .set({ status: "failed", endedAt: new Date() })
         .where(eq(workflowRuns.cardId, cardId));
 
+      await logCardEvent(cardId, "agent_failed", `session ${sessionName} died between list and check`);
       eventBus.emit("card:status-changed", { cardId, status: "failed" });
     }
   }
@@ -88,6 +92,7 @@ export default defineNitroPlugin(async () => {
       logger.warn(
         `Session reconnect: card ${card.id} is running but no tmux session, marking failed`,
       );
+      await logCardEvent(card.id, "agent_failed", "session not found on restart");
       await db
         .update(cards)
         .set({ status: "failed", updatedAt: new Date() })

--- a/plugins/tt-agentboard/server/services/agent-executor.ts
+++ b/plugins/tt-agentboard/server/services/agent-executor.ts
@@ -96,11 +96,19 @@ export class AgentExecutor {
 
     // Write .claude/settings.local.json with Stop hook in the slot directory
     writeHooks(slot.path, cardId, this.port, "complete");
+    await logCardEvent(cardId, "hooks_written", `endpoint=complete, path=${slot.path}`);
 
     await logCardEvent(cardId, "slot_claimed", `slotId=${slot.id}, path=${slot.path}`);
 
     // Create tmux session
-    const sessionName = tmuxManager.createSession(cardId, slot.path);
+    const { sessionName, created } = tmuxManager.createSession(cardId, slot.path);
+    if (created) {
+      await logCardEvent(
+        cardId,
+        "tmux_session_created",
+        `session=${sessionName}, cwd=${slot.path}`,
+      );
+    }
 
     // Branch handling
     const { execSync } = await import("node:child_process");
@@ -243,21 +251,24 @@ export class AgentExecutor {
     // TODO: add --verbose flag option
     // TODO: consider --append-system-prompt for card-level custom instructions
     const prompt = card.description ?? card.title;
-    const flags: string[] = ["-p"];
+    const systemPrompt =
+      "You are an autonomous agent. Complete the task fully without asking clarifying questions. " +
+      "Make your best judgment and implement the solution. Do not ask the user for confirmation — just do the work. " +
+      "IMPORTANT: When you are done, you MUST commit your changes with git add and git commit. Do not leave uncommitted files.";
+
+    const args: string[] = [];
     if (card.executionMode !== "interactive") {
-      flags.push("--dangerously-skip-permissions");
+      args.push("--dangerously-skip-permissions");
     }
-    flags.push("--max-turns", "50");
-    flags.push(
-      "--append-system-prompt",
-      shellEscape(
-        "You are an autonomous agent. Complete the task fully without asking clarifying questions. Make your best judgment and implement the solution. Do not ask the user for confirmation — just do the work. IMPORTANT: When you are done, you MUST commit your changes with git add and git commit. Do not leave uncommitted files.",
-      ),
-    );
-    const command = `claude ${flags.join(" ")} ${shellEscape(prompt)}`.trim();
+    args.push("--max-turns 50");
+    args.push(`--append-system-prompt ${shellEscape(systemPrompt)}`);
+    args.push(`-p ${shellEscape(prompt)}`);
+
+    const command = `claude \\\n  ${args.join(" \\\n  ")}`;
 
     // Send command to tmux session
     tmuxManager.sendCommand(sessionName, command);
+    await logCardEvent(cardId, "agent_command_sent", `session=${sessionName}`);
 
     // Start capturing output and forwarding via event bus
     tmuxManager.startCapture(sessionName, (output) => {

--- a/plugins/tt-agentboard/server/services/agent-executor.ts
+++ b/plugins/tt-agentboard/server/services/agent-executor.ts
@@ -8,7 +8,7 @@ import { workflowRunner } from "./workflow-runner";
 import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
 import { writeHooks } from "../utils/hook-writer";
-import { shellEscape } from "../utils/workflow-helpers";
+import { buildClaudeCommand, shellEscape } from "../utils/workflow-helpers";
 import { logCardEvent } from "../utils/card-events";
 
 /**
@@ -245,7 +245,6 @@ export class AgentExecutor {
       })
       .returning();
 
-    // Build the Claude Code command
     // TODO: add --model flag from card config
     // TODO: add --permission-mode instead of binary headless/interactive
     // TODO: add --verbose flag option
@@ -260,17 +259,15 @@ export class AgentExecutor {
     if (card.executionMode !== "interactive") {
       args.push("--dangerously-skip-permissions");
     }
-    args.push("--max-turns 50");
-    args.push(`--append-system-prompt ${shellEscape(systemPrompt)}`);
-    args.push(`-p ${shellEscape(prompt)}`);
+    args.push("--max-turns", "50");
+    args.push("--append-system-prompt", shellEscape(systemPrompt));
+    args.push("-p", shellEscape(prompt));
 
-    const command = `claude \\\n  ${args.join(" \\\n  ")}`;
+    const command = buildClaudeCommand(args);
 
-    // Send command to tmux session
     tmuxManager.sendCommand(sessionName, command);
     await logCardEvent(cardId, "agent_command_sent", `session=${sessionName}`);
 
-    // Start capturing output and forwarding via event bus
     tmuxManager.startCapture(sessionName, (output) => {
       eventBus.emit("agent:output", { cardId, content: output });
     });

--- a/plugins/tt-agentboard/server/services/tmux-manager.ts
+++ b/plugins/tt-agentboard/server/services/tmux-manager.ts
@@ -20,14 +20,14 @@ export class TmuxManager extends EventEmitter {
     }
   }
 
-  /** Create a named tmux session for a card */
-  createSession(cardId: number, cwd: string): string {
+  /** Create a named tmux session for a card. Returns { sessionName, created } */
+  createSession(cardId: number, cwd: string): { sessionName: string; created: boolean } {
     const sessionName = `card-${cardId}`;
 
     if (this.sessionExists(sessionName)) {
       logger.warn(`tmux session ${sessionName} already exists, reusing`);
       this.sessions.set(sessionName, { cardId });
-      return sessionName;
+      return { sessionName, created: false };
     }
 
     execSync(`tmux new-session -d -s ${sessionName} -c "${cwd}"`, {
@@ -35,7 +35,7 @@ export class TmuxManager extends EventEmitter {
     });
     this.sessions.set(sessionName, { cardId });
     logger.info(`Created tmux session: ${sessionName} in ${cwd}`);
-    return sessionName;
+    return { sessionName, created: true };
   }
 
   /** Send a command to a tmux session */
@@ -91,16 +91,19 @@ export class TmuxManager extends EventEmitter {
     }
   }
 
-  /** Kill a tmux session */
-  killSession(sessionName: string): void {
+  /** Kill a tmux session. Returns true if session was killed, false if already dead. */
+  killSession(sessionName: string): boolean {
     this.stopCapture(sessionName);
+    let killed = false;
     try {
       execSync(`tmux kill-session -t ${sessionName}`, { stdio: "ignore" });
+      killed = true;
     } catch {
       /* session may already be dead */
     }
     this.sessions.delete(sessionName);
     logger.info(`Killed tmux session: ${sessionName}`);
+    return killed;
   }
 
   /** List all agentboard tmux sessions (card-* prefix) */

--- a/plugins/tt-agentboard/server/services/tmux-manager.ts
+++ b/plugins/tt-agentboard/server/services/tmux-manager.ts
@@ -123,3 +123,7 @@ export class TmuxManager extends EventEmitter {
 }
 
 export const tmuxManager = new TmuxManager();
+
+export function cardSessionName(cardId: number): string {
+  return `card-${cardId}`;
+}

--- a/plugins/tt-agentboard/server/services/workflow-runner.ts
+++ b/plugins/tt-agentboard/server/services/workflow-runner.ts
@@ -12,7 +12,12 @@ import type { WorkflowDefinition, WorkflowStep } from "./workflow-loader";
 import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
 import { writeHooks } from "../utils/hook-writer";
-import { checkPassCondition, renderTemplate, shellEscape } from "../utils/workflow-helpers";
+import {
+  buildClaudeCommand,
+  checkPassCondition,
+  renderTemplate,
+  shellEscape,
+} from "../utils/workflow-helpers";
 import { logCardEvent } from "../utils/card-events";
 
 interface RunContext {
@@ -268,14 +273,12 @@ export class WorkflowRunner {
       // Build prompt
       const prompt = await this.buildStepPrompt(ctx, step);
 
-      // Build Claude Code command
       const args: string[] = ["--dangerously-skip-permissions"];
-      args.push("--max-turns 50");
-      if (step.model) args.push(`--model ${step.model}`);
-      args.push(`-p ${shellEscape(prompt)}`);
-      const command = `claude \\\n  ${args.join(" \\\n  ")}`;
+      args.push("--max-turns", "50");
+      if (step.model) args.push("--model", step.model);
+      args.push("-p", shellEscape(prompt));
+      const command = buildClaudeCommand(args);
 
-      // Send command to tmux
       tmuxManager.sendCommand(ctx.sessionName, command);
 
       // Wait for Stop hook callback (step-complete endpoint resolves this)
@@ -283,7 +286,11 @@ export class WorkflowRunner {
 
       if (!completed) {
         logger.warn(`Step ${step.id} timed out for card ${ctx.cardId}`);
-        await logCardEvent(ctx.cardId, "step_failed", `stepId=${step.id}, reason=timeout, retry=${retry}`);
+        await logCardEvent(
+          ctx.cardId,
+          "step_failed",
+          `stepId=${step.id}, reason=timeout, retry=${retry}`,
+        );
         await db
           .update(stepRuns)
           .set({ status: "failed", endedAt: new Date() })
@@ -312,7 +319,11 @@ export class WorkflowRunner {
       // Check for artifact after hook fired
       if (!existsSync(artifactPath)) {
         logger.warn(`Artifact not found at ${artifactPath} after step ${step.id} completed`);
-        await logCardEvent(ctx.cardId, "step_failed", `stepId=${step.id}, reason=artifact_missing, retry=${retry}`);
+        await logCardEvent(
+          ctx.cardId,
+          "step_failed",
+          `stepId=${step.id}, reason=artifact_missing, retry=${retry}`,
+        );
         await db
           .update(stepRuns)
           .set({ status: "failed", endedAt: new Date() })
@@ -336,7 +347,11 @@ export class WorkflowRunner {
       if (step.pass_condition) {
         const passed = checkPassCondition(step.pass_condition, artifactContent);
         if (!passed) {
-          await logCardEvent(ctx.cardId, "step_failed", `stepId=${step.id}, reason=pass_condition, retry=${retry}`);
+          await logCardEvent(
+            ctx.cardId,
+            "step_failed",
+            `stepId=${step.id}, reason=pass_condition, retry=${retry}`,
+          );
           await db
             .update(stepRuns)
             .set({ status: "failed", endedAt: new Date(), artifactPath })

--- a/plugins/tt-agentboard/server/services/workflow-runner.ts
+++ b/plugins/tt-agentboard/server/services/workflow-runner.ts
@@ -13,6 +13,7 @@ import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
 import { writeHooks } from "../utils/hook-writer";
 import { checkPassCondition, renderTemplate, shellEscape } from "../utils/workflow-helpers";
+import { logCardEvent } from "../utils/card-events";
 
 interface RunContext {
   cardId: number;
@@ -100,8 +101,12 @@ export class WorkflowRunner {
       // Cleanup
       pendingStepCallbacks.delete(ctx.cardId);
       tmuxManager.stopCapture(ctx.sessionName);
-      tmuxManager.killSession(ctx.sessionName);
+      const killed = tmuxManager.killSession(ctx.sessionName);
+      if (killed) {
+        await logCardEvent(ctx.cardId, "tmux_session_killed", `session=${ctx.sessionName}`);
+      }
       await slotAllocator.releaseSlot(ctx.slotId);
+      await logCardEvent(ctx.cardId, "slot_released", `slotId=${ctx.slotId}`);
     }
   }
 
@@ -157,7 +162,14 @@ export class WorkflowRunner {
     await this.updateCardStatus(cardId, "running");
 
     // Create tmux session
-    const sessionName = tmuxManager.createSession(cardId, slot.path);
+    const { sessionName, created } = tmuxManager.createSession(cardId, slot.path);
+    if (created) {
+      await logCardEvent(
+        cardId,
+        "tmux_session_created",
+        `session=${sessionName}, cwd=${slot.path}`,
+      );
+    }
 
     // Start output capture
     tmuxManager.startCapture(sessionName, (output) => {
@@ -247,17 +259,21 @@ export class WorkflowRunner {
         .where(eq(cards.id, ctx.cardId));
 
       eventBus.emit("step:started", { cardId: ctx.cardId, stepId: step.id });
+      await logCardEvent(ctx.cardId, "step_started", `stepId=${step.id}, retry=${retry}`);
 
       // Write Stop hook for this step — points to step-complete callback
       writeHooks(ctx.slotPath, ctx.cardId, this.port, "step-complete");
+      await logCardEvent(ctx.cardId, "hooks_written", `endpoint=step-complete, step=${step.id}`);
 
       // Build prompt
       const prompt = await this.buildStepPrompt(ctx, step);
 
       // Build Claude Code command
-      const modelFlag = step.model ? `--model ${step.model}` : "";
-      const command =
-        `claude -p ${shellEscape(prompt)} --dangerously-skip-permissions ${modelFlag}`.trim();
+      const args: string[] = ["--dangerously-skip-permissions"];
+      args.push("--max-turns 50");
+      if (step.model) args.push(`--model ${step.model}`);
+      args.push(`-p ${shellEscape(prompt)}`);
+      const command = `claude \\\n  ${args.join(" \\\n  ")}`;
 
       // Send command to tmux
       tmuxManager.sendCommand(ctx.sessionName, command);
@@ -267,6 +283,7 @@ export class WorkflowRunner {
 
       if (!completed) {
         logger.warn(`Step ${step.id} timed out for card ${ctx.cardId}`);
+        await logCardEvent(ctx.cardId, "step_failed", `stepId=${step.id}, reason=timeout, retry=${retry}`);
         await db
           .update(stepRuns)
           .set({ status: "failed", endedAt: new Date() })
@@ -295,6 +312,7 @@ export class WorkflowRunner {
       // Check for artifact after hook fired
       if (!existsSync(artifactPath)) {
         logger.warn(`Artifact not found at ${artifactPath} after step ${step.id} completed`);
+        await logCardEvent(ctx.cardId, "step_failed", `stepId=${step.id}, reason=artifact_missing, retry=${retry}`);
         await db
           .update(stepRuns)
           .set({ status: "failed", endedAt: new Date() })
@@ -318,6 +336,7 @@ export class WorkflowRunner {
       if (step.pass_condition) {
         const passed = checkPassCondition(step.pass_condition, artifactContent);
         if (!passed) {
+          await logCardEvent(ctx.cardId, "step_failed", `stepId=${step.id}, reason=pass_condition, retry=${retry}`);
           await db
             .update(stepRuns)
             .set({ status: "failed", endedAt: new Date(), artifactPath })
@@ -355,6 +374,7 @@ export class WorkflowRunner {
         .set({ currentStepId: `${step.id}:done`, updatedAt: new Date() })
         .where(eq(cards.id, ctx.cardId));
 
+      await logCardEvent(ctx.cardId, "step_completed", `stepId=${step.id}`);
       eventBus.emit("step:completed", {
         cardId: ctx.cardId,
         stepId: step.id,

--- a/plugins/tt-agentboard/server/utils/git.ts
+++ b/plugins/tt-agentboard/server/utils/git.ts
@@ -1,0 +1,19 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Run a git command. Returns stdout. Throws on error. */
+export async function gitRun(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout.trim();
+}
+
+/** Run a git command. Returns stdout or null on error. */
+export async function gitQuery(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    return await gitRun(cwd, args);
+  } catch {
+    return null;
+  }
+}

--- a/plugins/tt-agentboard/server/utils/hook-writer.ts
+++ b/plugins/tt-agentboard/server/utils/hook-writer.ts
@@ -35,6 +35,7 @@ export function writeHooks(
   settings.hooks = {
     ...(settings.hooks as Record<string, unknown> | undefined),
     Stop: httpHook(`${baseUrl}/${stopEndpoint}`),
+    StopFailure: httpHook(`${baseUrl}/failure`),
     Notification: httpHook(`${baseUrl}/notification`),
   };
 

--- a/plugins/tt-agentboard/server/utils/hook-writer.ts
+++ b/plugins/tt-agentboard/server/utils/hook-writer.ts
@@ -2,9 +2,13 @@ import { writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { logger } from "./logger";
 
+function httpHook(url: string) {
+  return [{ matcher: "", hooks: [{ type: "http", url }] }];
+}
+
 /**
  * Write .claude/settings.local.json with hooks that POST to AgentBoard
- * callback endpoints for lifecycle events: Stop, StopFailure, Notification.
+ * callback endpoints for lifecycle events: Stop, Notification.
  */
 export function writeHooks(
   slotPath: string,
@@ -27,12 +31,10 @@ export function writeHooks(
   }
 
   const baseUrl = `http://localhost:${port}/api/agents/${cardId}`;
-  const httpHook = (url: string) => [{ matcher: "", hooks: [{ type: "http", url }] }];
 
   settings.hooks = {
     ...(settings.hooks as Record<string, unknown> | undefined),
     Stop: httpHook(`${baseUrl}/${stopEndpoint}`),
-    StopFailure: httpHook(`${baseUrl}/failure`),
     Notification: httpHook(`${baseUrl}/notification`),
   };
 

--- a/plugins/tt-agentboard/server/utils/workflow-helpers.ts
+++ b/plugins/tt-agentboard/server/utils/workflow-helpers.ts
@@ -30,3 +30,8 @@ export function renderTemplate(template: string, vars: Record<string, string>): 
 export function shellEscape(str: string): string {
   return `'${str.replace(/'/g, "'\\''")}'`;
 }
+
+/** Build a multi-line claude CLI command from args */
+export function buildClaudeCommand(args: string[]): string {
+  return `claude \\\n  ${args.join(" \\\n  ")}`;
+}

--- a/plugins/tt-agentboard/test/plugins/session-reconnect.test.ts
+++ b/plugins/tt-agentboard/test/plugins/session-reconnect.test.ts
@@ -7,6 +7,7 @@ vi.mock("../../server/db", () => {
     chain.from = vi.fn().mockReturnValue(chain);
     chain.where = vi.fn().mockReturnValue(chain);
     chain.set = vi.fn().mockReturnValue(chain);
+    chain.values = vi.fn().mockResolvedValue(undefined);
     chain.limit = vi.fn().mockResolvedValue([]);
     return chain;
   };
@@ -15,9 +16,14 @@ vi.mock("../../server/db", () => {
     db: {
       select: vi.fn().mockReturnValue(mockChain()),
       update: vi.fn().mockReturnValue(mockChain()),
+      insert: vi.fn().mockReturnValue(mockChain()),
     },
   };
 });
+
+vi.mock("../../server/utils/card-events", () => ({
+  logCardEvent: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("../../server/utils/event-bus", () => ({
   eventBus: { emit: vi.fn(), on: vi.fn() },
@@ -61,6 +67,9 @@ async function runPlugin() {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   }));
   vi.doMock("../../server/services/tmux-manager", () => ({ tmuxManager }));
+  vi.doMock("../../server/utils/card-events", () => ({
+    logCardEvent: vi.fn().mockResolvedValue(undefined),
+  }));
 
   await import("../../server/plugins/session-reconnect");
 }

--- a/plugins/tt-agentboard/test/services/agent-executor.test.ts
+++ b/plugins/tt-agentboard/test/services/agent-executor.test.ts
@@ -37,7 +37,7 @@ vi.mock("../../server/utils/hook-writer", () => ({
 vi.mock("../../server/services/tmux-manager", () => ({
   tmuxManager: {
     isAvailable: vi.fn().mockReturnValue(true),
-    createSession: vi.fn().mockReturnValue("card-1"),
+    createSession: vi.fn().mockReturnValue({ sessionName: "card-1", created: true }),
     startCapture: vi.fn(),
     stopCapture: vi.fn(),
     killSession: vi.fn(),

--- a/plugins/tt-agentboard/test/services/tmux-manager.test.ts
+++ b/plugins/tt-agentboard/test/services/tmux-manager.test.ts
@@ -49,9 +49,9 @@ describe("TmuxManager", () => {
         return Buffer.from("");
       });
 
-      const name = manager.createSession(7, "/home/user/repo");
+      const result = manager.createSession(7, "/home/user/repo");
 
-      expect(name).toBe("card-7");
+      expect(result).toEqual({ sessionName: "card-7", created: true });
       expect(mockExecSync).toHaveBeenCalledWith(
         'tmux new-session -d -s card-7 -c "/home/user/repo"',
         { stdio: "ignore" },
@@ -62,9 +62,9 @@ describe("TmuxManager", () => {
       // sessionExists check succeeds
       mockExecSync.mockReturnValue(Buffer.from(""));
 
-      const name = manager.createSession(7, "/home/user/repo");
+      const result = manager.createSession(7, "/home/user/repo");
 
-      expect(name).toBe("card-7");
+      expect(result).toEqual({ sessionName: "card-7", created: false });
       // Should NOT have called new-session
       const newSessionCalls = mockExecSync.mock.calls.filter(
         (c) => typeof c[0] === "string" && c[0].includes("new-session"),

--- a/plugins/tt-agentboard/test/services/workflow-runner.test.ts
+++ b/plugins/tt-agentboard/test/services/workflow-runner.test.ts
@@ -42,7 +42,7 @@ vi.mock("../../server/utils/hook-writer", () => ({
 vi.mock("../../server/services/tmux-manager", () => ({
   tmuxManager: {
     isAvailable: vi.fn().mockReturnValue(true),
-    createSession: vi.fn().mockReturnValue("card-1"),
+    createSession: vi.fn().mockReturnValue({ sessionName: "card-1", created: true }),
     startCapture: vi.fn(),
     stopCapture: vi.fn(),
     killSession: vi.fn(),


### PR DESCRIPTION
## Summary

- **Safety guards**: Slot reset checks for dirty worktrees (`?force=true` to override), slot release blocks if tmux session is active
- **Bug fixes**: Restored StopFailure hook, fixed queue-manager race condition (started counter), use repo's defaultBranch instead of hardcoded `main`
- **Lifecycle improvements**: Better card event logging, repo data on cards, workspace slot git info/release/reset endpoints, auto-start ready cards on status changes
- **Code reuse**: Extracted `git.ts` utility, `buildClaudeCommand()`, `cardSessionName()`, `useCardUrls` composable
- **UI**: Restored compact mode guards in CardDetail, replaced slot polling with reactive watch
- **Docs**: system-flow.md architecture doc, CLAUDE.md updates

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 222 tests pass
- [x] `pnpm lint` — no new warnings
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)