### PR TITLE
feat: repo color labels and folder paths in dropdown

### DIFF
--- a/plugins/tt-agentboard/app/components/board/KanbanCard.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanCard.vue
@@ -91,7 +91,7 @@ watch(
 
     <!-- Repo + branch info -->
     <div v-if="card.repo" class="mb-2 flex flex-wrap items-center gap-1.5">
-      <SharedRepoBadge :name="card.repo.name" :org="card.repo.org" />
+      <SharedRepoBadge :name="card.repo.name" :org="card.repo.org" :repo-id="card.repoId" />
       <span
         v-if="card.branch"
         class="rounded bg-violet-500/10 px-1.5 py-0.5 text-[9px] font-mono text-violet-400"

--- a/plugins/tt-agentboard/app/components/board/NewCardForm.vue
+++ b/plugins/tt-agentboard/app/components/board/NewCardForm.vue
@@ -3,6 +3,7 @@ interface Repo {
   id: number;
   name: string;
   org: string | null;
+  slotPaths?: string[];
 }
 
 const props = defineProps<{
@@ -116,7 +117,12 @@ async function submit() {
           >
             <option :value="undefined">None</option>
             <option v-for="repo in repos" :key="repo.id" :value="repo.id">
-              {{ repo.org ? `${repo.org}/` : "" }}{{ repo.name }}
+              {{ repo.org ? `${repo.org}/` : "" }}{{ repo.name
+              }}{{
+                repo.slotPaths?.length
+                  ? ` (${repo.slotPaths.map((p) => p.split("/").pop()).join(", ")})`
+                  : ""
+              }}
             </option>
           </select>
           <p v-if="repos && repos.length === 0" class="mt-1.5 text-[11px] text-amber-500/80">

--- a/plugins/tt-agentboard/app/components/card/CardDetail.vue
+++ b/plugins/tt-agentboard/app/components/card/CardDetail.vue
@@ -50,7 +50,7 @@ function sendResponse() {
     </p>
 
     <div v-if="card.repo && !compact" class="mb-4">
-      <SharedRepoBadge :name="card.repo.name" :org="card.repo.org" />
+      <SharedRepoBadge :name="card.repo.name" :org="card.repo.org" :repo-id="card.repoId" />
     </div>
 
     <div

--- a/plugins/tt-agentboard/app/components/shared/RepoBadge.vue
+++ b/plugins/tt-agentboard/app/components/shared/RepoBadge.vue
@@ -1,14 +1,40 @@
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   name: string;
   org?: string | null;
+  repoId?: number | null;
 }>();
+
+const PALETTE = [
+  "bg-blue-500",
+  "bg-emerald-500",
+  "bg-amber-500",
+  "bg-rose-500",
+  "bg-violet-500",
+  "bg-cyan-500",
+  "bg-pink-500",
+  "bg-lime-500",
+  "bg-orange-500",
+  "bg-teal-500",
+  "bg-indigo-500",
+  "bg-fuchsia-500",
+];
+
+const colorClass = computed(() => {
+  if (props.repoId != null) {
+    return PALETTE[props.repoId % PALETTE.length];
+  }
+  const str = `${props.org ?? ""}/${props.name}`;
+  const hash = [...str].reduce((sum, ch) => sum + ch.charCodeAt(0), 0);
+  return PALETTE[hash % PALETTE.length];
+});
 </script>
 
 <template>
   <span
     class="inline-flex items-center gap-1 rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] font-mono text-zinc-400"
   >
+    <span class="h-2 w-2 shrink-0 rounded-full" :class="colorClass" />
     <svg
       class="h-3 w-3 text-zinc-500"
       fill="none"

--- a/plugins/tt-agentboard/server/api/repos/index.get.ts
+++ b/plugins/tt-agentboard/server/api/repos/index.get.ts
@@ -1,6 +1,21 @@
 import { db } from "~~/server/db";
-import { repositories } from "~~/server/db/schema";
+import { repositories, workspaceSlots } from "~~/server/db/schema";
 
 export default defineEventHandler(async () => {
-  return db.select().from(repositories);
+  const repos = await db.select().from(repositories);
+  const slots = await db
+    .select({ repoId: workspaceSlots.repoId, path: workspaceSlots.path })
+    .from(workspaceSlots);
+
+  const slotsByRepo = new Map<number, string[]>();
+  for (const slot of slots) {
+    const paths = slotsByRepo.get(slot.repoId) ?? [];
+    paths.push(slot.path);
+    slotsByRepo.set(slot.repoId, paths);
+  }
+
+  return repos.map((repo) => ({
+    ...repo,
+    slotPaths: slotsByRepo.get(repo.id) ?? [],
+  }));
 });


### PR DESCRIPTION
## Summary

- **Repo color dots**: RepoBadge now shows a deterministic colored dot based on repoId (12-color palette). Cards for the same repo share the same color across the board.
- **Folder paths in dropdown**: NewCardForm repo dropdown now shows workspace slot folder names alongside repo name (e.g. `org/repo (worktree-1, worktree-2)`), making slots for the same repo distinguishable.

## Changed files
- `RepoBadge.vue` — added repoId prop, color palette, colored dot
- `KanbanCard.vue` / `CardDetail.vue` — pass repoId to RepoBadge
- `NewCardForm.vue` — show slot paths in dropdown options
- `repos/index.get.ts` — return slotPaths with each repo

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 222 tests pass
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)