### PR TITLE
feat: stream structured Claude Code events with activity panel

### DIFF
--- a/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
+++ b/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
@@ -3,19 +3,24 @@ import type { AgentActivityEvent } from "~/composables/useWebSocket";
 
 const props = defineProps<{ cardId: number }>();
 
-interface ActivityEvent {
-  kind: "tool_use" | "thinking" | "text" | "result";
-  name?: string;
-  detail?: string;
-  input?: Record<string, unknown>;
-  summary?: string;
-  content?: string;
-  costUsd?: number;
-  durationMs?: number;
-  numTurns?: number;
-  isError?: boolean;
-  timestamp: number;
-}
+type ActivityEvent =
+  | {
+      kind: "tool_use";
+      name: string;
+      detail: string;
+      input: Record<string, unknown>;
+      timestamp: number;
+    }
+  | { kind: "thinking"; summary: string; timestamp: number }
+  | { kind: "text"; content: string; timestamp: number }
+  | {
+      kind: "result";
+      costUsd: number;
+      durationMs: number;
+      numTurns: number;
+      isError: boolean;
+      timestamp: number;
+    };
 
 const MAX_EVENTS = 500;
 const events = ref<ActivityEvent[]>([]);

--- a/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
+++ b/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import type { AgentActivityEvent } from "~/composables/useWebSocket";
+
+const props = defineProps<{ cardId: number }>();
+
+interface ActivityEvent {
+  kind: "tool_use" | "thinking" | "text" | "result";
+  name?: string;
+  detail?: string;
+  input?: Record<string, unknown>;
+  summary?: string;
+  content?: string;
+  costUsd?: number;
+  durationMs?: number;
+  numTurns?: number;
+  isError?: boolean;
+  timestamp: number;
+}
+
+const MAX_EVENTS = 500;
+const events = ref<ActivityEvent[]>([]);
+const container = ref<HTMLElement>();
+const autoScroll = ref(true);
+
+const { on, off, subscribeActivity, unsubscribeActivity } = useWebSocket();
+
+function handleActivity(raw: { type: string; [key: string]: unknown }) {
+  const evt = raw as unknown as AgentActivityEvent;
+  if (evt.cardId !== props.cardId) return;
+
+  const activity: ActivityEvent = {
+    ...evt.event,
+    timestamp: evt.timestamp,
+  };
+
+  events.value.push(activity);
+  if (events.value.length > MAX_EVENTS) {
+    events.value = events.value.slice(-MAX_EVENTS);
+  }
+
+  if (autoScroll.value) {
+    nextTick(() => {
+      container.value?.scrollTo({ top: container.value.scrollHeight });
+    });
+  }
+}
+
+function handleScroll() {
+  if (!container.value) return;
+  const { scrollTop, scrollHeight, clientHeight } = container.value;
+  autoScroll.value = scrollHeight - scrollTop - clientHeight < 40;
+}
+
+onMounted(() => {
+  subscribeActivity(props.cardId);
+  on("agent:activity", handleActivity);
+});
+
+onUnmounted(() => {
+  off("agent:activity", handleActivity);
+  unsubscribeActivity(props.cardId);
+});
+</script>
+
+<template>
+  <div ref="container" class="h-full overflow-y-auto p-4 space-y-2" @scroll="handleScroll">
+    <div v-if="events.length === 0" class="text-zinc-500 text-sm">
+      Waiting for agent activity...
+    </div>
+    <div v-for="(event, i) in events" :key="i" class="text-sm">
+      <!-- Tool use -->
+      <div v-if="event.kind === 'tool_use'" class="flex items-start gap-2 py-1">
+        <span class="text-blue-400 font-mono text-xs shrink-0">▶</span>
+        <span class="font-mono text-blue-300">{{ event.name }}</span>
+        <span class="text-zinc-500 truncate">{{ event.detail }}</span>
+      </div>
+      <!-- Thinking -->
+      <div v-else-if="event.kind === 'thinking'" class="py-1 text-zinc-500 italic truncate">
+        {{ event.summary }}
+      </div>
+      <!-- Text output -->
+      <div v-else-if="event.kind === 'text'" class="py-1 text-zinc-300">
+        {{ event.content }}
+      </div>
+      <!-- Result -->
+      <div v-else-if="event.kind === 'result'" class="py-2 border-t border-zinc-700 mt-2">
+        <span :class="event.isError ? 'text-red-400' : 'text-emerald-400'">
+          {{ event.isError ? "Failed" : "Completed" }}
+        </span>
+        <span class="text-zinc-500 ml-2">
+          {{ event.numTurns }} turns · ${{ event.costUsd?.toFixed(4) }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/plugins/tt-agentboard/app/composables/useWebSocket.ts
+++ b/plugins/tt-agentboard/app/composables/useWebSocket.ts
@@ -26,6 +26,16 @@ export interface AgentOutputEvent extends BoardEvent {
   content: string;
 }
 
+export interface AgentActivityEvent extends BoardEvent {
+  type: "agent:activity";
+  cardId: number;
+  event: {
+    kind: "tool_use" | "thinking" | "text" | "result";
+    [key: string]: unknown;
+  };
+  timestamp: number;
+}
+
 export interface WorkflowCompletedEvent extends BoardEvent {
   type: "workflow:completed";
   cardId: number;
@@ -151,6 +161,16 @@ function unsubscribeTerminal(cardId: number) {
   send({ type: "unsubscribe-terminal", cardId });
 }
 
+/** Subscribe to activity events for a specific card */
+function subscribeActivity(cardId: number) {
+  send({ type: "subscribe-activity", cardId });
+}
+
+/** Unsubscribe from activity events for a specific card */
+function unsubscribeActivity(cardId: number) {
+  send({ type: "unsubscribe-activity", cardId });
+}
+
 /**
  * Integrate with useCards — update card list reactively from WebSocket events.
  * Returns a cleanup function.
@@ -213,6 +233,8 @@ export function useWebSocket() {
     send,
     subscribeTerminal,
     unsubscribeTerminal,
+    subscribeActivity,
+    unsubscribeActivity,
     bindCards,
     connect,
     disconnect,

--- a/plugins/tt-agentboard/app/pages/cards/[id].vue
+++ b/plugins/tt-agentboard/app/pages/cards/[id].vue
@@ -7,7 +7,7 @@ const cardId = computed(() => Number(route.params.id));
 const { data: card, refresh } = await useFetch<Card>(`/api/cards/${cardId.value}`);
 
 const router = useRouter();
-const activeTab = ref<"terminal" | "diff">("terminal");
+const activeTab = ref<"terminal" | "diff" | "activity">("terminal");
 
 // Default to diff tab for review_ready cards
 watch(
@@ -115,11 +115,23 @@ onUnmounted(() => {
           >
             Diff
           </button>
+          <button
+            class="px-4 py-2 text-xs font-medium transition-colors"
+            :class="
+              activeTab === 'activity'
+                ? 'border-b-2 border-emerald-500 text-zinc-200'
+                : 'text-zinc-500 hover:text-zinc-300'
+            "
+            @click="activeTab = 'activity'"
+          >
+            Activity
+          </button>
         </div>
         <div class="flex-1 p-4 sm:p-6">
           <ClientOnly>
             <CardTerminalPanel v-if="activeTab === 'terminal'" :card-id="cardId" />
-            <CardDiffViewer v-else :card-id="cardId" />
+            <CardDiffViewer v-else-if="activeTab === 'diff'" :card-id="cardId" />
+            <CardActivityPanel v-else-if="activeTab === 'activity'" :card-id="cardId" />
           </ClientOnly>
         </div>
       </div>

--- a/plugins/tt-agentboard/server/routes/ws.ts
+++ b/plugins/tt-agentboard/server/routes/ws.ts
@@ -47,6 +47,7 @@ const forwardedEvents = [
   "slot:claimed",
   "slot:released",
   "agent:output",
+  "agent:activity",
   "agent:waiting",
   "workflow:completed",
   "github:issue-found",
@@ -97,6 +98,19 @@ export default defineWebSocketHandler({
         if (peers.size === 0) {
           tmuxManager.stopCapture(`card-${data.cardId}`);
         }
+      }
+    }
+
+    if (data.type === "subscribe-activity") {
+      const cardId = data.cardId;
+      addSubscription(`card:${cardId}`, peer);
+    }
+
+    if (data.type === "unsubscribe-activity") {
+      const channel = `card:${data.cardId}`;
+      const peers = subscribers.get(channel);
+      if (peers) {
+        peers.delete(peer);
       }
     }
   },

--- a/plugins/tt-agentboard/server/services/agent-executor.ts
+++ b/plugins/tt-agentboard/server/services/agent-executor.ts
@@ -10,6 +10,7 @@ import { logger } from "../utils/logger";
 import { writeHooks } from "../utils/hook-writer";
 import { buildClaudeCommand, shellEscape } from "../utils/workflow-helpers";
 import { logCardEvent } from "../utils/card-events";
+import { streamTailer } from "./stream-tailer";
 
 /**
  * Handles single agent execution: claim slot, configure Stop hook,
@@ -259,14 +260,19 @@ export class AgentExecutor {
     if (card.executionMode !== "interactive") {
       args.push("--dangerously-skip-permissions");
     }
+    args.push("--output-format", "stream-json");
     args.push("--max-turns", "50");
     args.push("--append-system-prompt", shellEscape(systemPrompt));
     args.push("-p", shellEscape(prompt));
 
-    const command = buildClaudeCommand(args);
+    const logFilePath = join(slot.path, ".claude-stream.ndjson");
+    const command = `${buildClaudeCommand(args)} 2>&1 | tee ${shellEscape(logFilePath)}`;
 
     tmuxManager.sendCommand(sessionName, command);
     await logCardEvent(cardId, "agent_command_sent", `session=${sessionName}`);
+
+    // Start tailing the stream-json output for structured activity events
+    await streamTailer.startTailing(cardId, logFilePath);
 
     tmuxManager.startCapture(sessionName, (output) => {
       eventBus.emit("agent:output", { cardId, content: output });

--- a/plugins/tt-agentboard/server/services/agent-executor.ts
+++ b/plugins/tt-agentboard/server/services/agent-executor.ts
@@ -8,7 +8,7 @@ import { workflowRunner } from "./workflow-runner";
 import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
 import { writeHooks } from "../utils/hook-writer";
-import { buildClaudeCommand, shellEscape } from "../utils/workflow-helpers";
+import { buildStreamingCommand, shellEscape } from "../utils/workflow-helpers";
 import { logCardEvent } from "../utils/card-events";
 import { streamTailer } from "./stream-tailer";
 
@@ -260,13 +260,12 @@ export class AgentExecutor {
     if (card.executionMode !== "interactive") {
       args.push("--dangerously-skip-permissions");
     }
-    args.push("--output-format", "stream-json", "--verbose");
     args.push("--max-turns", "50");
     args.push("--append-system-prompt", shellEscape(systemPrompt));
     args.push("-p", shellEscape(prompt));
 
     const logFilePath = join(slot.path, ".claude-stream.ndjson");
-    const command = `${buildClaudeCommand(args)} 2>&1 | tee ${shellEscape(logFilePath)}`;
+    const command = buildStreamingCommand(args, logFilePath);
 
     tmuxManager.sendCommand(sessionName, command);
     await logCardEvent(cardId, "agent_command_sent", `session=${sessionName}`);

--- a/plugins/tt-agentboard/server/services/agent-executor.ts
+++ b/plugins/tt-agentboard/server/services/agent-executor.ts
@@ -260,7 +260,7 @@ export class AgentExecutor {
     if (card.executionMode !== "interactive") {
       args.push("--dangerously-skip-permissions");
     }
-    args.push("--output-format", "stream-json");
+    args.push("--output-format", "stream-json", "--verbose");
     args.push("--max-turns", "50");
     args.push("--append-system-prompt", shellEscape(systemPrompt));
     args.push("-p", shellEscape(prompt));

--- a/plugins/tt-agentboard/server/services/stream-tailer.ts
+++ b/plugins/tt-agentboard/server/services/stream-tailer.ts
@@ -1,0 +1,116 @@
+import type { FSWatcher } from "node:fs";
+import { watch as fsWatch, createReadStream } from "node:fs";
+import { open } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import { parseStreamLine } from "../utils/stream-parser";
+import { eventBus } from "../utils/event-bus";
+import { logger } from "../utils/logger";
+
+interface TailHandle {
+  close: () => void;
+}
+
+class StreamTailer {
+  private tailers = new Map<number, TailHandle>();
+
+  async startTailing(cardId: number, logFilePath: string): Promise<void> {
+    this.stopTailing(cardId);
+
+    let offset = 0;
+    let watcher: FSWatcher | null = null;
+    let closed = false;
+    let reading = false;
+
+    const readNewLines = async () => {
+      if (closed || reading) return;
+      reading = true;
+
+      try {
+        const fh = await open(logFilePath, "r");
+        const stat = await fh.stat();
+
+        if (stat.size <= offset) {
+          await fh.close();
+          reading = false;
+          return;
+        }
+
+        const stream = createReadStream(logFilePath, {
+          start: offset,
+          encoding: "utf-8",
+        });
+        const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+        let newOffset = offset;
+
+        for await (const line of rl) {
+          // +1 for the newline character
+          newOffset += Buffer.byteLength(line, "utf-8") + 1;
+
+          const event = parseStreamLine(line);
+          if (event) {
+            eventBus.emit("agent:activity", {
+              cardId,
+              event,
+              timestamp: Date.now(),
+            });
+          }
+        }
+
+        offset = newOffset;
+        await fh.close();
+      } catch (err) {
+        if (!closed) {
+          logger.warn(`Stream tailer read error for card ${cardId}:`, err);
+        }
+      }
+
+      reading = false;
+    };
+
+    // Initial read from start of file
+    await readNewLines();
+
+    // Watch for file changes
+    try {
+      watcher = fsWatch(logFilePath, () => {
+        readNewLines();
+      });
+
+      watcher.on("error", (err) => {
+        if (!closed) {
+          logger.warn(`Stream tailer watcher error for card ${cardId}:`, err);
+        }
+      });
+    } catch (err) {
+      logger.warn(`Could not watch ${logFilePath} for card ${cardId}:`, err);
+    }
+
+    const handle: TailHandle = {
+      close: () => {
+        closed = true;
+        watcher?.close();
+      },
+    };
+
+    this.tailers.set(cardId, handle);
+    logger.info(`Started stream tailing for card ${cardId}: ${logFilePath}`);
+  }
+
+  stopTailing(cardId: number): void {
+    const handle = this.tailers.get(cardId);
+    if (handle) {
+      handle.close();
+      this.tailers.delete(cardId);
+      logger.info(`Stopped stream tailing for card ${cardId}`);
+    }
+  }
+
+  stopAll(): void {
+    for (const [cardId] of this.tailers) {
+      this.stopTailing(cardId);
+    }
+  }
+}
+
+export const streamTailer = new StreamTailer();

--- a/plugins/tt-agentboard/server/services/stream-tailer.ts
+++ b/plugins/tt-agentboard/server/services/stream-tailer.ts
@@ -1,6 +1,5 @@
 import type { FSWatcher } from "node:fs";
-import { watch as fsWatch, createReadStream } from "node:fs";
-import { open } from "node:fs/promises";
+import { watch as fsWatch, createReadStream, statSync } from "node:fs";
 import { createInterface } from "node:readline";
 import { parseStreamLine } from "../utils/stream-parser";
 import { eventBus } from "../utils/event-bus";
@@ -26,11 +25,8 @@ class StreamTailer {
       reading = true;
 
       try {
-        const fh = await open(logFilePath, "r");
-        const stat = await fh.stat();
-
-        if (stat.size <= offset) {
-          await fh.close();
+        const fileSize = statSync(logFilePath).size;
+        if (fileSize <= offset) {
           reading = false;
           return;
         }
@@ -41,12 +37,7 @@ class StreamTailer {
         });
         const rl = createInterface({ input: stream, crlfDelay: Infinity });
 
-        let newOffset = offset;
-
         for await (const line of rl) {
-          // +1 for the newline character
-          newOffset += Buffer.byteLength(line, "utf-8") + 1;
-
           const event = parseStreamLine(line);
           if (event) {
             eventBus.emit("agent:activity", {
@@ -57,8 +48,8 @@ class StreamTailer {
           }
         }
 
-        offset = newOffset;
-        await fh.close();
+        // Use actual file size as offset — avoids CRLF byte-counting issues
+        offset = fileSize;
       } catch (err) {
         if (!closed) {
           logger.warn(`Stream tailer read error for card ${cardId}:`, err);

--- a/plugins/tt-agentboard/server/services/workflow-runner.ts
+++ b/plugins/tt-agentboard/server/services/workflow-runner.ts
@@ -2,7 +2,7 @@ import { db } from "../db";
 import { cards, workflowRuns, stepRuns, repositories } from "../db/schema";
 import { eq } from "drizzle-orm";
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
 import { execSync } from "node:child_process";
 import { tmuxManager } from "./tmux-manager";
 import { slotAllocator } from "./slot-allocator";
@@ -19,6 +19,7 @@ import {
   shellEscape,
 } from "../utils/workflow-helpers";
 import { logCardEvent } from "../utils/card-events";
+import { streamTailer } from "./stream-tailer";
 
 interface RunContext {
   cardId: number;
@@ -105,6 +106,7 @@ export class WorkflowRunner {
     } finally {
       // Cleanup
       pendingStepCallbacks.delete(ctx.cardId);
+      streamTailer.stopTailing(ctx.cardId);
       tmuxManager.stopCapture(ctx.sessionName);
       const killed = tmuxManager.killSession(ctx.sessionName);
       if (killed) {
@@ -274,12 +276,18 @@ export class WorkflowRunner {
       const prompt = await this.buildStepPrompt(ctx, step);
 
       const args: string[] = ["--dangerously-skip-permissions"];
+      args.push("--output-format", "stream-json");
       args.push("--max-turns", "50");
       if (step.model) args.push("--model", step.model);
       args.push("-p", shellEscape(prompt));
-      const command = buildClaudeCommand(args);
+
+      const logFilePath = join(ctx.slotPath, ".claude-stream.ndjson");
+      const command = `${buildClaudeCommand(args)} 2>&1 | tee ${shellEscape(logFilePath)}`;
 
       tmuxManager.sendCommand(ctx.sessionName, command);
+
+      // Start tailing the stream-json output for structured activity events
+      await streamTailer.startTailing(ctx.cardId, logFilePath);
 
       // Wait for Stop hook callback (step-complete endpoint resolves this)
       const completed = await this.waitForStepComplete(ctx.cardId);

--- a/plugins/tt-agentboard/server/services/workflow-runner.ts
+++ b/plugins/tt-agentboard/server/services/workflow-runner.ts
@@ -276,7 +276,7 @@ export class WorkflowRunner {
       const prompt = await this.buildStepPrompt(ctx, step);
 
       const args: string[] = ["--dangerously-skip-permissions"];
-      args.push("--output-format", "stream-json");
+      args.push("--output-format", "stream-json", "--verbose");
       args.push("--max-turns", "50");
       if (step.model) args.push("--model", step.model);
       args.push("-p", shellEscape(prompt));

--- a/plugins/tt-agentboard/server/services/workflow-runner.ts
+++ b/plugins/tt-agentboard/server/services/workflow-runner.ts
@@ -13,7 +13,7 @@ import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
 import { writeHooks } from "../utils/hook-writer";
 import {
-  buildClaudeCommand,
+  buildStreamingCommand,
   checkPassCondition,
   renderTemplate,
   shellEscape,
@@ -276,13 +276,12 @@ export class WorkflowRunner {
       const prompt = await this.buildStepPrompt(ctx, step);
 
       const args: string[] = ["--dangerously-skip-permissions"];
-      args.push("--output-format", "stream-json", "--verbose");
       args.push("--max-turns", "50");
       if (step.model) args.push("--model", step.model);
       args.push("-p", shellEscape(prompt));
 
       const logFilePath = join(ctx.slotPath, ".claude-stream.ndjson");
-      const command = `${buildClaudeCommand(args)} 2>&1 | tee ${shellEscape(logFilePath)}`;
+      const command = buildStreamingCommand(args, logFilePath);
 
       tmuxManager.sendCommand(ctx.sessionName, command);
 

--- a/plugins/tt-agentboard/server/utils/event-bus.ts
+++ b/plugins/tt-agentboard/server/utils/event-bus.ts
@@ -11,6 +11,7 @@ export const eventBus = new EventEmitter();
 // 'slot:claimed'        { slotId, cardId }
 // 'slot:released'       { slotId }
 // 'agent:output'        { cardId, content }
+// 'agent:activity'      { cardId, event: AgentActivityEvent, timestamp }
 // 'agent:waiting'       { cardId, question }
 // 'workflow:completed'  { cardId, status }
 // 'github:issue-found'  { issueNumber, repoId }

--- a/plugins/tt-agentboard/server/utils/stream-parser.ts
+++ b/plugins/tt-agentboard/server/utils/stream-parser.ts
@@ -1,0 +1,157 @@
+export interface AgentToolEvent {
+  kind: "tool_use";
+  name: string;
+  detail: string;
+  input: Record<string, unknown>;
+}
+
+export interface AgentThinkingEvent {
+  kind: "thinking";
+  summary: string;
+}
+
+export interface AgentTextEvent {
+  kind: "text";
+  content: string;
+}
+
+export interface AgentResultEvent {
+  kind: "result";
+  costUsd: number;
+  durationMs: number;
+  numTurns: number;
+  isError: boolean;
+}
+
+export type AgentActivityEvent =
+  | AgentToolEvent
+  | AgentThinkingEvent
+  | AgentTextEvent
+  | AgentResultEvent;
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + "\u2026" : s;
+}
+
+function toolDetail(block: Record<string, unknown>): string {
+  const input =
+    typeof block.input === "object" && block.input !== null
+      ? (block.input as Record<string, unknown>)
+      : null;
+  if (!input) return "";
+
+  const filePath = input.file_path ?? input.path;
+  if (typeof filePath === "string") {
+    let detail = filePath;
+    if (typeof input.old_string === "string" && typeof input.new_string === "string") {
+      const old = truncate(input.old_string.split("\n")[0].trim(), 40);
+      const replacement = truncate(input.new_string.split("\n")[0].trim(), 40);
+      detail += ` "${old}" -> "${replacement}"`;
+    }
+    return detail;
+  }
+  if (typeof input.pattern === "string") return input.pattern;
+  if (typeof input.command === "string") return truncate(input.command, 60);
+  if (typeof input.subject === "string") return truncate(input.subject, 60);
+  return "";
+}
+
+/** Parse a single NDJSON line from Claude Code's stream-json output */
+export function parseStreamLine(line: string): AgentActivityEvent | null {
+  if (!line.trim()) return null;
+
+  let event: Record<string, unknown>;
+  try {
+    event = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  // Result event — top-level with result/is_error/num_turns
+  if ("result" in event && "is_error" in event && "num_turns" in event) {
+    return {
+      kind: "result",
+      costUsd: Number(event.cost_usd ?? event.total_cost_usd ?? 0),
+      durationMs: Number(event.duration_ms ?? 0),
+      numTurns: Number(event.num_turns),
+      isError: Boolean(event.is_error),
+    };
+  }
+
+  // Stream events — tool_use, thinking, text inside content_block_start
+  if (event.type === "stream_event" && typeof event.event === "object" && event.event !== null) {
+    const inner = event.event as Record<string, unknown>;
+
+    if (
+      inner.type === "content_block_start" &&
+      typeof inner.content_block === "object" &&
+      inner.content_block !== null
+    ) {
+      const block = inner.content_block as Record<string, unknown>;
+
+      if (block.type === "tool_use" && typeof block.name === "string") {
+        return {
+          kind: "tool_use",
+          name: block.name,
+          detail: toolDetail(block),
+          input:
+            typeof block.input === "object" && block.input !== null
+              ? (block.input as Record<string, unknown>)
+              : {},
+        };
+      }
+
+      if (block.type === "thinking") {
+        const text = typeof block.thinking === "string" ? block.thinking : "";
+        return {
+          kind: "thinking",
+          summary: truncate(text.split("\n")[0].trim(), 120),
+        };
+      }
+
+      if (block.type === "text" && typeof block.text === "string") {
+        return {
+          kind: "text",
+          content: block.text,
+        };
+      }
+    }
+  }
+
+  // Assistant message events — content array with tool_use/thinking/text
+  if (event.type === "assistant" && typeof event.message === "object" && event.message !== null) {
+    const message = event.message as Record<string, unknown>;
+    if (Array.isArray(message.content) && message.content.length > 0) {
+      const block = message.content[0] as Record<string, unknown>;
+
+      if (block.type === "tool_use" && typeof block.name === "string") {
+        return {
+          kind: "tool_use",
+          name: block.name,
+          detail: toolDetail(block),
+          input:
+            typeof block.input === "object" && block.input !== null
+              ? (block.input as Record<string, unknown>)
+              : {},
+        };
+      }
+
+      if (block.type === "thinking") {
+        const text = typeof block.thinking === "string" ? block.thinking : "";
+        return {
+          kind: "thinking",
+          summary: truncate(text.split("\n")[0].trim(), 120),
+        };
+      }
+
+      if (block.type === "text" && typeof block.text === "string") {
+        return {
+          kind: "text",
+          content: block.text,
+        };
+      }
+    }
+  }
+
+  return null;
+}

--- a/plugins/tt-agentboard/server/utils/workflow-helpers.ts
+++ b/plugins/tt-agentboard/server/utils/workflow-helpers.ts
@@ -35,3 +35,9 @@ export function shellEscape(str: string): string {
 export function buildClaudeCommand(args: string[]): string {
   return `claude \\\n  ${args.join(" \\\n  ")}`;
 }
+
+/** Build a claude command with stream-json output piped to a log file via tee */
+export function buildStreamingCommand(args: string[], logFilePath: string): string {
+  args.push("--output-format", "stream-json", "--verbose");
+  return `${buildClaudeCommand(args)} 2>&1 | tee ${shellEscape(logFilePath)}`;
+}

--- a/plugins/tt-agentboard/test/integration/stream-json.test.ts
+++ b/plugins/tt-agentboard/test/integration/stream-json.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { readFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseStreamLine } from "../../server/utils/stream-parser";
+import type { AgentActivityEvent } from "../../server/utils/stream-parser";
+
+/**
+ * Integration test: runs `claude` with `--output-format stream-json` using Haiku,
+ * captures NDJSON output, and verifies the parser handles real Claude output.
+ *
+ * Requires: `claude` CLI available and authenticated.
+ */
+describe("Stream JSON Integration (Haiku)", { timeout: 90_000 }, () => {
+  const testDir = join(tmpdir(), `stream-json-test-${Date.now()}`);
+  const outputFile = join(testDir, "output.ndjson");
+
+  function runClaude(prompt: string): string {
+    mkdirSync(testDir, { recursive: true });
+    try {
+      execSync(
+        `claude --model claude-haiku-4-5-20251001 --output-format stream-json --verbose -p ${JSON.stringify(prompt)} --max-turns 2 < /dev/null > ${JSON.stringify(outputFile)} 2>&1`,
+        {
+          timeout: 60_000,
+          cwd: testDir,
+          env: { ...process.env, HOME: process.env.HOME },
+        },
+      );
+    } catch {
+      // claude may exit non-zero; output file should still have content
+    }
+
+    if (!existsSync(outputFile)) return "";
+    return readFileSync(outputFile, "utf-8");
+  }
+
+  function parseAllLines(raw: string): AgentActivityEvent[] {
+    return raw
+      .split("\n")
+      .filter((line) => line.trim())
+      .map(parseStreamLine)
+      .filter((e): e is AgentActivityEvent => e !== null);
+  }
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("produces parseable NDJSON with text events from a simple prompt", () => {
+    const raw = runClaude("Say exactly: hello world. Nothing else.");
+    expect(raw.length).toBeGreaterThan(0);
+
+    const events = parseAllLines(raw);
+    expect(events.length).toBeGreaterThan(0);
+
+    const textEvents = events.filter((e) => e.kind === "text");
+    expect(textEvents.length).toBeGreaterThan(0);
+
+    const textContent = textEvents.map((e) => (e as { content: string }).content).join("");
+    expect(textContent.toLowerCase()).toContain("hello");
+  });
+
+  it("produces tool_use events when tools are invoked", () => {
+    const raw = runClaude(
+      "List the files in the current directory using the Bash tool. Run: ls -la",
+    );
+    expect(raw.length).toBeGreaterThan(0);
+
+    const events = parseAllLines(raw);
+    expect(events.length).toBeGreaterThan(0);
+
+    const kinds = new Set(events.map((e) => e.kind));
+    expect(kinds.size).toBeGreaterThan(0);
+
+    const toolEvents = events.filter((e) => e.kind === "tool_use");
+    for (const event of toolEvents) {
+      if (event.kind === "tool_use") {
+        expect(event.name).toBeTruthy();
+        expect(typeof event.detail).toBe("string");
+        expect(typeof event.input).toBe("object");
+      }
+    }
+  });
+
+  it("produces a result event at the end of the stream", () => {
+    const raw = runClaude("Reply with just the word 'done'.");
+    const events = parseAllLines(raw);
+
+    const resultEvents = events.filter((e) => e.kind === "result");
+    expect(resultEvents.length).toBeGreaterThanOrEqual(1);
+
+    const result = resultEvents[resultEvents.length - 1];
+    if (result.kind === "result") {
+      expect(typeof result.numTurns).toBe("number");
+      expect(typeof result.isError).toBe("boolean");
+      expect(typeof result.costUsd).toBe("number");
+      expect(result.numTurns).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("cleanly handles every line without throwing", () => {
+    const raw = runClaude("What is 2+2? Answer briefly.");
+    const lines = raw.split("\n").filter((l) => l.trim());
+
+    for (const line of lines) {
+      expect(() => parseStreamLine(line)).not.toThrow();
+    }
+  });
+});

--- a/plugins/tt-agentboard/test/integration/stream-json.test.ts
+++ b/plugins/tt-agentboard/test/integration/stream-json.test.ts
@@ -20,7 +20,7 @@ describe("Stream JSON Integration (Haiku)", { timeout: 90_000 }, () => {
     mkdirSync(testDir, { recursive: true });
     try {
       execSync(
-        `claude --model claude-haiku-4-5-20251001 --output-format stream-json --verbose -p ${JSON.stringify(prompt)} --max-turns 2 < /dev/null > ${JSON.stringify(outputFile)} 2>&1`,
+        `claude --model haiku --output-format stream-json --verbose -p ${JSON.stringify(prompt)} --max-turns 2 < /dev/null > ${JSON.stringify(outputFile)} 2>&1`,
         {
           timeout: 60_000,
           cwd: testDir,

--- a/plugins/tt-agentboard/test/services/stream-tailer.test.ts
+++ b/plugins/tt-agentboard/test/services/stream-tailer.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("../../server/utils/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const emittedEvents: Array<{ cardId: number; event: unknown; timestamp: number }> = [];
+
+vi.mock("../../server/utils/event-bus", () => ({
+  eventBus: {
+    emit: vi.fn((type: string, data: unknown) => {
+      if (type === "agent:activity") {
+        emittedEvents.push(data as { cardId: number; event: unknown; timestamp: number });
+      }
+    }),
+  },
+}));
+
+describe("StreamTailer", () => {
+  let testDir: string;
+  let logFile: string;
+  let streamTailer: (typeof import("../../server/services/stream-tailer"))["streamTailer"];
+
+  beforeEach(async () => {
+    emittedEvents.length = 0;
+
+    testDir = join(tmpdir(), `stream-tailer-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    logFile = join(testDir, "test.ndjson");
+    writeFileSync(logFile, "");
+
+    // Fresh import each test to reset singleton state
+    vi.resetModules();
+    const mod = await import("../../server/services/stream-tailer");
+    streamTailer = mod.streamTailer;
+  });
+
+  afterEach(() => {
+    streamTailer.stopAll();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("parses existing lines from file on start", async () => {
+    const toolLine = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", name: "Read", input: { file_path: "/tmp/test.ts" } }],
+      },
+    });
+    writeFileSync(logFile, toolLine + "\n");
+
+    await streamTailer.startTailing(1, logFile);
+
+    // Give a small delay for async processing
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(emittedEvents.length).toBeGreaterThanOrEqual(1);
+    const event = emittedEvents[0];
+    expect(event.cardId).toBe(1);
+    expect((event.event as { kind: string }).kind).toBe("tool_use");
+    expect((event.event as { name: string }).name).toBe("Read");
+  });
+
+  it("picks up new lines appended after tailing starts", async () => {
+    await streamTailer.startTailing(2, logFile);
+
+    // Append a line after tailing started
+    const resultLine = JSON.stringify({
+      result: "Done",
+      is_error: false,
+      num_turns: 3,
+      cost_usd: 0.01,
+      duration_ms: 5000,
+    });
+    appendFileSync(logFile, resultLine + "\n");
+
+    // Wait for fs.watch to trigger and process
+    await new Promise((r) => setTimeout(r, 500));
+
+    const resultEvents = emittedEvents.filter(
+      (e) => (e.event as { kind: string }).kind === "result",
+    );
+    expect(resultEvents.length).toBeGreaterThanOrEqual(1);
+    expect(resultEvents[0].cardId).toBe(2);
+  });
+
+  it("parses multiple event types in sequence", async () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "thinking", thinking: "Planning the approach" }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", name: "Bash", input: { command: "ls -la" } }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Here is what I found" }],
+        },
+      }),
+    ];
+    writeFileSync(logFile, lines.join("\n") + "\n");
+
+    await streamTailer.startTailing(3, logFile);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const kinds = emittedEvents.map((e) => (e.event as { kind: string }).kind);
+    expect(kinds).toContain("thinking");
+    expect(kinds).toContain("tool_use");
+    expect(kinds).toContain("text");
+  });
+
+  it("skips non-parseable lines without crashing", async () => {
+    const lines = [
+      "not valid json",
+      JSON.stringify({ type: "ping" }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", name: "Grep", input: { pattern: "foo" } }],
+        },
+      }),
+    ];
+    writeFileSync(logFile, lines.join("\n") + "\n");
+
+    await streamTailer.startTailing(4, logFile);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Only the Grep tool_use should have been emitted
+    expect(emittedEvents.length).toBe(1);
+    expect((emittedEvents[0].event as { name: string }).name).toBe("Grep");
+  });
+
+  it("stops tailing when stopTailing is called", async () => {
+    await streamTailer.startTailing(5, logFile);
+    streamTailer.stopTailing(5);
+
+    // Append after stop — should NOT be picked up
+    appendFileSync(
+      logFile,
+      JSON.stringify({
+        result: "Done",
+        is_error: false,
+        num_turns: 1,
+        cost_usd: 0,
+        duration_ms: 0,
+      }) + "\n",
+    );
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    const postStopEvents = emittedEvents.filter((e) => e.cardId === 5);
+    expect(postStopEvents.length).toBe(0);
+  });
+
+  it("replaces existing tailer when startTailing is called again", async () => {
+    await streamTailer.startTailing(6, logFile);
+
+    // Start again with same cardId — should not error
+    const logFile2 = join(testDir, "test2.ndjson");
+    writeFileSync(
+      logFile2,
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "from second file" }],
+        },
+      }) + "\n",
+    );
+
+    await streamTailer.startTailing(6, logFile2);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const textEvents = emittedEvents.filter((e) => (e.event as { kind: string }).kind === "text");
+    expect(textEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("includes timestamp in emitted events", async () => {
+    const before = Date.now();
+    writeFileSync(
+      logFile,
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "hello" }] },
+      }) + "\n",
+    );
+
+    await streamTailer.startTailing(7, logFile);
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(emittedEvents.length).toBe(1);
+    expect(emittedEvents[0].timestamp).toBeGreaterThanOrEqual(before);
+    expect(emittedEvents[0].timestamp).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/plugins/tt-agentboard/test/utils/stream-parser.test.ts
+++ b/plugins/tt-agentboard/test/utils/stream-parser.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect } from "vitest";
+import { parseStreamLine } from "../../server/utils/stream-parser";
+
+describe("parseStreamLine", () => {
+  it("returns null for empty lines", () => {
+    expect(parseStreamLine("")).toBeNull();
+    expect(parseStreamLine("   ")).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseStreamLine("not json")).toBeNull();
+    expect(parseStreamLine("{broken")).toBeNull();
+  });
+
+  it("returns null for unrecognized event types", () => {
+    expect(parseStreamLine(JSON.stringify({ type: "ping" }))).toBeNull();
+    expect(parseStreamLine(JSON.stringify({ type: "system", data: {} }))).toBeNull();
+  });
+
+  describe("result events", () => {
+    it("parses a result event", () => {
+      const line = JSON.stringify({
+        result: "Task completed successfully",
+        is_error: false,
+        num_turns: 5,
+        cost_usd: 0.0342,
+        duration_ms: 12000,
+      });
+
+      const event = parseStreamLine(line);
+      expect(event).toEqual({
+        kind: "result",
+        costUsd: 0.0342,
+        durationMs: 12000,
+        numTurns: 5,
+        isError: false,
+      });
+    });
+
+    it("parses an error result", () => {
+      const line = JSON.stringify({
+        result: "Failed",
+        is_error: true,
+        num_turns: 1,
+        cost_usd: 0.001,
+        duration_ms: 500,
+      });
+
+      const event = parseStreamLine(line);
+      expect(event).toEqual({
+        kind: "result",
+        costUsd: 0.001,
+        durationMs: 500,
+        numTurns: 1,
+        isError: true,
+      });
+    });
+
+    it("defaults cost to 0 when missing", () => {
+      const line = JSON.stringify({
+        result: "done",
+        is_error: false,
+        num_turns: 3,
+      });
+
+      const event = parseStreamLine(line);
+      expect(event?.kind).toBe("result");
+      if (event?.kind === "result") {
+        expect(event.costUsd).toBe(0);
+        expect(event.durationMs).toBe(0);
+      }
+    });
+
+    it("handles total_cost_usd field name", () => {
+      const line = JSON.stringify({
+        result: "done",
+        is_error: false,
+        num_turns: 2,
+        total_cost_usd: 0.05,
+      });
+
+      const event = parseStreamLine(line);
+      if (event?.kind === "result") {
+        expect(event.costUsd).toBe(0.05);
+      }
+    });
+  });
+
+  describe("stream_event tool_use", () => {
+    it("parses a tool_use event with file_path input", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "tool_use",
+            name: "Read",
+            input: { file_path: "/home/user/code/main.ts" },
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      expect(event).toEqual({
+        kind: "tool_use",
+        name: "Read",
+        detail: "/home/user/code/main.ts",
+        input: { file_path: "/home/user/code/main.ts" },
+      });
+    });
+
+    it("parses Edit tool with old/new string detail", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "tool_use",
+            name: "Edit",
+            input: {
+              file_path: "src/index.ts",
+              old_string: "const x = 1;",
+              new_string: "const x = 2;",
+            },
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      expect(event?.kind).toBe("tool_use");
+      if (event?.kind === "tool_use") {
+        expect(event.name).toBe("Edit");
+        expect(event.detail).toContain("src/index.ts");
+        expect(event.detail).toContain('"const x = 1;"');
+        expect(event.detail).toContain('"const x = 2;"');
+      }
+    });
+
+    it("parses Bash tool with command detail", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "tool_use",
+            name: "Bash",
+            input: { command: "pnpm test" },
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      if (event?.kind === "tool_use") {
+        expect(event.name).toBe("Bash");
+        expect(event.detail).toBe("pnpm test");
+      }
+    });
+
+    it("parses Grep tool with pattern detail", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "tool_use",
+            name: "Grep",
+            input: { pattern: "parseStreamLine" },
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      if (event?.kind === "tool_use") {
+        expect(event.name).toBe("Grep");
+        expect(event.detail).toBe("parseStreamLine");
+      }
+    });
+
+    it("returns empty detail for tool with no recognized input fields", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "tool_use",
+            name: "CustomTool",
+            input: { some_field: "value" },
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      if (event?.kind === "tool_use") {
+        expect(event.detail).toBe("");
+      }
+    });
+
+    it("handles tool_use with no input", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "tool_use",
+            name: "SomeTool",
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      if (event?.kind === "tool_use") {
+        expect(event.input).toEqual({});
+        expect(event.detail).toBe("");
+      }
+    });
+  });
+
+  describe("stream_event thinking", () => {
+    it("parses a thinking event", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "thinking",
+            thinking: "I need to read the file first to understand the structure.",
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      expect(event).toEqual({
+        kind: "thinking",
+        summary: "I need to read the file first to understand the structure.",
+      });
+    });
+
+    it("truncates long thinking to 120 chars", () => {
+      const longThinking = "A".repeat(200);
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "thinking",
+            thinking: longThinking,
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      if (event?.kind === "thinking") {
+        expect(event.summary.length).toBeLessThanOrEqual(121); // 120 + ellipsis
+        expect(event.summary).toContain("…");
+      }
+    });
+
+    it("uses only first line of multi-line thinking", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "thinking",
+            thinking: "First line\nSecond line\nThird line",
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      if (event?.kind === "thinking") {
+        expect(event.summary).toBe("First line");
+      }
+    });
+
+    it("handles empty thinking", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: { type: "thinking" },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      if (event?.kind === "thinking") {
+        expect(event.summary).toBe("");
+      }
+    });
+  });
+
+  describe("stream_event text", () => {
+    it("parses a text event", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: {
+            type: "text",
+            text: "Here is the implementation plan:",
+          },
+        },
+      });
+
+      const event = parseStreamLine(line);
+      expect(event).toEqual({
+        kind: "text",
+        content: "Here is the implementation plan:",
+      });
+    });
+  });
+
+  describe("assistant message format", () => {
+    it("parses tool_use from assistant message content array", () => {
+      const line = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "Write",
+              input: { file_path: "/tmp/test.ts", content: "hello" },
+            },
+          ],
+        },
+      });
+
+      const event = parseStreamLine(line);
+      expect(event?.kind).toBe("tool_use");
+      if (event?.kind === "tool_use") {
+        expect(event.name).toBe("Write");
+        expect(event.detail).toBe("/tmp/test.ts");
+      }
+    });
+
+    it("parses thinking from assistant message content array", () => {
+      const line = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "thinking", thinking: "Let me think about this" }],
+        },
+      });
+
+      const event = parseStreamLine(line);
+      expect(event).toEqual({
+        kind: "thinking",
+        summary: "Let me think about this",
+      });
+    });
+
+    it("parses text from assistant message content array", () => {
+      const line = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "I will now implement the feature." }],
+        },
+      });
+
+      const event = parseStreamLine(line);
+      expect(event).toEqual({
+        kind: "text",
+        content: "I will now implement the feature.",
+      });
+    });
+
+    it("returns null for empty content array", () => {
+      const line = JSON.stringify({
+        type: "assistant",
+        message: { content: [] },
+      });
+
+      expect(parseStreamLine(line)).toBeNull();
+    });
+  });
+
+  describe("ignores non-interesting events", () => {
+    it("ignores content_block_delta", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "partial" },
+        },
+      });
+
+      expect(parseStreamLine(line)).toBeNull();
+    });
+
+    it("ignores message_start", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "message_start", message: {} },
+      });
+
+      expect(parseStreamLine(line)).toBeNull();
+    });
+
+    it("ignores message_stop", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "message_stop" },
+      });
+
+      expect(parseStreamLine(line)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #121. Adds `--output-format stream-json` to Claude CLI commands and displays structured events in a new Activity tab.

- **Stream parser** (`server/utils/stream-parser.ts`) — parses NDJSON lines into typed events: tool_use, thinking, text, result (with cost/turns)
- **File tailer** (`server/services/stream-tailer.ts`) — watches `.claude-stream.ndjson` log files, reads new lines via byte offset tracking, emits `agent:activity` events
- **Agent executor / workflow runner** — pipes claude output through `tee` to log file, starts tailer after command dispatch
- **WebSocket** — forwards `agent:activity` events with subscribe/unsubscribe pattern (matching terminal subscription)
- **Activity panel** (`app/components/card/ActivityPanel.vue`) — scrollable list of tool calls, thinking blocks, text, and result summaries with auto-scroll and 500-event cap
- **Card detail page** — new "Activity" tab alongside Terminal and Diff

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 222 tests pass
- [ ] Manual test: start an agent, verify Activity tab shows tool calls and thinking in real-time
- [ ] Verify terminal tab still works (tmux capture-pane unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)