### PR TITLE
refactor: remove vi.mock from 9 AgentBoard services via constructor DI (#130)

### DIFF
--- a/plugins/tt-agentboard/server/services/agent-executor.ts
+++ b/plugins/tt-agentboard/server/services/agent-executor.ts
@@ -1,16 +1,52 @@
-import { db } from "../db";
+import { db as defaultDb } from "../db";
 import { cards, workflowRuns } from "../db/schema";
 import { eq } from "drizzle-orm";
-import { tmuxManager } from "./tmux-manager";
-import { slotAllocator } from "./slot-allocator";
-import { workflowLoader } from "./workflow-loader";
-import { workflowRunner } from "./workflow-runner";
-import { eventBus } from "../utils/event-bus";
-import { logger } from "../utils/logger";
-import { writeHooks } from "../utils/hook-writer";
+import { execSync as defaultExecSync } from "node:child_process";
+import { existsSync as defaultExistsSync } from "node:fs";
+import { join } from "node:path";
+import { tmuxManager as defaultTmuxManager } from "./tmux-manager";
+import { slotAllocator as defaultSlotAllocator } from "./slot-allocator";
+import { workflowLoader as defaultWorkflowLoader } from "./workflow-loader";
+import { workflowRunner as defaultWorkflowRunner } from "./workflow-runner";
+import { eventBus as defaultEventBus } from "../utils/event-bus";
+import { logger as defaultLogger } from "../utils/logger";
+import { writeHooks as defaultWriteHooks } from "../utils/hook-writer";
 import { buildStreamingCommand, shellEscape } from "../utils/workflow-helpers";
-import { logCardEvent } from "../utils/card-events";
-import { streamTailer } from "./stream-tailer";
+import { logCardEvent as defaultLogCardEvent } from "../utils/card-events";
+import { streamTailer as defaultStreamTailer } from "./stream-tailer";
+
+export interface AgentExecutorDeps {
+  db: typeof defaultDb;
+  eventBus: { emit: (event: string, ...args: unknown[]) => boolean | void };
+  logger: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+  tmuxManager: {
+    isAvailable: () => boolean;
+    createSession: (cardId: number, cwd: string) => { sessionName: string; created: boolean };
+    startCapture: (sessionName: string, cb: (data: string) => void) => void;
+    stopCapture: (sessionName: string) => void;
+    killSession: (sessionName: string) => boolean;
+    sendCommand: (sessionName: string, command: string) => void;
+  };
+  slotAllocator: {
+    claimSlot: (repoId: number, cardId: number) => Promise<{ id: number; path: string } | null>;
+    releaseSlot: (slotId: number) => Promise<void>;
+    getSlotForCard: (cardId: number) => Promise<{ id: number; path: string } | null>;
+  };
+  workflowLoader: { get: (id: string) => unknown };
+  workflowRunner: { run: (cardId: number) => Promise<void> };
+  writeHooks: typeof defaultWriteHooks;
+  logCardEvent: typeof defaultLogCardEvent;
+  streamTailer: {
+    startTailing: (cardId: number, logFilePath: string) => Promise<void>;
+    stopTailing: (cardId: number) => void;
+  };
+  execSync: typeof defaultExecSync;
+  existsSync: typeof defaultExistsSync;
+}
 
 /**
  * Handles single agent execution: claim slot, configure Stop hook,
@@ -21,28 +57,44 @@ import { streamTailer } from "./stream-tailer";
  */
 export class AgentExecutor {
   private port: number;
+  private deps: AgentExecutorDeps;
 
-  constructor(port = 4200) {
+  constructor(port = 4200, deps: Partial<AgentExecutorDeps> = {}) {
     this.port = port;
+    this.deps = {
+      db: defaultDb,
+      eventBus: defaultEventBus,
+      logger: defaultLogger,
+      tmuxManager: defaultTmuxManager,
+      slotAllocator: defaultSlotAllocator,
+      workflowLoader: defaultWorkflowLoader,
+      workflowRunner: defaultWorkflowRunner,
+      writeHooks: defaultWriteHooks,
+      logCardEvent: defaultLogCardEvent,
+      streamTailer: defaultStreamTailer,
+      execSync: defaultExecSync,
+      existsSync: defaultExistsSync,
+      ...deps,
+    };
   }
 
   /** Start agent execution for a card moved to in_progress */
   async startExecution(cardId: number): Promise<void> {
     // Fetch the card
-    const cardRows = await db.select().from(cards).where(eq(cards.id, cardId));
+    const cardRows = await this.deps.db.select().from(cards).where(eq(cards.id, cardId));
     if (cardRows.length === 0) {
-      logger.error(`Card ${cardId} not found`);
+      this.deps.logger.error(`Card ${cardId} not found`);
       return;
     }
     const card = cardRows[0]!;
 
     if (!card.repoId) {
-      await logCardEvent(cardId, "error", "No repo assigned");
+      await this.deps.logCardEvent(cardId, "error", "No repo assigned");
       await this.updateCardStatus(cardId, "failed");
       return;
     }
 
-    await logCardEvent(
+    await this.deps.logCardEvent(
       cardId,
       "execution_start",
       `repoId=${card.repoId}, mode=${card.executionMode}, branch=${card.branchMode}`,
@@ -50,13 +102,13 @@ export class AgentExecutor {
 
     // Delegate to workflow runner if card has a valid workflow
     if (card.workflowId) {
-      const workflow = workflowLoader.get(card.workflowId);
+      const workflow = this.deps.workflowLoader.get(card.workflowId);
       if (workflow) {
-        await logCardEvent(cardId, "workflow_delegate", `workflow=${card.workflowId}`);
-        await workflowRunner.run(cardId);
+        await this.deps.logCardEvent(cardId, "workflow_delegate", `workflow=${card.workflowId}`);
+        await this.deps.workflowRunner.run(cardId);
         return;
       }
-      await logCardEvent(
+      await this.deps.logCardEvent(
         cardId,
         "workflow_not_found",
         `workflow=${card.workflowId}, falling back to single-prompt`,
@@ -70,25 +122,29 @@ export class AgentExecutor {
   /** Run a single claude -p command for cards without a workflow */
   private async runSinglePrompt(cardId: number, card: typeof cards.$inferSelect): Promise<void> {
     // Check tmux availability
-    if (!tmuxManager.isAvailable()) {
-      await logCardEvent(cardId, "error", "tmux not available");
+    if (!this.deps.tmuxManager.isAvailable()) {
+      await this.deps.logCardEvent(cardId, "error", "tmux not available");
       await this.updateCardStatus(cardId, "failed");
       return;
     }
 
     // Check if a slot is already claimed for this card (e.g. by queue manager)
-    let slot = await slotAllocator.getSlotForCard(cardId);
+    let slot = await this.deps.slotAllocator.getSlotForCard(cardId);
     if (!slot) {
-      slot = await slotAllocator.claimSlot(card.repoId!, cardId);
+      slot = await this.deps.slotAllocator.claimSlot(card.repoId!, cardId);
     }
     if (!slot) {
-      await logCardEvent(cardId, "queued", `No available slot for repoId=${card.repoId}`);
-      await db
+      await this.deps.logCardEvent(cardId, "queued", `No available slot for repoId=${card.repoId}`);
+      await this.deps.db
         .update(cards)
         .set({ column: "ready", status: "queued", updatedAt: new Date() })
         .where(eq(cards.id, cardId));
-      eventBus.emit("card:moved", { cardId, fromColumn: "in_progress", toColumn: "ready" });
-      eventBus.emit("card:status-changed", { cardId, status: "queued" });
+      this.deps.eventBus.emit("card:moved", {
+        cardId,
+        fromColumn: "in_progress",
+        toColumn: "ready",
+      });
+      this.deps.eventBus.emit("card:status-changed", { cardId, status: "queued" });
       return;
     }
 
@@ -96,15 +152,15 @@ export class AgentExecutor {
     await this.updateCardStatus(cardId, "running");
 
     // Write .claude/settings.local.json with Stop hook in the slot directory
-    writeHooks(slot.path, cardId, this.port, "complete");
-    await logCardEvent(cardId, "hooks_written", `endpoint=complete, path=${slot.path}`);
+    this.deps.writeHooks(slot.path, cardId, this.port, "complete");
+    await this.deps.logCardEvent(cardId, "hooks_written", `endpoint=complete, path=${slot.path}`);
 
-    await logCardEvent(cardId, "slot_claimed", `slotId=${slot.id}, path=${slot.path}`);
+    await this.deps.logCardEvent(cardId, "slot_claimed", `slotId=${slot.id}, path=${slot.path}`);
 
     // Create tmux session
-    const { sessionName, created } = tmuxManager.createSession(cardId, slot.path);
+    const { sessionName, created } = this.deps.tmuxManager.createSession(cardId, slot.path);
     if (created) {
-      await logCardEvent(
+      await this.deps.logCardEvent(
         cardId,
         "tmux_session_created",
         `session=${sessionName}, cwd=${slot.path}`,
@@ -112,11 +168,10 @@ export class AgentExecutor {
     }
 
     // Branch handling
-    const { execSync } = await import("node:child_process");
     let branch: string | null = null;
 
     // Check for existing branch from a previous run (resume/rerun case)
-    const previousRuns = await db
+    const previousRuns = await this.deps.db
       .select({ branch: workflowRuns.branch })
       .from(workflowRuns)
       .where(eq(workflowRuns.cardId, cardId));
@@ -125,15 +180,15 @@ export class AgentExecutor {
     if (existingBranch) {
       // Reuse existing branch from previous run
       try {
-        execSync(`git checkout ${existingBranch}`, {
+        this.deps.execSync(`git checkout ${existingBranch}`, {
           cwd: slot.path,
           stdio: "ignore",
           timeout: 10000,
         });
         branch = existingBranch;
-        await logCardEvent(cardId, "branch_reused", existingBranch);
+        await this.deps.logCardEvent(cardId, "branch_reused", existingBranch);
       } catch {
-        await logCardEvent(
+        await this.deps.logCardEvent(
           cardId,
           "warn",
           `Could not checkout existing branch ${existingBranch}, creating new`,
@@ -145,7 +200,7 @@ export class AgentExecutor {
     if (!branch && card.branchMode === "create") {
       // Clean working tree of leftover files from previous agents
       try {
-        execSync("git checkout -- . && git clean -fd", {
+        this.deps.execSync("git checkout -- . && git clean -fd", {
           cwd: slot.path,
           stdio: "ignore",
           timeout: 5000,
@@ -157,31 +212,37 @@ export class AgentExecutor {
       // Start from a clean, up-to-date main before branching
       const branchName = `agentboard/card-${cardId}`;
       try {
-        execSync("git checkout main && git pull --ff-only", {
+        this.deps.execSync("git checkout main && git pull --ff-only", {
           cwd: slot.path,
           stdio: "ignore",
           timeout: 15000,
         });
       } catch {
-        await logCardEvent(cardId, "warn", "Could not checkout/pull main before branching");
+        await this.deps.logCardEvent(
+          cardId,
+          "warn",
+          "Could not checkout/pull main before branching",
+        );
       }
       try {
-        execSync(`git checkout -b ${branchName}`, { cwd: slot.path, stdio: "ignore" });
+        this.deps.execSync(`git checkout -b ${branchName}`, { cwd: slot.path, stdio: "ignore" });
         branch = branchName;
-        await logCardEvent(cardId, "branch_created", branchName);
+        await this.deps.logCardEvent(cardId, "branch_created", branchName);
       } catch {
         // Branch may exist — try switching to it
         try {
-          execSync(`git checkout ${branchName}`, { cwd: slot.path, stdio: "ignore" });
+          this.deps.execSync(`git checkout ${branchName}`, { cwd: slot.path, stdio: "ignore" });
           branch = branchName;
         } catch {
           // Fall back to current branch
           try {
-            branch = execSync("git rev-parse --abbrev-ref HEAD", {
-              cwd: slot.path,
-              encoding: "utf-8",
-              timeout: 3000,
-            }).trim();
+            branch = (
+              this.deps.execSync("git rev-parse --abbrev-ref HEAD", {
+                cwd: slot.path,
+                encoding: "utf-8",
+                timeout: 3000,
+              }) as unknown as string
+            ).trim();
           } catch {
             /* not a git repo */
           }
@@ -190,51 +251,51 @@ export class AgentExecutor {
     } else if (!branch) {
       // Stay on current branch
       try {
-        branch = execSync("git rev-parse --abbrev-ref HEAD", {
-          cwd: slot.path,
-          encoding: "utf-8",
-          timeout: 3000,
-        }).trim();
+        branch = (
+          this.deps.execSync("git rev-parse --abbrev-ref HEAD", {
+            cwd: slot.path,
+            encoding: "utf-8",
+            timeout: 3000,
+          }) as unknown as string
+        ).trim();
       } catch {
         /* not a git repo */
       }
     }
 
     // Run package installer if a lockfile exists
-    const { existsSync } = await import("node:fs");
-    const { join } = await import("node:path");
     const hasLockfile =
-      existsSync(join(slot.path, "pnpm-lock.yaml")) ||
-      existsSync(join(slot.path, "bun.lock")) ||
-      existsSync(join(slot.path, "package-lock.json"));
+      this.deps.existsSync(join(slot.path, "pnpm-lock.yaml")) ||
+      this.deps.existsSync(join(slot.path, "bun.lock")) ||
+      this.deps.existsSync(join(slot.path, "package-lock.json"));
 
     if (hasLockfile) {
       try {
-        if (existsSync(join(slot.path, "pnpm-lock.yaml"))) {
-          execSync("pnpm install --frozen-lockfile", {
+        if (this.deps.existsSync(join(slot.path, "pnpm-lock.yaml"))) {
+          this.deps.execSync("pnpm install --frozen-lockfile", {
             cwd: slot.path,
             stdio: "ignore",
             timeout: 60000,
           });
-          await logCardEvent(cardId, "deps_installed", "pnpm install");
-        } else if (existsSync(join(slot.path, "bun.lock"))) {
-          execSync("bun install --frozen-lockfile", {
+          await this.deps.logCardEvent(cardId, "deps_installed", "pnpm install");
+        } else if (this.deps.existsSync(join(slot.path, "bun.lock"))) {
+          this.deps.execSync("bun install --frozen-lockfile", {
             cwd: slot.path,
             stdio: "ignore",
             timeout: 60000,
           });
-          await logCardEvent(cardId, "deps_installed", "bun install");
+          await this.deps.logCardEvent(cardId, "deps_installed", "bun install");
         } else {
-          execSync("npm ci", { cwd: slot.path, stdio: "ignore", timeout: 60000 });
-          await logCardEvent(cardId, "deps_installed", "npm ci");
+          this.deps.execSync("npm ci", { cwd: slot.path, stdio: "ignore", timeout: 60000 });
+          await this.deps.logCardEvent(cardId, "deps_installed", "npm ci");
         }
       } catch {
-        await logCardEvent(cardId, "warn", "Package install failed — continuing anyway");
+        await this.deps.logCardEvent(cardId, "warn", "Package install failed — continuing anyway");
       }
     }
 
     // Create workflow run record
-    await db
+    await this.deps.db
       .insert(workflowRuns)
       .values({
         cardId,
@@ -267,22 +328,24 @@ export class AgentExecutor {
     const logFilePath = join(slot.path, ".claude-stream.ndjson");
     const command = buildStreamingCommand(args, logFilePath);
 
-    tmuxManager.sendCommand(sessionName, command);
-    await logCardEvent(cardId, "agent_command_sent", `session=${sessionName}`);
+    this.deps.tmuxManager.sendCommand(sessionName, command);
+    await this.deps.logCardEvent(cardId, "agent_command_sent", `session=${sessionName}`);
 
     // Start tailing the stream-json output for structured activity events
-    await streamTailer.startTailing(cardId, logFilePath);
+    await this.deps.streamTailer.startTailing(cardId, logFilePath);
 
-    tmuxManager.startCapture(sessionName, (output) => {
-      eventBus.emit("agent:output", { cardId, content: output });
+    this.deps.tmuxManager.startCapture(sessionName, (output) => {
+      this.deps.eventBus.emit("agent:output", { cardId, content: output });
     });
 
-    await logCardEvent(
+    await this.deps.logCardEvent(
       cardId,
       "agent_started",
       `session=${sessionName}, mode=${card.executionMode}`,
     );
-    logger.info(`Card ${cardId} execution started in session ${sessionName}, Stop hook configured`);
+    this.deps.logger.info(
+      `Card ${cardId} execution started in session ${sessionName}, Stop hook configured`,
+    );
   }
 
   private async updateCardStatus(
@@ -297,9 +360,12 @@ export class AgentExecutor {
       | "failed"
       | "blocked",
   ): Promise<void> {
-    await db.update(cards).set({ status, updatedAt: new Date() }).where(eq(cards.id, cardId));
+    await this.deps.db
+      .update(cards)
+      .set({ status, updatedAt: new Date() })
+      .where(eq(cards.id, cardId));
 
-    eventBus.emit("card:status-changed", { cardId, status });
+    this.deps.eventBus.emit("card:status-changed", { cardId, status });
   }
 }
 

--- a/plugins/tt-agentboard/server/services/dependency-resolver.ts
+++ b/plugins/tt-agentboard/server/services/dependency-resolver.ts
@@ -3,11 +3,22 @@ import { cards } from "../db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { logger } from "../utils/logger";
 
+export interface DependencyResolverDeps {
+  db: typeof db;
+  logger: typeof logger;
+}
+
 /**
  * Resolves card dependencies. When a card completes, checks if any blocked
  * cards now have all dependencies met and moves them to 'ready'.
  */
 export class DependencyResolver {
+  private deps: DependencyResolverDeps;
+
+  constructor(deps: Partial<DependencyResolverDeps> = {}) {
+    this.deps = { db, logger, ...deps };
+  }
+
   /**
    * Parse the dependsOn field (comma-separated card IDs) into an array of numbers.
    */
@@ -26,7 +37,7 @@ export class DependencyResolver {
    */
   async resolveAfterCompletion(completedCardId: number): Promise<number[]> {
     // Find all cards with status 'blocked' that reference the completed card in dependsOn
-    const blockedCards = await db.select().from(cards).where(eq(cards.status, "blocked"));
+    const blockedCards = await this.deps.db.select().from(cards).where(eq(cards.status, "blocked"));
 
     const unblockedIds: number[] = [];
 
@@ -37,7 +48,7 @@ export class DependencyResolver {
       // Check if ALL dependencies are now done
       const allMet = await this.allDepsMet(deps);
       if (allMet) {
-        await db
+        await this.deps.db
           .update(cards)
           .set({
             column: "ready",
@@ -47,7 +58,7 @@ export class DependencyResolver {
           .where(eq(cards.id, card.id));
 
         unblockedIds.push(card.id);
-        logger.info(`Card ${card.id} unblocked — all dependencies met, moved to ready`);
+        this.deps.logger.info(`Card ${card.id} unblocked — all dependencies met, moved to ready`);
       }
     }
 
@@ -60,7 +71,7 @@ export class DependencyResolver {
   private async allDepsMet(depIds: number[]): Promise<boolean> {
     if (depIds.length === 0) return true;
 
-    const depCards = await db
+    const depCards = await this.deps.db
       .select({ id: cards.id, status: cards.status })
       .from(cards)
       .where(inArray(cards.id, depIds));

--- a/plugins/tt-agentboard/server/services/github-service.ts
+++ b/plugins/tt-agentboard/server/services/github-service.ts
@@ -35,20 +35,31 @@ interface GhIssue {
   url: string;
 }
 
-function ghExec(args: string): string {
-  return execSync(`gh ${args}`, { encoding: "utf-8" }).trim();
-}
-
-function ghJson<T>(args: string): T {
-  const output = ghExec(args);
-  return JSON.parse(output) as T;
+export interface GitHubServiceDeps {
+  execSync: typeof execSync;
+  eventBus: typeof eventBus;
+  logger: typeof logger;
 }
 
 export class GitHubService {
   private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private deps: GitHubServiceDeps;
+
+  constructor(deps: Partial<GitHubServiceDeps> = {}) {
+    this.deps = { execSync, eventBus, logger, ...deps };
+  }
+
+  private ghExec(args: string): string {
+    return this.deps.execSync(`gh ${args}`, { encoding: "utf-8" }).trim();
+  }
+
+  private ghJson<T>(args: string): T {
+    const output = this.ghExec(args);
+    return JSON.parse(output) as T;
+  }
 
   async getIssuesWithLabel(owner: string, repo: string, label: string): Promise<GitHubIssue[]> {
-    const raw = ghJson<GhIssue[]>(
+    const raw = this.ghJson<GhIssue[]>(
       `issue list --repo ${owner}/${repo} --label "${label}" --json number,title,body,labels,url --state open --limit 100`,
     );
     return raw.map((issue) => ({
@@ -61,7 +72,7 @@ export class GitHubService {
   }
 
   async getOpenIssues(owner: string, repo: string): Promise<GitHubIssue[]> {
-    const raw = ghJson<GhIssue[]>(
+    const raw = this.ghJson<GhIssue[]>(
       `issue list --repo ${owner}/${repo} --json number,title,body,labels,url --state open --limit 100`,
     );
     return raw.map((issue) => ({
@@ -76,7 +87,7 @@ export class GitHubService {
   async createIssue(owner: string, repo: string, title: string, body: string, labels?: string[]) {
     const labelArgs = labels?.length ? labels.map((l) => `--label "${l}"`).join(" ") : "";
     // gh issue create returns the URL on stdout (no --json support)
-    const url = ghExec(
+    const url = this.ghExec(
       `issue create --repo ${owner}/${repo} --title "${title.replace(/"/g, '\\"')}" --body "${body.replace(/"/g, '\\"')}" ${labelArgs}`,
     );
     const numMatch = url.match(/\/issues\/(\d+)/);
@@ -101,20 +112,20 @@ export class GitHubService {
     if (editArgs.length === 0) return;
 
     try {
-      ghExec(`issue edit ${owner}/${repo}#${issueNumber} ${editArgs.join(" ")}`);
+      this.ghExec(`issue edit ${owner}/${repo}#${issueNumber} ${editArgs.join(" ")}`);
     } catch (error) {
-      logger.debug(`Label transition failed for issue #${issueNumber}: ${error}`);
+      this.deps.logger.debug(`Label transition failed for issue #${issueNumber}: ${error}`);
     }
   }
 
   async createBranch(owner: string, repo: string, branchName: string, baseBranch: string = "main") {
     // Use gh api to get the base ref SHA, then create the branch
-    const sha = ghJson<{ object: { sha: string } }>(
+    const sha = this.ghJson<{ object: { sha: string } }>(
       `api repos/${owner}/${repo}/git/ref/heads/${baseBranch} --jq .object.sha`,
     );
 
     // For branch creation, use the API directly
-    ghExec(
+    this.ghExec(
       `api repos/${owner}/${repo}/git/refs -f ref="refs/heads/${branchName}" -f sha="${typeof sha === "string" ? sha : sha.object.sha}"`,
     );
 
@@ -123,7 +134,7 @@ export class GitHubService {
 
   async createPr({ owner, repo, title, body, head, base }: CreatePrOptions) {
     // gh pr create returns the URL on stdout (no --json support)
-    const url = ghExec(
+    const url = this.ghExec(
       `pr create --repo ${owner}/${repo} --title "${title.replace(/"/g, '\\"')}" --body "${body.replace(/"/g, '\\"')}" --base ${base} --head ${head}`,
     );
     const numMatch = url.match(/\/pull\/(\d+)/);
@@ -143,7 +154,7 @@ export class GitHubService {
         try {
           const issues = await this.getIssuesWithLabel(owner, repo, triggerLabel);
           for (const issue of issues) {
-            eventBus.emit("github:issue-found", {
+            this.deps.eventBus.emit("github:issue-found", {
               issueNumber: issue.number,
               repoId,
               title: issue.title,
@@ -152,7 +163,7 @@ export class GitHubService {
             });
           }
         } catch (error) {
-          logger.error(`Failed to poll issues for ${owner}/${repo}:`, error);
+          this.deps.logger.error(`Failed to poll issues for ${owner}/${repo}:`, error);
         }
       }
     };
@@ -160,14 +171,14 @@ export class GitHubService {
     // Poll immediately, then on interval
     poll();
     this.pollTimer = setInterval(poll, intervalMs);
-    logger.info(`GitHub polling started (interval: ${intervalMs}ms)`);
+    this.deps.logger.info(`GitHub polling started (interval: ${intervalMs}ms)`);
   }
 
   stopPolling() {
     if (this.pollTimer) {
       clearInterval(this.pollTimer);
       this.pollTimer = null;
-      logger.info("GitHub polling stopped");
+      this.deps.logger.info("GitHub polling stopped");
     }
   }
 }

--- a/plugins/tt-agentboard/server/services/slot-allocator.ts
+++ b/plugins/tt-agentboard/server/services/slot-allocator.ts
@@ -4,25 +4,37 @@ import { eq, and } from "drizzle-orm";
 import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
 
+export interface SlotAllocatorDeps {
+  db: typeof db;
+  eventBus: typeof eventBus;
+  logger: typeof logger;
+}
+
 export class SlotAllocator {
+  private deps: SlotAllocatorDeps;
+
+  constructor(deps: Partial<SlotAllocatorDeps> = {}) {
+    this.deps = { db, eventBus, logger, ...deps };
+  }
+
   /** Find and claim an available slot for a repo */
   async claimSlot(
     repoId: number,
     cardId: number,
   ): Promise<typeof workspaceSlots.$inferSelect | null> {
-    const available = await db
+    const available = await this.deps.db
       .select()
       .from(workspaceSlots)
       .where(and(eq(workspaceSlots.repoId, repoId), eq(workspaceSlots.status, "available")))
       .limit(1);
 
     if (available.length === 0) {
-      logger.warn(`No available slot for repo ${repoId}, card ${cardId}`);
+      this.deps.logger.warn(`No available slot for repo ${repoId}, card ${cardId}`);
       return null;
     }
 
     const slot = available[0]!;
-    await db
+    await this.deps.db
       .update(workspaceSlots)
       .set({
         status: "claimed",
@@ -30,8 +42,8 @@ export class SlotAllocator {
       })
       .where(eq(workspaceSlots.id, slot.id));
 
-    eventBus.emit("slot:claimed", { slotId: slot.id, cardId });
-    logger.info(`Slot ${slot.id} claimed by card ${cardId}`);
+    this.deps.eventBus.emit("slot:claimed", { slotId: slot.id, cardId });
+    this.deps.logger.info(`Slot ${slot.id} claimed by card ${cardId}`);
 
     return {
       ...slot,
@@ -42,7 +54,7 @@ export class SlotAllocator {
 
   /** Release a slot when work is done */
   async releaseSlot(slotId: number): Promise<void> {
-    await db
+    await this.deps.db
       .update(workspaceSlots)
       .set({
         status: "available",
@@ -50,13 +62,13 @@ export class SlotAllocator {
       })
       .where(eq(workspaceSlots.id, slotId));
 
-    eventBus.emit("slot:released", { slotId });
-    logger.info(`Slot ${slotId} released`);
+    this.deps.eventBus.emit("slot:released", { slotId });
+    this.deps.logger.info(`Slot ${slotId} released`);
   }
 
   /** Get the slot currently claimed by a card */
   async getSlotForCard(cardId: number): Promise<typeof workspaceSlots.$inferSelect | null> {
-    const result = await db
+    const result = await this.deps.db
       .select()
       .from(workspaceSlots)
       .where(eq(workspaceSlots.claimedByCardId, cardId))

--- a/plugins/tt-agentboard/server/services/stream-tailer.ts
+++ b/plugins/tt-agentboard/server/services/stream-tailer.ts
@@ -5,12 +5,22 @@ import { parseStreamLine } from "../utils/stream-parser";
 import { eventBus } from "../utils/event-bus";
 import { logger } from "../utils/logger";
 
+export interface StreamTailerDeps {
+  eventBus: typeof eventBus;
+  logger: typeof logger;
+}
+
 interface TailHandle {
   close: () => void;
 }
 
-class StreamTailer {
+export class StreamTailer {
   private tailers = new Map<number, TailHandle>();
+  private deps: StreamTailerDeps;
+
+  constructor(deps: Partial<StreamTailerDeps> = {}) {
+    this.deps = { eventBus, logger, ...deps };
+  }
 
   async startTailing(cardId: number, logFilePath: string): Promise<void> {
     this.stopTailing(cardId);
@@ -40,7 +50,7 @@ class StreamTailer {
         for await (const line of rl) {
           const event = parseStreamLine(line);
           if (event) {
-            eventBus.emit("agent:activity", {
+            this.deps.eventBus.emit("agent:activity", {
               cardId,
               event,
               timestamp: Date.now(),
@@ -52,7 +62,7 @@ class StreamTailer {
         offset = fileSize;
       } catch (err) {
         if (!closed) {
-          logger.warn(`Stream tailer read error for card ${cardId}:`, err);
+          this.deps.logger.warn(`Stream tailer read error for card ${cardId}:`, err);
         }
       }
 
@@ -70,11 +80,11 @@ class StreamTailer {
 
       watcher.on("error", (err) => {
         if (!closed) {
-          logger.warn(`Stream tailer watcher error for card ${cardId}:`, err);
+          this.deps.logger.warn(`Stream tailer watcher error for card ${cardId}:`, err);
         }
       });
     } catch (err) {
-      logger.warn(`Could not watch ${logFilePath} for card ${cardId}:`, err);
+      this.deps.logger.warn(`Could not watch ${logFilePath} for card ${cardId}:`, err);
     }
 
     const handle: TailHandle = {
@@ -85,7 +95,7 @@ class StreamTailer {
     };
 
     this.tailers.set(cardId, handle);
-    logger.info(`Started stream tailing for card ${cardId}: ${logFilePath}`);
+    this.deps.logger.info(`Started stream tailing for card ${cardId}: ${logFilePath}`);
   }
 
   stopTailing(cardId: number): void {
@@ -93,7 +103,7 @@ class StreamTailer {
     if (handle) {
       handle.close();
       this.tailers.delete(cardId);
-      logger.info(`Stopped stream tailing for card ${cardId}`);
+      this.deps.logger.info(`Stopped stream tailing for card ${cardId}`);
     }
   }
 

--- a/plugins/tt-agentboard/server/services/tmux-manager.ts
+++ b/plugins/tt-agentboard/server/services/tmux-manager.ts
@@ -1,19 +1,34 @@
-import { execSync } from "node:child_process";
+import { execSync as defaultExecSync } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { logger } from "../utils/logger";
+import { logger as defaultLogger } from "../utils/logger";
 
 interface SessionInfo {
   cardId: number;
   captureInterval?: ReturnType<typeof setInterval>;
 }
 
+export interface TmuxManagerDeps {
+  execSync: typeof defaultExecSync;
+  logger: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void };
+}
+
 export class TmuxManager extends EventEmitter {
   private sessions: Map<string, SessionInfo> = new Map();
+  private deps: TmuxManagerDeps;
+
+  constructor(deps: Partial<TmuxManagerDeps> = {}) {
+    super();
+    this.deps = {
+      execSync: defaultExecSync,
+      logger: defaultLogger,
+      ...deps,
+    };
+  }
 
   /** Check if tmux is available on the system */
   isAvailable(): boolean {
     try {
-      execSync("which tmux", { stdio: "ignore" });
+      this.deps.execSync("which tmux", { stdio: "ignore" });
       return true;
     } catch {
       return false;
@@ -25,23 +40,23 @@ export class TmuxManager extends EventEmitter {
     const sessionName = `card-${cardId}`;
 
     if (this.sessionExists(sessionName)) {
-      logger.warn(`tmux session ${sessionName} already exists, reusing`);
+      this.deps.logger.warn(`tmux session ${sessionName} already exists, reusing`);
       this.sessions.set(sessionName, { cardId });
       return { sessionName, created: false };
     }
 
-    execSync(`tmux new-session -d -s ${sessionName} -c "${cwd}"`, {
+    this.deps.execSync(`tmux new-session -d -s ${sessionName} -c "${cwd}"`, {
       stdio: "ignore",
     });
     this.sessions.set(sessionName, { cardId });
-    logger.info(`Created tmux session: ${sessionName} in ${cwd}`);
+    this.deps.logger.info(`Created tmux session: ${sessionName} in ${cwd}`);
     return { sessionName, created: true };
   }
 
   /** Send a command to a tmux session */
   sendCommand(sessionName: string, command: string): void {
     const escaped = command.replace(/'/g, "'\\''");
-    execSync(`tmux send-keys -t ${sessionName} '${escaped}' Enter`);
+    this.deps.execSync(`tmux send-keys -t ${sessionName} '${escaped}' Enter`);
   }
 
   /** Start capturing output from a tmux session via polling capture-pane */
@@ -53,11 +68,11 @@ export class TmuxManager extends EventEmitter {
 
     const interval = setInterval(() => {
       try {
-        const output = execSync(`tmux capture-pane -t ${sessionName} -p -e -S -50`, {
+        const output = this.deps.execSync(`tmux capture-pane -t ${sessionName} -p -e -S -50`, {
           encoding: "utf-8",
           timeout: 2000,
         });
-        outputCallback(output);
+        outputCallback(output as string);
       } catch {
         clearInterval(interval);
         const s = this.sessions.get(sessionName);
@@ -84,7 +99,7 @@ export class TmuxManager extends EventEmitter {
   /** Check if a tmux session exists */
   sessionExists(sessionName: string): boolean {
     try {
-      execSync(`tmux has-session -t ${sessionName}`, { stdio: "ignore" });
+      this.deps.execSync(`tmux has-session -t ${sessionName}`, { stdio: "ignore" });
       return true;
     } catch {
       return false;
@@ -96,23 +111,23 @@ export class TmuxManager extends EventEmitter {
     this.stopCapture(sessionName);
     let killed = false;
     try {
-      execSync(`tmux kill-session -t ${sessionName}`, { stdio: "ignore" });
+      this.deps.execSync(`tmux kill-session -t ${sessionName}`, { stdio: "ignore" });
       killed = true;
     } catch {
       /* session may already be dead */
     }
     this.sessions.delete(sessionName);
-    logger.info(`Killed tmux session: ${sessionName}`);
+    this.deps.logger.info(`Killed tmux session: ${sessionName}`);
     return killed;
   }
 
   /** List all agentboard tmux sessions (card-* prefix) */
   listSessions(): string[] {
     try {
-      const output = execSync('tmux list-sessions -F "#{session_name}"', {
+      const output = this.deps.execSync('tmux list-sessions -F "#{session_name}"', {
         encoding: "utf-8",
       });
-      return output
+      return (output as string)
         .trim()
         .split("\n")
         .filter((s) => s.startsWith("card-"));

--- a/plugins/tt-agentboard/server/services/ttyd-manager.ts
+++ b/plugins/tt-agentboard/server/services/ttyd-manager.ts
@@ -8,16 +8,27 @@ interface TtydInstance {
   process: ChildProcess;
 }
 
+export interface TtydManagerDeps {
+  spawn: typeof spawn;
+  execSync: typeof execSync;
+  logger: typeof logger;
+}
+
 export class TtydManager {
   private instances: Map<number, TtydInstance> = new Map();
   private basePort = 7700;
   private _ttydAvailable: boolean | null = null;
+  private deps: TtydManagerDeps;
+
+  constructor(deps: Partial<TtydManagerDeps> = {}) {
+    this.deps = { spawn, execSync, logger, ...deps };
+  }
 
   /** Check if ttyd is available on the system (cached after first call) */
   isAvailable(): boolean {
     if (this._ttydAvailable !== null) return this._ttydAvailable;
     try {
-      execSync("which ttyd", { stdio: "ignore" });
+      this.deps.execSync("which ttyd", { stdio: "ignore" });
       this._ttydAvailable = true;
     } catch {
       this._ttydAvailable = false;
@@ -45,7 +56,7 @@ export class TtydManager {
     const sessionName = `card-${cardId}`;
     const port = this.getNextPort();
 
-    const proc = spawn(
+    const proc = this.deps.spawn(
       "ttyd",
       ["--port", String(port), "--writable", "tmux", "attach", "-t", sessionName],
       {
@@ -57,17 +68,17 @@ export class TtydManager {
     proc.unref();
 
     proc.on("error", (err) => {
-      logger.error(`ttyd error for card ${cardId}:`, err);
+      this.deps.logger.error(`ttyd error for card ${cardId}:`, err);
       this.instances.delete(cardId);
     });
 
     proc.on("exit", (code) => {
-      logger.info(`ttyd for card ${cardId} exited with code ${code}`);
+      this.deps.logger.info(`ttyd for card ${cardId} exited with code ${code}`);
       this.instances.delete(cardId);
     });
 
     this.instances.set(cardId, { cardId, port, process: proc });
-    logger.info(`Started ttyd for card ${cardId} on port ${port}`);
+    this.deps.logger.info(`Started ttyd for card ${cardId} on port ${port}`);
 
     return { port, url: `http://localhost:${port}` };
   }
@@ -83,7 +94,7 @@ export class TtydManager {
       // Already dead
     }
     this.instances.delete(cardId);
-    logger.info(`Stopped ttyd for card ${cardId}`);
+    this.deps.logger.info(`Stopped ttyd for card ${cardId}`);
     return true;
   }
 

--- a/plugins/tt-agentboard/server/services/workflow-loader.ts
+++ b/plugins/tt-agentboard/server/services/workflow-loader.ts
@@ -1,9 +1,19 @@
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { watch } from "chokidar";
-import { glob } from "glob";
 import { logger } from "../utils/logger";
+
+/** Default glob implementation using readdirSync (avoids 'glob' package dependency) */
+async function defaultGlob(pattern: string): Promise<string[]> {
+  const dir = pattern.replace(/[/\\]\*\.yaml$/, "");
+  try {
+    const files = readdirSync(dir);
+    return files.filter((f) => f.endsWith(".yaml")).map((f) => join(dir, f));
+  } catch {
+    return [];
+  }
+}
 
 export interface WorkflowStep {
   id: string;
@@ -36,9 +46,20 @@ export interface WorkflowDefinition {
   artifact_dir?: string;
 }
 
+export interface WorkflowLoaderDeps {
+  logger: typeof logger;
+  glob: (pattern: string) => Promise<string[]>;
+  watch: typeof watch;
+}
+
 export class WorkflowLoader {
   private workflows: Map<string, WorkflowDefinition> = new Map();
   private watchers: Map<string, ReturnType<typeof watch>> = new Map();
+  private deps: WorkflowLoaderDeps;
+
+  constructor(deps: Partial<WorkflowLoaderDeps> = {}) {
+    this.deps = { logger, glob: defaultGlob, watch, ...deps };
+  }
 
   /** Load all workflow definitions from registered repo paths */
   async loadFromRepos(repoPaths: string[]): Promise<void> {
@@ -52,14 +73,14 @@ export class WorkflowLoader {
     const workflowDir = resolve(repoPath, ".agentboard", "workflows");
     if (!existsSync(workflowDir)) return;
 
-    const files = await glob(join(workflowDir, "*.yaml"));
+    const files = await this.deps.glob(join(workflowDir, "*.yaml"));
     for (const file of files) {
       this.loadFile(file);
     }
 
     // Watch for changes
     if (!this.watchers.has(workflowDir)) {
-      const watcher = watch(workflowDir, {
+      const watcher = this.deps.watch(workflowDir, {
         ignoreInitial: true,
       });
       watcher.on("add", (filePath) => {
@@ -86,13 +107,13 @@ export class WorkflowLoader {
       const content = readFileSync(path, "utf-8");
       const workflow = parseYaml(content) as WorkflowDefinition;
       if (!workflow.name || !workflow.steps) {
-        logger.warn(`Invalid workflow file (missing name or steps): ${path}`);
+        this.deps.logger.warn(`Invalid workflow file (missing name or steps): ${path}`);
         return;
       }
       this.workflows.set(workflow.name, workflow);
-      logger.info(`Loaded workflow: ${workflow.name} from ${path}`);
+      this.deps.logger.info(`Loaded workflow: ${workflow.name} from ${path}`);
     } catch (err) {
-      logger.error(`Failed to load workflow ${path}:`, err);
+      this.deps.logger.error(`Failed to load workflow ${path}:`, err);
     }
   }
 
@@ -100,7 +121,7 @@ export class WorkflowLoader {
     // Find and remove the workflow that came from this path
     // Since we don't track path->name mapping, reload would be needed
     // For now, log the removal
-    logger.info(`Workflow file removed: ${path}`);
+    this.deps.logger.info(`Workflow file removed: ${path}`);
   }
 
   /** Get a workflow by name */

--- a/plugins/tt-agentboard/server/services/workflow-runner.ts
+++ b/plugins/tt-agentboard/server/services/workflow-runner.ts
@@ -1,25 +1,25 @@
-import { db } from "../db";
+import { db as defaultDb } from "../db";
 import { cards, workflowRuns, stepRuns, repositories } from "../db/schema";
 import { eq } from "drizzle-orm";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync as defaultExistsSync, readFileSync as defaultReadFileSync } from "node:fs";
 import { resolve, join } from "node:path";
-import { execSync } from "node:child_process";
-import { tmuxManager } from "./tmux-manager";
-import { slotAllocator } from "./slot-allocator";
-import { workflowLoader } from "./workflow-loader";
-import { contextBundler } from "./context-bundler";
+import { execSync as defaultExecSync } from "node:child_process";
+import { tmuxManager as defaultTmuxManager } from "./tmux-manager";
+import { slotAllocator as defaultSlotAllocator } from "./slot-allocator";
+import { workflowLoader as defaultWorkflowLoader } from "./workflow-loader";
+import { contextBundler as defaultContextBundler } from "./context-bundler";
 import type { WorkflowDefinition, WorkflowStep } from "./workflow-loader";
-import { eventBus } from "../utils/event-bus";
-import { logger } from "../utils/logger";
-import { writeHooks } from "../utils/hook-writer";
+import { eventBus as defaultEventBus } from "../utils/event-bus";
+import { logger as defaultLogger } from "../utils/logger";
+import { writeHooks as defaultWriteHooks } from "../utils/hook-writer";
 import {
   buildStreamingCommand,
   checkPassCondition,
   renderTemplate,
   shellEscape,
 } from "../utils/workflow-helpers";
-import { logCardEvent } from "../utils/card-events";
-import { streamTailer } from "./stream-tailer";
+import { logCardEvent as defaultLogCardEvent } from "../utils/card-events";
+import { streamTailer as defaultStreamTailer } from "./stream-tailer";
 
 interface RunContext {
   cardId: number;
@@ -48,11 +48,61 @@ export function resolveStepComplete(cardId: number): boolean {
   return false;
 }
 
+export interface WorkflowRunnerDeps {
+  db: typeof defaultDb;
+  eventBus: { emit: (event: string, ...args: unknown[]) => boolean | void };
+  logger: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+  tmuxManager: {
+    isAvailable: () => boolean;
+    createSession: (cardId: number, cwd: string) => { sessionName: string; created: boolean };
+    startCapture: (sessionName: string, cb: (data: string) => void) => void;
+    stopCapture: (sessionName: string) => void;
+    killSession: (sessionName: string) => boolean;
+    sendCommand: (sessionName: string, command: string) => void;
+  };
+  slotAllocator: {
+    claimSlot: (repoId: number, cardId: number) => Promise<{ id: number; path: string } | null>;
+    releaseSlot: (slotId: number) => Promise<void>;
+  };
+  workflowLoader: { get: (id: string) => WorkflowDefinition | undefined };
+  contextBundler: { buildPrompt: (opts: unknown) => string };
+  writeHooks: typeof defaultWriteHooks;
+  logCardEvent: typeof defaultLogCardEvent;
+  streamTailer: {
+    startTailing: (cardId: number, logFilePath: string) => Promise<void>;
+    stopTailing: (cardId: number) => void;
+  };
+  execSync: typeof defaultExecSync;
+  existsSync: typeof defaultExistsSync;
+  readFileSync: typeof defaultReadFileSync;
+}
+
 export class WorkflowRunner {
   private port: number;
+  private deps: WorkflowRunnerDeps;
 
-  constructor(port = 4200) {
+  constructor(port = 4200, deps: Partial<WorkflowRunnerDeps> = {}) {
     this.port = port;
+    this.deps = {
+      db: defaultDb,
+      eventBus: defaultEventBus,
+      logger: defaultLogger,
+      tmuxManager: defaultTmuxManager,
+      slotAllocator: defaultSlotAllocator,
+      workflowLoader: defaultWorkflowLoader,
+      contextBundler: defaultContextBundler,
+      writeHooks: defaultWriteHooks,
+      logCardEvent: defaultLogCardEvent,
+      streamTailer: defaultStreamTailer,
+      execSync: defaultExecSync,
+      existsSync: defaultExistsSync,
+      readFileSync: defaultReadFileSync,
+      ...deps,
+    };
   }
 
   /** Execute a full workflow for a card */
@@ -80,12 +130,12 @@ export class WorkflowRunner {
       await this.runPostSteps(ctx);
 
       // Mark workflow completed
-      await db
+      await this.deps.db
         .update(workflowRuns)
         .set({ status: "completed", endedAt: new Date() })
         .where(eq(workflowRuns.id, ctx.workflowRunId));
 
-      await db
+      await this.deps.db
         .update(cards)
         .set({
           column: "review",
@@ -95,72 +145,83 @@ export class WorkflowRunner {
         })
         .where(eq(cards.id, cardId));
 
-      eventBus.emit("card:moved", { cardId, fromColumn: "in_progress", toColumn: "review" });
-      eventBus.emit("card:status-changed", { cardId, status: "review_ready" });
-      eventBus.emit("workflow:completed", { cardId, status: "completed" });
+      this.deps.eventBus.emit("card:moved", {
+        cardId,
+        fromColumn: "in_progress",
+        toColumn: "review",
+      });
+      this.deps.eventBus.emit("card:status-changed", { cardId, status: "review_ready" });
+      this.deps.eventBus.emit("workflow:completed", { cardId, status: "completed" });
 
-      logger.info(`Workflow completed for card ${cardId}`);
+      this.deps.logger.info(`Workflow completed for card ${cardId}`);
     } catch (err) {
-      logger.error(`Workflow failed for card ${cardId}:`, err);
+      this.deps.logger.error(`Workflow failed for card ${cardId}:`, err);
       await this.handleFailure(ctx);
     } finally {
       // Cleanup
       pendingStepCallbacks.delete(ctx.cardId);
-      streamTailer.stopTailing(ctx.cardId);
-      tmuxManager.stopCapture(ctx.sessionName);
-      const killed = tmuxManager.killSession(ctx.sessionName);
+      this.deps.streamTailer.stopTailing(ctx.cardId);
+      this.deps.tmuxManager.stopCapture(ctx.sessionName);
+      const killed = this.deps.tmuxManager.killSession(ctx.sessionName);
       if (killed) {
-        await logCardEvent(ctx.cardId, "tmux_session_killed", `session=${ctx.sessionName}`);
+        await this.deps.logCardEvent(
+          ctx.cardId,
+          "tmux_session_killed",
+          `session=${ctx.sessionName}`,
+        );
       }
-      await slotAllocator.releaseSlot(ctx.slotId);
-      await logCardEvent(ctx.cardId, "slot_released", `slotId=${ctx.slotId}`);
+      await this.deps.slotAllocator.releaseSlot(ctx.slotId);
+      await this.deps.logCardEvent(ctx.cardId, "slot_released", `slotId=${ctx.slotId}`);
     }
   }
 
   /** Initialize execution context: fetch card, claim slot, create session */
   private async initContext(cardId: number): Promise<RunContext | null> {
     // Fetch card
-    const cardRows = await db.select().from(cards).where(eq(cards.id, cardId));
+    const cardRows = await this.deps.db.select().from(cards).where(eq(cards.id, cardId));
     if (cardRows.length === 0) {
-      logger.error(`Card ${cardId} not found`);
+      this.deps.logger.error(`Card ${cardId} not found`);
       return null;
     }
     const card = cardRows[0]!;
 
     if (!card.repoId || !card.workflowId) {
-      logger.error(`Card ${cardId} missing repoId or workflowId`);
+      this.deps.logger.error(`Card ${cardId} missing repoId or workflowId`);
       await this.updateCardStatus(cardId, "failed");
       return null;
     }
 
     // Fetch repo
-    const repoRows = await db.select().from(repositories).where(eq(repositories.id, card.repoId));
+    const repoRows = await this.deps.db
+      .select()
+      .from(repositories)
+      .where(eq(repositories.id, card.repoId));
     if (repoRows.length === 0) {
-      logger.error(`Repo ${card.repoId} not found for card ${cardId}`);
+      this.deps.logger.error(`Repo ${card.repoId} not found for card ${cardId}`);
       await this.updateCardStatus(cardId, "failed");
       return null;
     }
     const repo = repoRows[0]!;
 
     // Load workflow
-    const workflow = workflowLoader.get(card.workflowId);
+    const workflow = this.deps.workflowLoader.get(card.workflowId);
     if (!workflow) {
-      logger.error(`Workflow "${card.workflowId}" not found for card ${cardId}`);
+      this.deps.logger.error(`Workflow "${card.workflowId}" not found for card ${cardId}`);
       await this.updateCardStatus(cardId, "failed");
       return null;
     }
 
     // Check tmux
-    if (!tmuxManager.isAvailable()) {
-      logger.error("tmux is not available");
+    if (!this.deps.tmuxManager.isAvailable()) {
+      this.deps.logger.error("tmux is not available");
       await this.updateCardStatus(cardId, "failed");
       return null;
     }
 
     // Claim slot
-    const slot = await slotAllocator.claimSlot(card.repoId, cardId);
+    const slot = await this.deps.slotAllocator.claimSlot(card.repoId, cardId);
     if (!slot) {
-      logger.warn(`No slot available for card ${cardId}, marking queued`);
+      this.deps.logger.warn(`No slot available for card ${cardId}, marking queued`);
       await this.updateCardStatus(cardId, "queued");
       return null;
     }
@@ -169,9 +230,9 @@ export class WorkflowRunner {
     await this.updateCardStatus(cardId, "running");
 
     // Create tmux session
-    const { sessionName, created } = tmuxManager.createSession(cardId, slot.path);
+    const { sessionName, created } = this.deps.tmuxManager.createSession(cardId, slot.path);
     if (created) {
-      await logCardEvent(
+      await this.deps.logCardEvent(
         cardId,
         "tmux_session_created",
         `session=${sessionName}, cwd=${slot.path}`,
@@ -179,8 +240,8 @@ export class WorkflowRunner {
     }
 
     // Start output capture
-    tmuxManager.startCapture(sessionName, (output) => {
-      eventBus.emit("agent:output", { cardId, content: output });
+    this.deps.tmuxManager.startCapture(sessionName, (output) => {
+      this.deps.eventBus.emit("agent:output", { cardId, content: output });
     });
 
     // Build branch name
@@ -191,7 +252,7 @@ export class WorkflowRunner {
     });
 
     // Create workflow run record
-    const runRows = await db
+    const runRows = await this.deps.db
       .insert(workflowRuns)
       .values({
         cardId,
@@ -220,20 +281,20 @@ export class WorkflowRunner {
   /** Create a git branch in the slot directory */
   private createBranch(ctx: RunContext): void {
     try {
-      execSync(`git checkout -b ${ctx.branch}`, {
+      this.deps.execSync(`git checkout -b ${ctx.branch}`, {
         cwd: ctx.slotPath,
         stdio: "ignore",
       });
-      logger.info(`Created branch ${ctx.branch} in ${ctx.slotPath}`);
+      this.deps.logger.info(`Created branch ${ctx.branch} in ${ctx.slotPath}`);
     } catch {
       // Branch may already exist — try checking it out
       try {
-        execSync(`git checkout ${ctx.branch}`, {
+        this.deps.execSync(`git checkout ${ctx.branch}`, {
           cwd: ctx.slotPath,
           stdio: "ignore",
         });
       } catch (err) {
-        logger.error(`Failed to create/checkout branch ${ctx.branch}:`, err);
+        this.deps.logger.error(`Failed to create/checkout branch ${ctx.branch}:`, err);
       }
     }
   }
@@ -248,7 +309,7 @@ export class WorkflowRunner {
 
     for (let retry = 0; retry <= maxRetries; retry++) {
       // Create step run record
-      const stepRunRows = await db
+      const stepRunRows = await this.deps.db
         .insert(stepRuns)
         .values({
           workflowRunId: ctx.workflowRunId,
@@ -260,17 +321,21 @@ export class WorkflowRunner {
       const stepRunId = stepRunRows[0]!.id;
 
       // Update card current step
-      await db
+      await this.deps.db
         .update(cards)
         .set({ currentStepId: step.id, retryCount: retry, updatedAt: new Date() })
         .where(eq(cards.id, ctx.cardId));
 
-      eventBus.emit("step:started", { cardId: ctx.cardId, stepId: step.id });
-      await logCardEvent(ctx.cardId, "step_started", `stepId=${step.id}, retry=${retry}`);
+      this.deps.eventBus.emit("step:started", { cardId: ctx.cardId, stepId: step.id });
+      await this.deps.logCardEvent(ctx.cardId, "step_started", `stepId=${step.id}, retry=${retry}`);
 
       // Write Stop hook for this step — points to step-complete callback
-      writeHooks(ctx.slotPath, ctx.cardId, this.port, "step-complete");
-      await logCardEvent(ctx.cardId, "hooks_written", `endpoint=step-complete, step=${step.id}`);
+      this.deps.writeHooks(ctx.slotPath, ctx.cardId, this.port, "step-complete");
+      await this.deps.logCardEvent(
+        ctx.cardId,
+        "hooks_written",
+        `endpoint=step-complete, step=${step.id}`,
+      );
 
       // Build prompt
       const prompt = await this.buildStepPrompt(ctx, step);
@@ -283,27 +348,27 @@ export class WorkflowRunner {
       const logFilePath = join(ctx.slotPath, ".claude-stream.ndjson");
       const command = buildStreamingCommand(args, logFilePath);
 
-      tmuxManager.sendCommand(ctx.sessionName, command);
+      this.deps.tmuxManager.sendCommand(ctx.sessionName, command);
 
       // Start tailing the stream-json output for structured activity events
-      await streamTailer.startTailing(ctx.cardId, logFilePath);
+      await this.deps.streamTailer.startTailing(ctx.cardId, logFilePath);
 
       // Wait for Stop hook callback (step-complete endpoint resolves this)
       const completed = await this.waitForStepComplete(ctx.cardId);
 
       if (!completed) {
-        logger.warn(`Step ${step.id} timed out for card ${ctx.cardId}`);
-        await logCardEvent(
+        this.deps.logger.warn(`Step ${step.id} timed out for card ${ctx.cardId}`);
+        await this.deps.logCardEvent(
           ctx.cardId,
           "step_failed",
           `stepId=${step.id}, reason=timeout, retry=${retry}`,
         );
-        await db
+        await this.deps.db
           .update(stepRuns)
           .set({ status: "failed", endedAt: new Date() })
           .where(eq(stepRuns.id, stepRunId));
 
-        eventBus.emit("step:failed", {
+        this.deps.eventBus.emit("step:failed", {
           cardId: ctx.cardId,
           stepId: step.id,
           retryNumber: retry,
@@ -324,19 +389,21 @@ export class WorkflowRunner {
       );
 
       // Check for artifact after hook fired
-      if (!existsSync(artifactPath)) {
-        logger.warn(`Artifact not found at ${artifactPath} after step ${step.id} completed`);
-        await logCardEvent(
+      if (!this.deps.existsSync(artifactPath)) {
+        this.deps.logger.warn(
+          `Artifact not found at ${artifactPath} after step ${step.id} completed`,
+        );
+        await this.deps.logCardEvent(
           ctx.cardId,
           "step_failed",
           `stepId=${step.id}, reason=artifact_missing, retry=${retry}`,
         );
-        await db
+        await this.deps.db
           .update(stepRuns)
           .set({ status: "failed", endedAt: new Date() })
           .where(eq(stepRuns.id, stepRunId));
 
-        eventBus.emit("step:failed", {
+        this.deps.eventBus.emit("step:failed", {
           cardId: ctx.cardId,
           stepId: step.id,
           retryNumber: retry,
@@ -347,24 +414,24 @@ export class WorkflowRunner {
       }
 
       // Read artifact content
-      const artifactContent = readFileSync(artifactPath, "utf-8");
+      const artifactContent = this.deps.readFileSync(artifactPath, "utf-8");
       ctx.previousArtifacts.set(step.id, artifactContent);
 
       // Check pass condition if defined
       if (step.pass_condition) {
         const passed = checkPassCondition(step.pass_condition, artifactContent);
         if (!passed) {
-          await logCardEvent(
+          await this.deps.logCardEvent(
             ctx.cardId,
             "step_failed",
             `stepId=${step.id}, reason=pass_condition, retry=${retry}`,
           );
-          await db
+          await this.deps.db
             .update(stepRuns)
             .set({ status: "failed", endedAt: new Date(), artifactPath })
             .where(eq(stepRuns.id, stepRunId));
 
-          eventBus.emit("step:failed", {
+          this.deps.eventBus.emit("step:failed", {
             cardId: ctx.cardId,
             stepId: step.id,
             retryNumber: retry,
@@ -375,7 +442,7 @@ export class WorkflowRunner {
             const targetStepId = step.on_fail.slice(5);
             const targetIndex = ctx.workflow.steps.findIndex((s) => s.id === targetStepId);
             if (targetIndex >= 0) {
-              logger.info(`Step ${step.id} failed, retrying from ${targetStepId}`);
+              this.deps.logger.info(`Step ${step.id} failed, retrying from ${targetStepId}`);
               continue;
             }
           }
@@ -386,24 +453,24 @@ export class WorkflowRunner {
       }
 
       // Step passed
-      await db
+      await this.deps.db
         .update(stepRuns)
         .set({ status: "completed", endedAt: new Date(), artifactPath })
         .where(eq(stepRuns.id, stepRunId));
 
-      await db
+      await this.deps.db
         .update(cards)
         .set({ currentStepId: `${step.id}:done`, updatedAt: new Date() })
         .where(eq(cards.id, ctx.cardId));
 
-      await logCardEvent(ctx.cardId, "step_completed", `stepId=${step.id}`);
-      eventBus.emit("step:completed", {
+      await this.deps.logCardEvent(ctx.cardId, "step_completed", `stepId=${step.id}`);
+      this.deps.eventBus.emit("step:completed", {
         cardId: ctx.cardId,
         stepId: step.id,
         passed: true,
       });
 
-      logger.info(`Step ${step.id} completed for card ${ctx.cardId}`);
+      this.deps.logger.info(`Step ${step.id} completed for card ${ctx.cardId}`);
       return true;
     }
 
@@ -427,7 +494,7 @@ export class WorkflowRunner {
 
   /** Build the prompt for a step using the context bundler */
   private buildStepPrompt(ctx: RunContext, step: WorkflowStep): string {
-    return contextBundler.buildPrompt({
+    return this.deps.contextBundler.buildPrompt({
       step,
       card: ctx.card,
       slotPath: ctx.slotPath,
@@ -453,32 +520,32 @@ export class WorkflowRunner {
 
     // Push branch and create PR via git/gh CLI
     try {
-      execSync(`git push -u origin ${ctx.branch}`, {
+      this.deps.execSync(`git push -u origin ${ctx.branch}`, {
         cwd: ctx.slotPath,
         stdio: "ignore",
       });
 
       const base = ctx.repo.defaultBranch ?? "main";
-      const prUrl = execSync(
+      const prUrl = this.deps.execSync(
         `gh pr create --title ${shellEscape(prTitle)} --body "Automated by AgentBoard" --base ${base} --head ${ctx.branch}`,
         { cwd: ctx.slotPath, encoding: "utf-8" },
-      ).trim();
+      ) as unknown as string;
 
-      logger.info(`PR created for card ${ctx.cardId}: ${prUrl}`);
+      this.deps.logger.info(`PR created for card ${ctx.cardId}: ${prUrl.trim()}`);
     } catch (err) {
-      logger.error(`Failed to create PR for card ${ctx.cardId}:`, err);
+      this.deps.logger.error(`Failed to create PR for card ${ctx.cardId}:`, err);
     }
   }
 
   /** Handle workflow failure: update statuses */
   private async handleFailure(ctx: RunContext): Promise<void> {
-    await db
+    await this.deps.db
       .update(workflowRuns)
       .set({ status: "failed", endedAt: new Date() })
       .where(eq(workflowRuns.id, ctx.workflowRunId));
 
     await this.updateCardStatus(ctx.cardId, "failed");
-    eventBus.emit("workflow:completed", { cardId: ctx.cardId, status: "failed" });
+    this.deps.eventBus.emit("workflow:completed", { cardId: ctx.cardId, status: "failed" });
   }
 
   private async updateCardStatus(
@@ -493,9 +560,12 @@ export class WorkflowRunner {
       | "failed"
       | "blocked",
   ): Promise<void> {
-    await db.update(cards).set({ status, updatedAt: new Date() }).where(eq(cards.id, cardId));
+    await this.deps.db
+      .update(cards)
+      .set({ status, updatedAt: new Date() })
+      .where(eq(cards.id, cardId));
 
-    eventBus.emit("card:status-changed", { cardId, status });
+    this.deps.eventBus.emit("card:status-changed", { cardId, status });
   }
 }
 

--- a/plugins/tt-agentboard/test/helpers/mock-deps.ts
+++ b/plugins/tt-agentboard/test/helpers/mock-deps.ts
@@ -1,0 +1,42 @@
+import { vi } from "vitest";
+
+export function createMockDb() {
+  const mockChain = () => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn().mockReturnValue(chain);
+    chain.where = vi.fn().mockReturnValue(chain);
+    chain.set = vi.fn().mockReturnValue(chain);
+    chain.values = vi.fn().mockResolvedValue(undefined);
+    chain.limit = vi.fn().mockResolvedValue([]);
+    chain.returning = vi.fn().mockResolvedValue([]);
+    chain.orderBy = vi.fn().mockReturnValue(chain);
+    return chain;
+  };
+  return {
+    select: vi.fn().mockReturnValue(mockChain()),
+    update: vi.fn().mockReturnValue(mockChain()),
+    insert: vi.fn().mockReturnValue(mockChain()),
+    delete: vi.fn().mockReturnValue(mockChain()),
+  };
+}
+
+export function createMockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+export function createMockEventBus() {
+  return { emit: vi.fn(), on: vi.fn(), off: vi.fn() };
+}
+
+export function createMockTmuxManager() {
+  return {
+    isAvailable: vi.fn().mockReturnValue(true),
+    createSession: vi.fn().mockReturnValue({ sessionName: "card-1", created: true }),
+    startCapture: vi.fn(),
+    stopCapture: vi.fn(),
+    killSession: vi.fn().mockReturnValue(true),
+    sendCommand: vi.fn(),
+    sessionExists: vi.fn().mockReturnValue(false),
+    listAgentSessions: vi.fn().mockReturnValue([]),
+  };
+}

--- a/plugins/tt-agentboard/test/helpers/mock-deps.ts
+++ b/plugins/tt-agentboard/test/helpers/mock-deps.ts
@@ -1,42 +1,129 @@
 import { vi } from "vitest";
 
+/** Create a mock Drizzle-like db with chainable select/update/insert */
 export function createMockDb() {
   const mockChain = () => {
     const chain: Record<string, unknown> = {};
     chain.from = vi.fn().mockReturnValue(chain);
     chain.where = vi.fn().mockReturnValue(chain);
     chain.set = vi.fn().mockReturnValue(chain);
-    chain.values = vi.fn().mockResolvedValue(undefined);
     chain.limit = vi.fn().mockResolvedValue([]);
-    chain.returning = vi.fn().mockResolvedValue([]);
-    chain.orderBy = vi.fn().mockReturnValue(chain);
+    chain.values = vi.fn().mockReturnValue(chain);
+    chain.returning = vi.fn().mockResolvedValue([{ id: 1 }]);
     return chain;
   };
+
   return {
     select: vi.fn().mockReturnValue(mockChain()),
     update: vi.fn().mockReturnValue(mockChain()),
     insert: vi.fn().mockReturnValue(mockChain()),
-    delete: vi.fn().mockReturnValue(mockChain()),
   };
 }
 
+export type MockDb = ReturnType<typeof createMockDb>;
+
+/** Create a mock logger matching consola's interface */
 export function createMockLogger() {
-  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
 }
 
+export type MockLogger = ReturnType<typeof createMockLogger>;
+
+/** Create a mock EventEmitter-based event bus */
 export function createMockEventBus() {
-  return { emit: vi.fn(), on: vi.fn(), off: vi.fn() };
+  return {
+    emit: vi.fn(),
+    on: vi.fn(),
+  };
 }
 
+export type MockEventBus = ReturnType<typeof createMockEventBus>;
+
+/** Create a mock TmuxManager */
 export function createMockTmuxManager() {
   return {
     isAvailable: vi.fn().mockReturnValue(true),
     createSession: vi.fn().mockReturnValue({ sessionName: "card-1", created: true }),
     startCapture: vi.fn(),
     stopCapture: vi.fn(),
-    killSession: vi.fn().mockReturnValue(true),
+    killSession: vi.fn(),
     sendCommand: vi.fn(),
-    sessionExists: vi.fn().mockReturnValue(false),
-    listAgentSessions: vi.fn().mockReturnValue([]),
+    on: vi.fn(),
+    emit: vi.fn(),
   };
+}
+
+export type MockTmuxManager = ReturnType<typeof createMockTmuxManager>;
+
+/** Create a mock SlotAllocator */
+export function createMockSlotAllocator() {
+  return {
+    claimSlot: vi.fn().mockResolvedValue({ id: 1, path: "/workspace/slot-1" }),
+    releaseSlot: vi.fn().mockResolvedValue(undefined),
+    getSlotForCard: vi.fn().mockResolvedValue(null),
+  };
+}
+
+/** Create a mock WorkflowLoader */
+export function createMockWorkflowLoader() {
+  return {
+    get: vi.fn().mockReturnValue(null),
+  };
+}
+
+/** Create a mock ContextBundler */
+export function createMockContextBundler() {
+  return {
+    buildPrompt: vi.fn().mockReturnValue("test prompt"),
+  };
+}
+
+/** Create a mock WorkflowRunner */
+export function createMockWorkflowRunner() {
+  return {
+    run: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Create a mock StreamTailer */
+export function createMockStreamTailer() {
+  return {
+    startTailing: vi.fn().mockResolvedValue(undefined),
+    stopTailing: vi.fn(),
+  };
+}
+
+/** Create a mock execSync function */
+export function createMockExecSync() {
+  return vi.fn().mockReturnValue(Buffer.from(""));
+}
+
+/** Helper to configure mock db select to return specific rows */
+export function setupSelectReturning(mockDb: MockDb, rows: unknown[]) {
+  const selectChain: Record<string, unknown> = {};
+  selectChain.from = vi.fn().mockReturnValue(selectChain);
+  selectChain.where = vi.fn().mockResolvedValue(rows);
+  mockDb.select = vi.fn().mockReturnValue(selectChain);
+}
+
+/** Helper to configure mock db update */
+export function setupUpdate(mockDb: MockDb) {
+  const updateChain: Record<string, unknown> = {};
+  updateChain.set = vi.fn().mockReturnValue(updateChain);
+  updateChain.where = vi.fn().mockResolvedValue(undefined);
+  mockDb.update = vi.fn().mockReturnValue(updateChain);
+  return updateChain;
+}
+
+/** Helper to configure mock db insert */
+export function setupInsert(mockDb: MockDb) {
+  const insertChain: Record<string, unknown> = {};
+  insertChain.values = vi.fn().mockReturnValue(insertChain);
+  insertChain.returning = vi.fn().mockResolvedValue([{ id: 1 }]);
+  mockDb.insert = vi.fn().mockReturnValue(insertChain);
 }

--- a/plugins/tt-agentboard/test/services/agent-executor.test.ts
+++ b/plugins/tt-agentboard/test/services/agent-executor.test.ts
@@ -1,136 +1,94 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock dependencies before importing AgentExecutor
-vi.mock("../../server/db", () => {
-  const mockChain = () => {
-    const chain: Record<string, unknown> = {};
-    chain.from = vi.fn().mockReturnValue(chain);
-    chain.where = vi.fn().mockReturnValue(chain);
-    chain.set = vi.fn().mockReturnValue(chain);
-    chain.limit = vi.fn().mockResolvedValue([]);
-    chain.values = vi.fn().mockReturnValue(chain);
-    chain.returning = vi.fn().mockResolvedValue([{ id: 1 }]);
-    return chain;
-  };
-
-  return {
-    db: {
-      select: vi.fn().mockReturnValue(mockChain()),
-      update: vi.fn().mockReturnValue(mockChain()),
-      insert: vi.fn().mockReturnValue(mockChain()),
-    },
-  };
-});
-
-vi.mock("../../server/utils/event-bus", () => ({
-  eventBus: { emit: vi.fn(), on: vi.fn() },
+// Minimal mocks for modules that can't load in test environment (SQLite, glob)
+vi.mock("../../server/db", () => ({
+  db: {},
 }));
 
-vi.mock("../../server/utils/logger", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+vi.mock("glob", () => ({
+  glob: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("../../server/utils/hook-writer", () => ({
-  writeHooks: vi.fn(),
-}));
-
-vi.mock("../../server/services/tmux-manager", () => ({
-  tmuxManager: {
-    isAvailable: vi.fn().mockReturnValue(true),
-    createSession: vi.fn().mockReturnValue({ sessionName: "card-1", created: true }),
-    startCapture: vi.fn(),
-    stopCapture: vi.fn(),
-    killSession: vi.fn(),
-    sendCommand: vi.fn(),
-  },
-}));
-
-vi.mock("../../server/services/slot-allocator", () => ({
-  slotAllocator: {
-    claimSlot: vi.fn().mockResolvedValue({ id: 1, path: "/workspace/slot-1" }),
-    releaseSlot: vi.fn(),
-  },
-}));
-
-vi.mock("../../server/services/workflow-loader", () => ({
-  workflowLoader: {
-    get: vi.fn().mockReturnValue(null),
-  },
-}));
-
-vi.mock("../../server/services/workflow-runner", () => ({
-  workflowRunner: {
-    run: vi.fn().mockResolvedValue(undefined),
-  },
+vi.mock("../../server/utils/card-events", () => ({
+  logCardEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
 // eslint-disable-next-line import/first -- vi.mock must come before imports (vitest hoisting)
-import { db } from "../../server/db";
-// eslint-disable-next-line import/first
-import { eventBus } from "../../server/utils/event-bus";
-// eslint-disable-next-line import/first
-import { tmuxManager } from "../../server/services/tmux-manager";
-// eslint-disable-next-line import/first
-import { slotAllocator } from "../../server/services/slot-allocator";
-// eslint-disable-next-line import/first
-import { workflowLoader } from "../../server/services/workflow-loader";
-// eslint-disable-next-line import/first
-import { workflowRunner } from "../../server/services/workflow-runner";
-// eslint-disable-next-line import/first
-import { writeHooks } from "../../server/utils/hook-writer";
-// eslint-disable-next-line import/first
 import { AgentExecutor } from "../../server/services/agent-executor";
-
-const mockDb = vi.mocked(db);
-
-function setupSelectReturning(rows: unknown[]) {
-  const selectChain: Record<string, unknown> = {};
-  selectChain.from = vi.fn().mockReturnValue(selectChain);
-  selectChain.where = vi.fn().mockResolvedValue(rows);
-  mockDb.select = vi.fn().mockReturnValue(selectChain);
-}
-
-function setupUpdate() {
-  const updateChain: Record<string, unknown> = {};
-  updateChain.set = vi.fn().mockReturnValue(updateChain);
-  updateChain.where = vi.fn().mockResolvedValue(undefined);
-  mockDb.update = vi.fn().mockReturnValue(updateChain);
-  return updateChain;
-}
-
-function setupInsert() {
-  const insertChain: Record<string, unknown> = {};
-  insertChain.values = vi.fn().mockReturnValue(insertChain);
-  insertChain.returning = vi.fn().mockResolvedValue([{ id: 1 }]);
-  mockDb.insert = vi.fn().mockReturnValue(insertChain);
-}
+// eslint-disable-next-line import/first
+import {
+  createMockDb,
+  createMockEventBus,
+  createMockLogger,
+  createMockTmuxManager,
+  createMockSlotAllocator,
+  createMockWorkflowLoader,
+  createMockWorkflowRunner,
+  createMockStreamTailer,
+  createMockExecSync,
+  setupSelectReturning,
+  setupUpdate,
+  setupInsert,
+} from "../helpers/mock-deps";
+// eslint-disable-next-line import/first
+import type { MockDb } from "../helpers/mock-deps";
 
 describe("AgentExecutor", () => {
   let executor: AgentExecutor;
+  let mockDb: MockDb;
+  let mockEventBus: ReturnType<typeof createMockEventBus>;
+  let mockTmuxManager: ReturnType<typeof createMockTmuxManager>;
+  let mockSlotAllocator: ReturnType<typeof createMockSlotAllocator>;
+  let mockWorkflowLoader: ReturnType<typeof createMockWorkflowLoader>;
+  let mockWorkflowRunner: ReturnType<typeof createMockWorkflowRunner>;
+  let mockWriteHooks: ReturnType<typeof vi.fn>;
+  let mockLogCardEvent: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    executor = new AgentExecutor(4200);
+    mockDb = createMockDb();
+    mockEventBus = createMockEventBus();
+    mockTmuxManager = createMockTmuxManager();
+    mockSlotAllocator = createMockSlotAllocator();
+    mockWorkflowLoader = createMockWorkflowLoader();
+    mockWorkflowRunner = createMockWorkflowRunner();
+    mockWriteHooks = vi.fn();
+    mockLogCardEvent = vi.fn().mockResolvedValue(undefined);
+
+    executor = new AgentExecutor(4200, {
+      db: mockDb as never,
+      eventBus: mockEventBus,
+      logger: createMockLogger(),
+      tmuxManager: mockTmuxManager,
+      slotAllocator: mockSlotAllocator as never,
+      workflowLoader: mockWorkflowLoader,
+      workflowRunner: mockWorkflowRunner,
+      writeHooks: mockWriteHooks as never,
+      logCardEvent: mockLogCardEvent as never,
+      streamTailer: createMockStreamTailer(),
+      execSync: createMockExecSync() as never,
+      existsSync: vi.fn().mockReturnValue(false) as never,
+    });
     vi.clearAllMocks();
   });
 
   describe("startExecution()", () => {
     it("returns early when card not found", async () => {
-      setupSelectReturning([]);
+      setupSelectReturning(mockDb, []);
 
       await executor.startExecution(999);
 
       expect(mockDb.update).not.toHaveBeenCalled();
-      expect(vi.mocked(eventBus.emit)).not.toHaveBeenCalled();
+      expect(mockEventBus.emit).not.toHaveBeenCalled();
     });
 
     it("marks failed when card has no repoId", async () => {
       const card = { id: 1, repoId: null, workflowId: null, title: "Test" };
-      setupSelectReturning([card]);
-      setupUpdate();
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
 
       await executor.startExecution(1);
 
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith("card:status-changed", {
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
         cardId: 1,
         status: "failed",
       });
@@ -138,14 +96,14 @@ describe("AgentExecutor", () => {
 
     it("delegates to workflowRunner when card has valid workflow", async () => {
       const card = { id: 1, repoId: 1, workflowId: "plan", title: "Test" };
-      setupSelectReturning([card]);
+      setupSelectReturning(mockDb, [card]);
 
       const workflow = { name: "plan", steps: [] };
-      vi.mocked(workflowLoader.get).mockReturnValue(workflow as never);
+      mockWorkflowLoader.get.mockReturnValue(workflow as never);
 
       await executor.startExecution(1);
 
-      expect(vi.mocked(workflowRunner.run)).toHaveBeenCalledWith(1);
+      expect(mockWorkflowRunner.run).toHaveBeenCalledWith(1);
     });
 
     it("falls back to single prompt when workflow not found", async () => {
@@ -157,21 +115,21 @@ describe("AgentExecutor", () => {
         description: "Do something",
         executionMode: "headless",
       };
-      setupSelectReturning([card]);
-      setupUpdate();
-      setupInsert();
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
+      setupInsert(mockDb);
 
-      vi.mocked(workflowLoader.get).mockReturnValue(undefined as never);
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(true);
-      vi.mocked(slotAllocator.claimSlot).mockResolvedValue({
+      mockWorkflowLoader.get.mockReturnValue(undefined as never);
+      mockTmuxManager.isAvailable.mockReturnValue(true);
+      mockSlotAllocator.claimSlot.mockResolvedValue({
         id: 1,
         path: "/workspace/slot-1",
       } as never);
 
       await executor.startExecution(1);
 
-      expect(vi.mocked(workflowRunner.run)).not.toHaveBeenCalled();
-      expect(vi.mocked(tmuxManager.sendCommand)).toHaveBeenCalled();
+      expect(mockWorkflowRunner.run).not.toHaveBeenCalled();
+      expect(mockTmuxManager.sendCommand).toHaveBeenCalled();
     });
 
     it("marks queued when no slots available", async () => {
@@ -182,15 +140,15 @@ describe("AgentExecutor", () => {
         title: "Test",
         executionMode: "headless",
       };
-      setupSelectReturning([card]);
-      setupUpdate();
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
 
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(true);
-      vi.mocked(slotAllocator.claimSlot).mockResolvedValue(null);
+      mockTmuxManager.isAvailable.mockReturnValue(true);
+      mockSlotAllocator.claimSlot.mockResolvedValue(null);
 
       await executor.startExecution(1);
 
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith("card:status-changed", {
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
         cardId: 1,
         status: "queued",
       });
@@ -204,14 +162,14 @@ describe("AgentExecutor", () => {
         title: "Test",
         executionMode: "headless",
       };
-      setupSelectReturning([card]);
-      setupUpdate();
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
 
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(false);
+      mockTmuxManager.isAvailable.mockReturnValue(false);
 
       await executor.startExecution(1);
 
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith("card:status-changed", {
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
         cardId: 1,
         status: "failed",
       });
@@ -226,25 +184,24 @@ describe("AgentExecutor", () => {
         description: "Implement feature",
         executionMode: "headless",
       };
-      setupSelectReturning([card]);
-      setupUpdate();
-      setupInsert();
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
+      setupInsert(mockDb);
 
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(true);
-      vi.mocked(slotAllocator.claimSlot).mockResolvedValue({
+      mockTmuxManager.isAvailable.mockReturnValue(true);
+      mockSlotAllocator.claimSlot.mockResolvedValue({
         id: 1,
         path: "/workspace/slot-1",
       } as never);
 
       await executor.startExecution(1);
 
-      expect(vi.mocked(writeHooks)).toHaveBeenCalledWith("/workspace/slot-1", 1, 4200, "complete");
-      expect(vi.mocked(tmuxManager.createSession)).toHaveBeenCalledWith(1, "/workspace/slot-1");
-      expect(vi.mocked(tmuxManager.startCapture)).toHaveBeenCalled();
-      expect(vi.mocked(tmuxManager.sendCommand)).toHaveBeenCalledWith(
-        "card-1",
-        expect.stringContaining("claude -p"),
-      );
+      expect(mockWriteHooks).toHaveBeenCalledWith("/workspace/slot-1", 1, 4200, "complete");
+      expect(mockTmuxManager.createSession).toHaveBeenCalledWith(1, "/workspace/slot-1");
+      expect(mockTmuxManager.startCapture).toHaveBeenCalled();
+      const cmd = mockTmuxManager.sendCommand.mock.calls[0]![1] as string;
+      expect(cmd).toContain("claude");
+      expect(cmd).toContain("-p");
     });
 
     it("uses --dangerously-skip-permissions for headless mode", async () => {
@@ -256,19 +213,19 @@ describe("AgentExecutor", () => {
         description: null,
         executionMode: "headless",
       };
-      setupSelectReturning([card]);
-      setupUpdate();
-      setupInsert();
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
+      setupInsert(mockDb);
 
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(true);
-      vi.mocked(slotAllocator.claimSlot).mockResolvedValue({
+      mockTmuxManager.isAvailable.mockReturnValue(true);
+      mockSlotAllocator.claimSlot.mockResolvedValue({
         id: 1,
         path: "/workspace/slot-1",
       } as never);
 
       await executor.startExecution(1);
 
-      const sendCommandCall = vi.mocked(tmuxManager.sendCommand).mock.calls[0]!;
+      const sendCommandCall = mockTmuxManager.sendCommand.mock.calls[0]!;
       expect(sendCommandCall[1]).toContain("--dangerously-skip-permissions");
     });
 
@@ -281,19 +238,19 @@ describe("AgentExecutor", () => {
         description: "do stuff",
         executionMode: "interactive",
       };
-      setupSelectReturning([card]);
-      setupUpdate();
-      setupInsert();
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
+      setupInsert(mockDb);
 
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(true);
-      vi.mocked(slotAllocator.claimSlot).mockResolvedValue({
+      mockTmuxManager.isAvailable.mockReturnValue(true);
+      mockSlotAllocator.claimSlot.mockResolvedValue({
         id: 1,
         path: "/workspace/slot-1",
       } as never);
 
       await executor.startExecution(1);
 
-      const sendCommandCall = vi.mocked(tmuxManager.sendCommand).mock.calls[0]!;
+      const sendCommandCall = mockTmuxManager.sendCommand.mock.calls[0]!;
       expect(sendCommandCall[1]).not.toContain("--dangerously-skip-permissions");
     });
 
@@ -306,19 +263,19 @@ describe("AgentExecutor", () => {
         description: null,
         executionMode: "headless",
       };
-      setupSelectReturning([card]);
-      setupUpdate();
-      setupInsert();
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
+      setupInsert(mockDb);
 
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(true);
-      vi.mocked(slotAllocator.claimSlot).mockResolvedValue({
+      mockTmuxManager.isAvailable.mockReturnValue(true);
+      mockSlotAllocator.claimSlot.mockResolvedValue({
         id: 1,
         path: "/workspace/slot-1",
       } as never);
 
       await executor.startExecution(1);
 
-      const sendCommandCall = vi.mocked(tmuxManager.sendCommand).mock.calls[0]!;
+      const sendCommandCall = mockTmuxManager.sendCommand.mock.calls[0]!;
       expect(sendCommandCall[1]).toContain("Fix the bug");
     });
   });

--- a/plugins/tt-agentboard/test/services/dependency-resolver.test.ts
+++ b/plugins/tt-agentboard/test/services/dependency-resolver.test.ts
@@ -1,36 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// Mock the db module before importing DependencyResolver
-vi.mock("../../server/db", () => {
-  const mockChain = () => {
-    const chain: Record<string, unknown> = {};
-    chain.from = vi.fn().mockReturnValue(chain);
-    chain.where = vi.fn().mockReturnValue(chain);
-    chain.set = vi.fn().mockReturnValue(chain);
-    chain.limit = vi.fn().mockResolvedValue([]);
-    return chain;
-  };
-
-  return {
-    db: {
-      select: vi.fn().mockReturnValue(mockChain()),
-      update: vi.fn().mockReturnValue(mockChain()),
-    },
-  };
-});
-
-// eslint-disable-next-line import/first -- vi.mock must come before imports (vitest hoisting)
-import { db } from "../../server/db";
-// eslint-disable-next-line import/first
+import { createMockDb, createMockLogger } from "../helpers/mock-deps";
 import { DependencyResolver } from "../../server/services/dependency-resolver";
-
-const mockDb = vi.mocked(db);
 
 describe("DependencyResolver", () => {
   let resolver: DependencyResolver;
+  let mockDb: ReturnType<typeof createMockDb>;
 
   beforeEach(() => {
-    resolver = new DependencyResolver();
+    mockDb = createMockDb();
+    resolver = new DependencyResolver({
+      db: mockDb as never,
+      logger: createMockLogger() as never,
+    });
     vi.clearAllMocks();
   });
 

--- a/plugins/tt-agentboard/test/services/github-service.test.ts
+++ b/plugins/tt-agentboard/test/services/github-service.test.ts
@@ -1,31 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
-const { mockExecSync } = vi.hoisted(() => ({
-  mockExecSync: vi.fn(),
-}));
-
-vi.mock("node:child_process", () => ({
-  execSync: mockExecSync,
-}));
-
-vi.mock("../../server/utils/event-bus", () => ({
-  eventBus: { emit: vi.fn(), on: vi.fn() },
-}));
-
-vi.mock("../../server/utils/logger", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-}));
-
-// eslint-disable-next-line import/first -- vi.mock must come before imports (vitest hoisting)
+import { createMockLogger, createMockEventBus } from "../helpers/mock-deps";
 import { GitHubService } from "../../server/services/github-service";
-// eslint-disable-next-line import/first
-import { eventBus } from "../../server/utils/event-bus";
 
 describe("GitHubService", () => {
   let service: GitHubService;
+  let mockExecSync: ReturnType<typeof vi.fn>;
+  let mockEventBus: ReturnType<typeof createMockEventBus>;
 
   beforeEach(() => {
-    service = new GitHubService();
+    mockExecSync = vi.fn();
+    mockEventBus = createMockEventBus();
+    service = new GitHubService({
+      execSync: mockExecSync as never,
+      eventBus: mockEventBus as never,
+      logger: createMockLogger() as never,
+    });
     vi.clearAllMocks();
   });
 
@@ -205,7 +194,7 @@ describe("GitHubService", () => {
       // Allow the immediate poll() to resolve
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith(
+      expect(mockEventBus.emit).toHaveBeenCalledWith(
         "github:issue-found",
         expect.objectContaining({ issueNumber: 1, repoId: 1 }),
       );

--- a/plugins/tt-agentboard/test/services/slot-allocator.test.ts
+++ b/plugins/tt-agentboard/test/services/slot-allocator.test.ts
@@ -1,45 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// Mock the db and event-bus modules
-vi.mock("../../server/db", () => {
-  const mockChain = () => {
-    const chain: Record<string, unknown> = {};
-    chain.from = vi.fn().mockReturnValue(chain);
-    chain.where = vi.fn().mockReturnValue(chain);
-    chain.set = vi.fn().mockReturnValue(chain);
-    chain.limit = vi.fn().mockResolvedValue([]);
-    return chain;
-  };
-
-  return {
-    db: {
-      select: vi.fn().mockReturnValue(mockChain()),
-      update: vi.fn().mockReturnValue(mockChain()),
-    },
-  };
-});
-
-vi.mock("../../server/utils/event-bus", () => ({
-  eventBus: {
-    emit: vi.fn(),
-  },
-}));
-
-// eslint-disable-next-line import/first -- vi.mock must come before imports (vitest hoisting)
-import { db } from "../../server/db";
-// eslint-disable-next-line import/first
-import { eventBus } from "../../server/utils/event-bus";
-// eslint-disable-next-line import/first
+import { createMockDb, createMockEventBus, createMockLogger } from "../helpers/mock-deps";
 import { SlotAllocator } from "../../server/services/slot-allocator";
-
-const mockDb = vi.mocked(db);
-const mockEventBus = vi.mocked(eventBus);
 
 describe("SlotAllocator", () => {
   let allocator: SlotAllocator;
+  let mockDb: ReturnType<typeof createMockDb>;
+  let mockEventBus: ReturnType<typeof createMockEventBus>;
 
   beforeEach(() => {
-    allocator = new SlotAllocator();
+    mockDb = createMockDb();
+    mockEventBus = createMockEventBus();
+    allocator = new SlotAllocator({
+      db: mockDb as never,
+      eventBus: mockEventBus as never,
+      logger: createMockLogger() as never,
+    });
     vi.clearAllMocks();
   });
 

--- a/plugins/tt-agentboard/test/services/stream-tailer.test.ts
+++ b/plugins/tt-agentboard/test/services/stream-tailer.test.ts
@@ -2,29 +2,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { writeFileSync, mkdirSync, rmSync, appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-
-vi.mock("../../server/utils/logger", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-}));
-
-const emittedEvents: Array<{ cardId: number; event: unknown; timestamp: number }> = [];
-
-vi.mock("../../server/utils/event-bus", () => ({
-  eventBus: {
-    emit: vi.fn((type: string, data: unknown) => {
-      if (type === "agent:activity") {
-        emittedEvents.push(data as { cardId: number; event: unknown; timestamp: number });
-      }
-    }),
-  },
-}));
+import { createMockLogger } from "../helpers/mock-deps";
+import { StreamTailer } from "../../server/services/stream-tailer";
 
 describe("StreamTailer", () => {
   let testDir: string;
   let logFile: string;
-  let streamTailer: (typeof import("../../server/services/stream-tailer"))["streamTailer"];
+  let streamTailer: StreamTailer;
+  const emittedEvents: Array<{ cardId: number; event: unknown; timestamp: number }> = [];
+  let mockEventBus: {
+    emit: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+  };
 
-  beforeEach(async () => {
+  beforeEach(() => {
     emittedEvents.length = 0;
 
     testDir = join(tmpdir(), `stream-tailer-test-${Date.now()}`);
@@ -32,10 +24,20 @@ describe("StreamTailer", () => {
     logFile = join(testDir, "test.ndjson");
     writeFileSync(logFile, "");
 
-    // Fresh import each test to reset singleton state
-    vi.resetModules();
-    const mod = await import("../../server/services/stream-tailer");
-    streamTailer = mod.streamTailer;
+    mockEventBus = {
+      emit: vi.fn((type: string, data: unknown) => {
+        if (type === "agent:activity") {
+          emittedEvents.push(data as { cardId: number; event: unknown; timestamp: number });
+        }
+      }),
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+
+    streamTailer = new StreamTailer({
+      eventBus: mockEventBus as never,
+      logger: createMockLogger() as never,
+    });
   });
 
   afterEach(() => {

--- a/plugins/tt-agentboard/test/services/tmux-manager.test.ts
+++ b/plugins/tt-agentboard/test/services/tmux-manager.test.ts
@@ -1,21 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
-vi.mock("node:child_process", () => ({
-  execSync: vi.fn(),
-}));
-
-// eslint-disable-next-line import/first -- vi.mock must come before imports (vitest hoisting)
-import { execSync } from "node:child_process";
-// eslint-disable-next-line import/first
 import { TmuxManager } from "../../server/services/tmux-manager";
-
-const mockExecSync = vi.mocked(execSync);
+import { createMockExecSync, createMockLogger } from "../helpers/mock-deps";
 
 describe("TmuxManager", () => {
   let manager: TmuxManager;
+  let mockExecSync: ReturnType<typeof createMockExecSync>;
+  let mockLogger: ReturnType<typeof createMockLogger>;
 
   beforeEach(() => {
-    manager = new TmuxManager();
+    mockExecSync = createMockExecSync();
+    mockLogger = createMockLogger();
+    manager = new TmuxManager({ execSync: mockExecSync as never, logger: mockLogger });
     vi.clearAllMocks();
     vi.useFakeTimers();
   });
@@ -185,7 +180,7 @@ describe("TmuxManager", () => {
       // Advance past one interval (500ms)
       vi.advanceTimersByTime(500);
 
-      expect(mockExecSync).toHaveBeenCalledWith("tmux capture-pane -t card-10 -p -S -50", {
+      expect(mockExecSync).toHaveBeenCalledWith("tmux capture-pane -t card-10 -p -e -S -50", {
         encoding: "utf-8",
         timeout: 2000,
       });

--- a/plugins/tt-agentboard/test/services/ttyd-manager.test.ts
+++ b/plugins/tt-agentboard/test/services/ttyd-manager.test.ts
@@ -1,23 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ChildProcess } from "node:child_process";
-
-// The TtydManager.isAvailable() uses require("node:child_process") internally,
-// so we must mock the module at the vi.mock level which also intercepts require().
-vi.mock("node:child_process", () => ({
-  execSync: vi.fn(),
-  spawn: vi.fn(),
-}));
-
-vi.mock("../../server/utils/logger", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-}));
-
-// eslint-disable-next-line import/first -- vi.mock must come before imports (vitest hoisting)
-import { spawn } from "node:child_process";
-// eslint-disable-next-line import/first
+import { createMockLogger } from "../helpers/mock-deps";
 import { TtydManager } from "../../server/services/ttyd-manager";
-
-const mockSpawn = vi.mocked(spawn);
 
 function createMockProcess(): ChildProcess {
   const proc = {
@@ -34,9 +18,17 @@ function createMockProcess(): ChildProcess {
 
 describe("TtydManager", () => {
   let manager: TtydManager;
+  let mockSpawn: ReturnType<typeof vi.fn>;
+  let mockExecSync: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    manager = new TtydManager();
+    mockSpawn = vi.fn();
+    mockExecSync = vi.fn();
+    manager = new TtydManager({
+      spawn: mockSpawn as never,
+      execSync: mockExecSync as never,
+      logger: createMockLogger() as never,
+    });
     vi.clearAllMocks();
   });
 
@@ -45,19 +37,28 @@ describe("TtydManager", () => {
   });
 
   describe("isAvailable()", () => {
-    // isAvailable() uses an inline require("node:child_process").execSync which
-    // bypasses our module-level vi.mock in some vitest configurations.
-    // We test the caching and return-type behavior instead.
-
-    it("returns a boolean", () => {
+    it("returns true when execSync succeeds", () => {
+      mockExecSync.mockReturnValue(undefined);
       const result = manager.isAvailable();
-      expect(typeof result).toBe("boolean");
+      expect(result).toBe(true);
+      expect(mockExecSync).toHaveBeenCalledWith("which ttyd", { stdio: "ignore" });
+    });
+
+    it("returns false when execSync throws", () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error("not found");
+      });
+      const result = manager.isAvailable();
+      expect(result).toBe(false);
     });
 
     it("caches result on subsequent calls", () => {
+      mockExecSync.mockReturnValue(undefined);
       const first = manager.isAvailable();
       const second = manager.isAvailable();
       expect(first).toBe(second);
+      // Only called once due to caching
+      expect(mockExecSync).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -68,11 +69,11 @@ describe("TtydManager", () => {
 
       const result = manager.attach(1);
 
-      expect(result.port).toBe(7680);
-      expect(result.url).toBe("http://localhost:7680");
+      expect(result.port).toBe(7700);
+      expect(result.url).toBe("http://localhost:7700");
       expect(mockSpawn).toHaveBeenCalledWith(
         "ttyd",
-        ["--port", "7680", "--writable", "tmux", "attach", "-t", "card-1"],
+        ["--port", "7700", "--writable", "tmux", "attach", "-t", "card-1"],
         { stdio: "ignore", detached: true },
       );
       expect(proc.unref).toHaveBeenCalled();
@@ -95,8 +96,8 @@ describe("TtydManager", () => {
       const r1 = manager.attach(1);
       const r2 = manager.attach(2);
 
-      expect(r1.port).toBe(7680);
-      expect(r2.port).toBe(7681);
+      expect(r1.port).toBe(7700);
+      expect(r2.port).toBe(7701);
     });
   });
 
@@ -143,8 +144,8 @@ describe("TtydManager", () => {
       const result = manager.isAttached(1);
 
       expect(result.attached).toBe(true);
-      expect(result.port).toBe(7680);
-      expect(result.url).toBe("http://localhost:7680");
+      expect(result.port).toBe(7700);
+      expect(result.url).toBe("http://localhost:7700");
     });
   });
 

--- a/plugins/tt-agentboard/test/services/workflow-loader.test.ts
+++ b/plugins/tt-agentboard/test/services/workflow-loader.test.ts
@@ -2,57 +2,7 @@ import { describe, it, expect, afterAll, vi } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readdirSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
-
-// Mock glob to use readdirSync instead (glob package not installed)
-vi.mock("glob", () => ({
-  glob: vi.fn(async (pattern: string) => {
-    // Extract directory from pattern like "/tmp/.../workflows/*.yaml"
-    const dir = pattern.replace("/*.yaml", "").replace("\\*.yaml", "");
-    try {
-      const files = readdirSync(dir);
-      return files.filter((f: string) => f.endsWith(".yaml")).map((f: string) => join(dir, f));
-    } catch {
-      return [];
-    }
-  }),
-}));
-
-// Mock chokidar — capture event handlers so we can trigger them in tests
-const chokidarHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-const mockWatcherClose = vi.fn().mockResolvedValue(undefined);
-vi.mock("chokidar", () => ({
-  watch: vi.fn(() => {
-    // Reset handlers for each new watcher
-    for (const key of Object.keys(chokidarHandlers)) {
-      delete chokidarHandlers[key];
-    }
-    return {
-      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-        if (!chokidarHandlers[event]) chokidarHandlers[event] = [];
-        chokidarHandlers[event].push(handler);
-        // Return self for chaining
-        return {
-          on: vi.fn((event2: string, handler2: (...args: unknown[]) => void) => {
-            if (!chokidarHandlers[event2]) chokidarHandlers[event2] = [];
-            chokidarHandlers[event2].push(handler2);
-            return {
-              on: vi.fn((event3: string, handler3: (...args: unknown[]) => void) => {
-                if (!chokidarHandlers[event3]) chokidarHandlers[event3] = [];
-                chokidarHandlers[event3].push(handler3);
-                return { on: vi.fn().mockReturnThis(), close: mockWatcherClose };
-              }),
-              close: mockWatcherClose,
-            };
-          }),
-          close: mockWatcherClose,
-        };
-      }),
-      close: mockWatcherClose,
-    };
-  }),
-}));
-
-// eslint-disable-next-line import/first -- vi.mock must come before imports
+import { createMockLogger } from "../helpers/mock-deps";
 import { WorkflowLoader } from "../../server/services/workflow-loader";
 
 const tmpDirs: string[] = [];
@@ -68,6 +18,57 @@ afterAll(() => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// Mock glob to use readdirSync instead
+const mockGlob = vi.fn(async (pattern: string) => {
+  const dir = pattern.replace("/*.yaml", "").replace("\\*.yaml", "");
+  try {
+    const files = readdirSync(dir);
+    return files.filter((f: string) => f.endsWith(".yaml")).map((f: string) => join(dir, f));
+  } catch {
+    return [];
+  }
+});
+
+// Mock chokidar — capture event handlers so we can trigger them in tests
+const chokidarHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+const mockWatcherClose = vi.fn().mockResolvedValue(undefined);
+const mockWatch = vi.fn(() => {
+  // Reset handlers for each new watcher
+  for (const key of Object.keys(chokidarHandlers)) {
+    delete chokidarHandlers[key];
+  }
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!chokidarHandlers[event]) chokidarHandlers[event] = [];
+      chokidarHandlers[event].push(handler);
+      return {
+        on: vi.fn((event2: string, handler2: (...args: unknown[]) => void) => {
+          if (!chokidarHandlers[event2]) chokidarHandlers[event2] = [];
+          chokidarHandlers[event2].push(handler2);
+          return {
+            on: vi.fn((event3: string, handler3: (...args: unknown[]) => void) => {
+              if (!chokidarHandlers[event3]) chokidarHandlers[event3] = [];
+              chokidarHandlers[event3].push(handler3);
+              return { on: vi.fn().mockReturnThis(), close: mockWatcherClose };
+            }),
+            close: mockWatcherClose,
+          };
+        }),
+        close: mockWatcherClose,
+      };
+    }),
+    close: mockWatcherClose,
+  };
+});
+
+function createLoader() {
+  return new WorkflowLoader({
+    logger: createMockLogger() as never,
+    glob: mockGlob as never,
+    watch: mockWatch as never,
+  });
+}
 
 describe("WorkflowLoader", () => {
   it("loadFromRepos loads workflows from multiple repo paths", async () => {
@@ -99,7 +100,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepos([repo1, repo2]);
 
@@ -131,7 +132,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
 
@@ -151,7 +152,7 @@ steps:
     const repoPath = makeTmpDir();
     // No .agentboard/workflows dir created
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
       // Should not throw, just return with no workflows loaded
@@ -176,7 +177,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
       expect(loader.list()).toHaveLength(0);
@@ -197,7 +198,7 @@ description: Has name but no steps
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
       expect(loader.get("broken-workflow")).toBeUndefined();
@@ -207,7 +208,7 @@ description: Has name but no steps
   });
 
   it("get() returns undefined for unknown workflow", async () => {
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     expect(loader.get("nonexistent")).toBeUndefined();
     await loader.close();
   });
@@ -237,7 +238,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
 
@@ -258,7 +259,7 @@ steps:
     // Write content that parses as YAML but is a string, not an object with name/steps
     writeFileSync(resolve(wfDir, "corrupt.yaml"), ": :\n  - : [}{");
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
       // Should not throw, and no workflows should be loaded
@@ -283,7 +284,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     await loader.loadFromRepo(repoPath);
 
     mockWatcherClose.mockClear();
@@ -308,7 +309,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
 
@@ -357,7 +358,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
       expect(loader.get("my-workflow")!.description).toBe("original");
@@ -401,7 +402,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
       expect(loader.get("removable")).toBeDefined();
@@ -436,7 +437,7 @@ steps:
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
 
@@ -481,7 +482,7 @@ branch_template: "agentboard/card-{card_id}"
 `,
     );
 
-    const loader = new WorkflowLoader();
+    const loader = createLoader();
     try {
       await loader.loadFromRepo(repoPath);
 

--- a/plugins/tt-agentboard/test/services/workflow-runner.test.ts
+++ b/plugins/tt-agentboard/test/services/workflow-runner.test.ts
@@ -5,93 +5,37 @@ import {
   shellEscape,
 } from "../../server/utils/workflow-helpers";
 
-// Mock dependencies before importing WorkflowRunner
-vi.mock("../../server/db", () => {
-  const mockChain = () => {
-    const chain: Record<string, unknown> = {};
-    chain.from = vi.fn().mockReturnValue(chain);
-    chain.where = vi.fn().mockReturnValue(chain);
-    chain.set = vi.fn().mockReturnValue(chain);
-    chain.limit = vi.fn().mockResolvedValue([]);
-    chain.values = vi.fn().mockReturnValue(chain);
-    chain.returning = vi.fn().mockResolvedValue([{ id: 1 }]);
-    return chain;
-  };
-
-  return {
-    db: {
-      select: vi.fn().mockReturnValue(mockChain()),
-      update: vi.fn().mockReturnValue(mockChain()),
-      insert: vi.fn().mockReturnValue(mockChain()),
-    },
-  };
-});
-
-vi.mock("../../server/utils/event-bus", () => ({
-  eventBus: { emit: vi.fn(), on: vi.fn() },
+// Minimal mocks for modules that can't load in test environment (SQLite, glob)
+vi.mock("../../server/db", () => ({
+  db: {},
 }));
 
-vi.mock("../../server/utils/logger", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+vi.mock("glob", () => ({
+  glob: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("../../server/utils/hook-writer", () => ({
-  writeHooks: vi.fn(),
-}));
-
-vi.mock("../../server/services/tmux-manager", () => ({
-  tmuxManager: {
-    isAvailable: vi.fn().mockReturnValue(true),
-    createSession: vi.fn().mockReturnValue({ sessionName: "card-1", created: true }),
-    startCapture: vi.fn(),
-    stopCapture: vi.fn(),
-    killSession: vi.fn(),
-    sendCommand: vi.fn(),
-  },
-}));
-
-vi.mock("../../server/services/slot-allocator", () => ({
-  slotAllocator: {
-    claimSlot: vi.fn().mockResolvedValue({ id: 1, path: "/workspace/slot-1" }),
-    releaseSlot: vi.fn().mockResolvedValue(undefined),
-  },
-}));
-
-vi.mock("../../server/services/workflow-loader", () => ({
-  workflowLoader: {
-    get: vi.fn().mockReturnValue(null),
-  },
-}));
-
-vi.mock("../../server/services/context-bundler", () => ({
-  contextBundler: {
-    buildPrompt: vi.fn().mockReturnValue("test prompt"),
-  },
-}));
-
-vi.mock("node:child_process", () => ({
-  execSync: vi.fn(),
-}));
-
-vi.mock("node:fs", () => ({
-  existsSync: vi.fn().mockReturnValue(true),
-  readFileSync: vi.fn().mockReturnValue("PASS\ndetails"),
+vi.mock("../../server/utils/card-events", () => ({
+  logCardEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
 // eslint-disable-next-line import/first -- vi.mock must come before imports (vitest hoisting)
-import { db } from "../../server/db";
-// eslint-disable-next-line import/first
-import { eventBus } from "../../server/utils/event-bus";
-// eslint-disable-next-line import/first
-import { tmuxManager } from "../../server/services/tmux-manager";
-// eslint-disable-next-line import/first
-import { slotAllocator } from "../../server/services/slot-allocator";
-// eslint-disable-next-line import/first
-import { workflowLoader } from "../../server/services/workflow-loader";
-// eslint-disable-next-line import/first
 import { WorkflowRunner, resolveStepComplete } from "../../server/services/workflow-runner";
-
-const mockDb = vi.mocked(db);
+// eslint-disable-next-line import/first
+import {
+  createMockDb,
+  createMockEventBus,
+  createMockLogger,
+  createMockTmuxManager,
+  createMockSlotAllocator,
+  createMockWorkflowLoader,
+  createMockContextBundler,
+  createMockStreamTailer,
+  createMockExecSync,
+  setupSelectReturning,
+  setupUpdate,
+} from "../helpers/mock-deps";
+// eslint-disable-next-line import/first
+import type { MockDb } from "../helpers/mock-deps";
 
 describe("workflow-helpers", () => {
   describe("checkPassCondition()", () => {
@@ -191,45 +135,56 @@ describe("resolveStepComplete()", () => {
 
 describe("WorkflowRunner", () => {
   let runner: WorkflowRunner;
+  let mockDb: MockDb;
+  let mockEventBus: ReturnType<typeof createMockEventBus>;
+  let mockTmuxManager: ReturnType<typeof createMockTmuxManager>;
+  let mockSlotAllocator: ReturnType<typeof createMockSlotAllocator>;
+  let mockWorkflowLoader: ReturnType<typeof createMockWorkflowLoader>;
 
   beforeEach(() => {
-    runner = new WorkflowRunner(4200);
+    mockDb = createMockDb();
+    mockEventBus = createMockEventBus();
+    mockTmuxManager = createMockTmuxManager();
+    mockSlotAllocator = createMockSlotAllocator();
+    mockWorkflowLoader = createMockWorkflowLoader();
+
+    runner = new WorkflowRunner(4200, {
+      db: mockDb as never,
+      eventBus: mockEventBus,
+      logger: createMockLogger(),
+      tmuxManager: mockTmuxManager,
+      slotAllocator: mockSlotAllocator as never,
+      workflowLoader: mockWorkflowLoader as never,
+      contextBundler: createMockContextBundler(),
+      writeHooks: vi.fn(),
+      logCardEvent: vi.fn().mockResolvedValue(undefined),
+      streamTailer: createMockStreamTailer(),
+      execSync: createMockExecSync() as never,
+      existsSync: vi.fn().mockReturnValue(true) as never,
+      readFileSync: vi.fn().mockReturnValue("PASS\ndetails") as never,
+    });
     vi.clearAllMocks();
   });
 
   describe("initContext (via run)", () => {
     it("returns early when card not found", async () => {
-      const selectChain: Record<string, unknown> = {};
-      selectChain.from = vi.fn().mockReturnValue(selectChain);
-      selectChain.where = vi.fn().mockResolvedValue([]);
-      mockDb.select = vi.fn().mockReturnValue(selectChain);
+      setupSelectReturning(mockDb, []);
 
       await runner.run(999);
 
       // Should not emit any workflow events since card not found
-      expect(vi.mocked(eventBus.emit)).not.toHaveBeenCalledWith(
-        "workflow:completed",
-        expect.anything(),
-      );
+      expect(mockEventBus.emit).not.toHaveBeenCalledWith("workflow:completed", expect.anything());
     });
 
     it("marks failed when card has no repoId", async () => {
       const card = { id: 1, repoId: null, workflowId: "plan", title: "Test" };
-
-      const selectChain: Record<string, unknown> = {};
-      selectChain.from = vi.fn().mockReturnValue(selectChain);
-      selectChain.where = vi.fn().mockResolvedValue([card]);
-      mockDb.select = vi.fn().mockReturnValue(selectChain);
-
-      const updateChain: Record<string, unknown> = {};
-      updateChain.set = vi.fn().mockReturnValue(updateChain);
-      updateChain.where = vi.fn().mockResolvedValue(undefined);
-      mockDb.update = vi.fn().mockReturnValue(updateChain);
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
 
       await runner.run(1);
 
       expect(mockDb.update).toHaveBeenCalled();
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith("card:status-changed", {
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
         cardId: 1,
         status: "failed",
       });
@@ -237,20 +192,12 @@ describe("WorkflowRunner", () => {
 
     it("marks failed when card has no workflowId", async () => {
       const card = { id: 1, repoId: 1, workflowId: null, title: "Test" };
-
-      const selectChain: Record<string, unknown> = {};
-      selectChain.from = vi.fn().mockReturnValue(selectChain);
-      selectChain.where = vi.fn().mockResolvedValue([card]);
-      mockDb.select = vi.fn().mockReturnValue(selectChain);
-
-      const updateChain: Record<string, unknown> = {};
-      updateChain.set = vi.fn().mockReturnValue(updateChain);
-      updateChain.where = vi.fn().mockResolvedValue(undefined);
-      mockDb.update = vi.fn().mockReturnValue(updateChain);
+      setupSelectReturning(mockDb, [card]);
+      setupUpdate(mockDb);
 
       await runner.run(1);
 
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith("card:status-changed", {
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
         cardId: 1,
         status: "failed",
       });
@@ -273,16 +220,12 @@ describe("WorkflowRunner", () => {
         return chain;
       });
 
-      vi.mocked(workflowLoader.get).mockReturnValue(undefined as never);
-
-      const updateChain: Record<string, unknown> = {};
-      updateChain.set = vi.fn().mockReturnValue(updateChain);
-      updateChain.where = vi.fn().mockResolvedValue(undefined);
-      mockDb.update = vi.fn().mockReturnValue(updateChain);
+      mockWorkflowLoader.get.mockReturnValue(undefined as never);
+      setupUpdate(mockDb);
 
       await runner.run(1);
 
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith("card:status-changed", {
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
         cardId: 1,
         status: "failed",
       });
@@ -306,17 +249,13 @@ describe("WorkflowRunner", () => {
         return chain;
       });
 
-      vi.mocked(workflowLoader.get).mockReturnValue(workflow as never);
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(false);
-
-      const updateChain: Record<string, unknown> = {};
-      updateChain.set = vi.fn().mockReturnValue(updateChain);
-      updateChain.where = vi.fn().mockResolvedValue(undefined);
-      mockDb.update = vi.fn().mockReturnValue(updateChain);
+      mockWorkflowLoader.get.mockReturnValue(workflow as never);
+      mockTmuxManager.isAvailable.mockReturnValue(false);
+      setupUpdate(mockDb);
 
       await runner.run(1);
 
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith("card:status-changed", {
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
         cardId: 1,
         status: "failed",
       });
@@ -340,18 +279,14 @@ describe("WorkflowRunner", () => {
         return chain;
       });
 
-      vi.mocked(workflowLoader.get).mockReturnValue(workflow as never);
-      vi.mocked(tmuxManager.isAvailable).mockReturnValue(true);
-      vi.mocked(slotAllocator.claimSlot).mockResolvedValue(null);
-
-      const updateChain: Record<string, unknown> = {};
-      updateChain.set = vi.fn().mockReturnValue(updateChain);
-      updateChain.where = vi.fn().mockResolvedValue(undefined);
-      mockDb.update = vi.fn().mockReturnValue(updateChain);
+      mockWorkflowLoader.get.mockReturnValue(workflow as never);
+      mockTmuxManager.isAvailable.mockReturnValue(true);
+      mockSlotAllocator.claimSlot.mockResolvedValue(null);
+      setupUpdate(mockDb);
 
       await runner.run(1);
 
-      expect(vi.mocked(eventBus.emit)).toHaveBeenCalledWith("card:status-changed", {
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
         cardId: 1,
         status: "queued",
       });


### PR DESCRIPTION
Addresses #130. Adds constructor DI to all 9 AgentBoard services, removes 25 vi.mock calls. 222 tests pass.