### PR TITLE
chore: add oxlint rule to ban vi.mock/spyOn/stubGlobal

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["node", "jsdoc", "import", "typescript", "unicorn", "vitest", "promise"],
+  "plugins": ["node", "jsdoc", "import", "typescript", "unicorn", "vitest", "jest", "promise"],
   "categories": {
     "correctness": "off"
   },
@@ -231,7 +231,12 @@
     "unicorn/prefer-number-properties": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
     "unicorn/prefer-type-error": "error",
-    "unicorn/throw-new-error": "error"
+    "unicorn/throw-new-error": "error",
+    "jest/no-restricted-jest-methods": ["warn", {
+      "mock": "vi.mock() is banned. Use constructor or parameter dependency injection instead.",
+      "spyOn": "vi.spyOn() is banned. Use constructor or parameter dependency injection instead.",
+      "stubGlobal": "vi.stubGlobal() is banned. Use constructor or parameter dependency injection instead."
+    }]
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -232,11 +232,14 @@
     "unicorn/prefer-string-starts-ends-with": "error",
     "unicorn/prefer-type-error": "error",
     "unicorn/throw-new-error": "error",
-    "jest/no-restricted-jest-methods": ["warn", {
-      "mock": "vi.mock() is banned. Use constructor or parameter dependency injection instead.",
-      "spyOn": "vi.spyOn() is banned. Use constructor or parameter dependency injection instead.",
-      "stubGlobal": "vi.stubGlobal() is banned. Use constructor or parameter dependency injection instead."
-    }]
+    "jest/no-restricted-jest-methods": [
+      "warn",
+      {
+        "mock": "vi.mock() is banned. Use constructor or parameter dependency injection instead.",
+        "spyOn": "vi.spyOn() is banned. Use constructor or parameter dependency injection instead.",
+        "stubGlobal": "vi.stubGlobal() is banned. Use constructor or parameter dependency injection instead."
+      }
+    ]
   },
   "overrides": [
     {


### PR DESCRIPTION
## Summary

Addresses #130. Adds `jest/no-restricted-jest-methods` rule (warn level) to oxlint config, flagging all 50 existing `vi.mock()`, `vi.spyOn()`, and `vi.stubGlobal()` usages for migration to dependency injection.

Set as `warn` (not `error`) so CI doesn't break while migration is in progress. Once all 50 usages are migrated, escalate to `error`.

## Test plan
- [x] `pnpm lint` — 50 new warnings (expected), 0 errors
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 222 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)