### PR TITLE
feat(agentboard): auto-claude integration, activity panel, diff fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tsconfig.tsbuildinfo
 # auto-claude artifacts
 .auto-claude/
 .auto-claude/**/prompt-*.md
+.claude-stream.ndjson

--- a/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
+++ b/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
@@ -56,6 +56,55 @@ function handleScroll() {
   autoScroll.value = scrollHeight - scrollTop - clientHeight < 40;
 }
 
+/** Map tool names to display labels matching Claude Code TUI style */
+const TOOL_ICONS: Record<string, { label: string; color: string }> = {
+  Read: { label: "Read", color: "text-blue-400 border-blue-500/30 bg-blue-500/5" },
+  Edit: { label: "Edit", color: "text-amber-400 border-amber-500/30 bg-amber-500/5" },
+  Write: { label: "Write", color: "text-amber-400 border-amber-500/30 bg-amber-500/5" },
+  Bash: { label: "Bash", color: "text-emerald-400 border-emerald-500/30 bg-emerald-500/5" },
+  Glob: { label: "Glob", color: "text-cyan-400 border-cyan-500/30 bg-cyan-500/5" },
+  Grep: { label: "Grep", color: "text-cyan-400 border-cyan-500/30 bg-cyan-500/5" },
+  Agent: { label: "Agent", color: "text-purple-400 border-purple-500/30 bg-purple-500/5" },
+  TodoWrite: { label: "TodoWrite", color: "text-violet-400 border-violet-500/30 bg-violet-500/5" },
+  TaskCreate: {
+    label: "TaskCreate",
+    color: "text-violet-400 border-violet-500/30 bg-violet-500/5",
+  },
+  TaskUpdate: {
+    label: "TaskUpdate",
+    color: "text-violet-400 border-violet-500/30 bg-violet-500/5",
+  },
+  WebFetch: { label: "WebFetch", color: "text-sky-400 border-sky-500/30 bg-sky-500/5" },
+  WebSearch: { label: "WebSearch", color: "text-sky-400 border-sky-500/30 bg-sky-500/5" },
+};
+
+function getToolStyle(name: string) {
+  return (
+    TOOL_ICONS[name] ?? { label: name, color: "text-zinc-400 border-zinc-600/30 bg-zinc-800/50" }
+  );
+}
+
+function formatDetail(event: ActivityEvent & { kind: "tool_use" }) {
+  const input = event.input;
+  if (!input) return event.detail;
+
+  const filePath = input.file_path ?? input.path;
+  if (typeof filePath === "string") return filePath;
+  if (typeof input.command === "string") return input.command;
+  if (typeof input.pattern === "string") return input.pattern;
+  if (typeof input.subject === "string") return input.subject;
+  return event.detail;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m ${rem}s`;
+}
+
 onMounted(() => {
   subscribeActivity(props.cardId);
   on("agent:activity", handleActivity);
@@ -68,34 +117,104 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div ref="container" class="h-full overflow-y-auto p-4 space-y-2" @scroll="handleScroll">
-    <div v-if="events.length === 0" class="text-zinc-500 text-sm">
-      Waiting for agent activity...
+  <div
+    ref="container"
+    class="h-full overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-950 font-mono text-[13px]"
+    @scroll="handleScroll"
+  >
+    <!-- Empty state -->
+    <div
+      v-if="events.length === 0"
+      class="flex flex-col items-center justify-center py-16 text-center"
+    >
+      <div class="mb-2 text-zinc-600">
+        <svg class="mx-auto h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+      </div>
+      <p class="text-xs text-zinc-500">Waiting for agent activity...</p>
+      <p class="mt-1 text-[10px] text-zinc-600">Events will appear here as the agent works</p>
     </div>
-    <div v-for="(event, i) in events" :key="i" class="text-sm">
-      <!-- Tool use -->
-      <div v-if="event.kind === 'tool_use'" class="flex items-start gap-2 py-1">
-        <span class="text-blue-400 font-mono text-xs shrink-0">▶</span>
-        <span class="font-mono text-blue-300">{{ event.name }}</span>
-        <span class="text-zinc-500 truncate">{{ event.detail }}</span>
-      </div>
-      <!-- Thinking -->
-      <div v-else-if="event.kind === 'thinking'" class="py-1 text-zinc-500 italic truncate">
-        {{ event.summary }}
-      </div>
-      <!-- Text output -->
-      <div v-else-if="event.kind === 'text'" class="py-1 text-zinc-300">
-        {{ event.content }}
-      </div>
-      <!-- Result -->
-      <div v-else-if="event.kind === 'result'" class="py-2 border-t border-zinc-700 mt-2">
-        <span :class="event.isError ? 'text-red-400' : 'text-emerald-400'">
-          {{ event.isError ? "Failed" : "Completed" }}
-        </span>
-        <span class="text-zinc-500 ml-2">
-          {{ event.numTurns }} turns · ${{ event.costUsd?.toFixed(4) }}
-        </span>
-      </div>
+
+    <!-- Event stream -->
+    <div v-else class="divide-y divide-zinc-800/50">
+      <template v-for="(event, i) in events" :key="i">
+        <!-- Tool use — Claude Code TUI style block -->
+        <div v-if="event.kind === 'tool_use'" class="px-4 py-2.5">
+          <div class="flex items-center gap-2">
+            <span
+              class="inline-flex items-center rounded border px-2 py-0.5 text-[11px] font-semibold"
+              :class="getToolStyle(event.name).color"
+            >
+              {{ getToolStyle(event.name).label }}
+            </span>
+            <span class="truncate text-zinc-400">{{ formatDetail(event) }}</span>
+          </div>
+          <!-- Show edit preview for Edit/Write -->
+          <div
+            v-if="(event.name === 'Edit' || event.name === 'Write') && event.input?.old_string"
+            class="mt-1.5 ml-1 border-l-2 border-zinc-700 pl-3 text-[11px]"
+          >
+            <div class="text-red-400/70 line-through">
+              {{ String(event.input.old_string).split("\n")[0]?.slice(0, 80) }}
+            </div>
+            <div v-if="event.input?.new_string" class="text-emerald-400/70">
+              {{ String(event.input.new_string).split("\n")[0]?.slice(0, 80) }}
+            </div>
+          </div>
+          <!-- Show command for Bash -->
+          <div
+            v-if="event.name === 'Bash' && event.input?.command"
+            class="mt-1.5 ml-1 rounded border border-zinc-800 bg-black px-2.5 py-1.5 text-[11px] text-emerald-300/80"
+          >
+            $ {{ String(event.input.command).slice(0, 120) }}
+          </div>
+        </div>
+
+        <!-- Thinking — subtle italic like Claude Code -->
+        <div v-else-if="event.kind === 'thinking'" class="px-4 py-2">
+          <span class="text-[11px] italic text-zinc-500">{{ event.summary }}</span>
+        </div>
+
+        <!-- Text output — Claude's markdown response -->
+        <div
+          v-else-if="event.kind === 'text'"
+          class="px-4 py-2.5 text-zinc-200 whitespace-pre-wrap leading-relaxed"
+        >
+          {{ event.content }}
+        </div>
+
+        <!-- Result — session complete banner -->
+        <div v-else-if="event.kind === 'result'" class="px-4 py-3">
+          <div
+            class="flex items-center justify-between rounded-lg border px-3 py-2"
+            :class="
+              event.isError
+                ? 'border-red-500/30 bg-red-500/5'
+                : 'border-emerald-500/30 bg-emerald-500/5'
+            "
+          >
+            <div class="flex items-center gap-2">
+              <span
+                class="text-xs font-semibold"
+                :class="event.isError ? 'text-red-400' : 'text-emerald-400'"
+              >
+                {{ event.isError ? "✕ Failed" : "✓ Completed" }}
+              </span>
+            </div>
+            <div class="flex items-center gap-3 text-[11px] text-zinc-500">
+              <span>{{ event.numTurns }} turns</span>
+              <span>{{ formatDuration(event.durationMs) }}</span>
+              <span>${{ event.costUsd?.toFixed(4) }}</span>
+            </div>
+          </div>
+        </div>
+      </template>
     </div>
   </div>
 </template>

--- a/plugins/tt-agentboard/app/components/card/CardDetail.vue
+++ b/plugins/tt-agentboard/app/components/card/CardDetail.vue
@@ -36,7 +36,7 @@ function sendResponse() {
       <span class="rounded bg-zinc-800 px-2 py-0.5 text-[10px] font-mono uppercase text-zinc-400">
         {{ COLUMN_LABELS[card.column] }}
       </span>
-      <span v-if="!compact" class="text-[10px] font-mono text-zinc-500">
+      <span class="text-[10px] font-mono text-zinc-500">
         {{ EXECUTION_MODE_LABELS[card.executionMode] ?? card.executionMode }}
       </span>
     </div>
@@ -49,12 +49,12 @@ function sendResponse() {
       {{ card.description }}
     </p>
 
-    <div v-if="card.repo && !compact" class="mb-4">
+    <div v-if="card.repo" class="mb-4">
       <SharedRepoBadge :name="card.repo.name" :org="card.repo.org" :repo-id="card.repoId" />
     </div>
 
     <div
-      v-if="(card.githubIssueNumber || card.githubPrNumber || card.branch) && !compact"
+      v-if="card.githubIssueNumber || card.githubPrNumber || card.branch"
       class="mb-4 space-y-1.5"
     >
       <!-- Branch -->
@@ -108,7 +108,6 @@ function sendResponse() {
 
     <!-- Timestamps + branch mode -->
     <div
-      v-if="!compact"
       class="mb-4 flex flex-wrap gap-x-4 gap-y-1 text-[10px] font-mono text-zinc-500"
     >
       <span>Created {{ new Date(card.createdAt).toLocaleString() }}</span>

--- a/plugins/tt-agentboard/app/pages/cards/[id].vue
+++ b/plugins/tt-agentboard/app/pages/cards/[id].vue
@@ -7,9 +7,9 @@ const cardId = computed(() => Number(route.params.id));
 const { data: card, refresh } = await useFetch<Card>(`/api/cards/${cardId.value}`);
 
 const router = useRouter();
-const activeTab = ref<"terminal" | "diff" | "activity">("terminal");
+const activeTab = ref<"terminal" | "diff" | "activity">("activity");
 
-// Default to diff tab for review_ready cards
+// Switch tab based on card status
 watch(
   () => card.value?.status,
   (status) => {

--- a/plugins/tt-agentboard/app/pages/index.vue
+++ b/plugins/tt-agentboard/app/pages/index.vue
@@ -72,7 +72,7 @@ watch(isListening, async (listening) => {
   setContext("idle");
 });
 
-const activeTab = ref<"terminal" | "diff" | "events">("terminal");
+const activeTab = ref<"terminal" | "diff" | "events" | "activity">("activity");
 const cardEvents = ref<{ id: number; event: string; detail: string | null; timestamp: string }[]>(
   [],
 );
@@ -95,7 +95,7 @@ function selectCard(cardId: number) {
   selectedCardId.value = cardId;
   selectedCard.value = null;
   selectedCardLoading.value = true;
-  activeTab.value = "terminal";
+  activeTab.value = "activity";
   fetchSelectedCard().then(() => {
     selectedCardLoading.value = false;
     fetchCardEvents();
@@ -360,6 +360,17 @@ useKeyboardShortcuts({
             <button
               class="px-4 py-2 text-xs font-medium transition-colors"
               :class="
+                activeTab === 'activity'
+                  ? 'border-b-2 border-emerald-500 text-zinc-200'
+                  : 'text-zinc-500 hover:text-zinc-300'
+              "
+              @click="activeTab = 'activity'"
+            >
+              Activity
+            </button>
+            <button
+              class="px-4 py-2 text-xs font-medium transition-colors"
+              :class="
                 activeTab === 'events'
                   ? 'border-b-2 border-amber-500 text-zinc-200'
                   : 'text-zinc-500 hover:text-zinc-300'
@@ -376,7 +387,8 @@ useKeyboardShortcuts({
           <!-- Tab content -->
           <div v-if="selectedCard" class="flex-1 overflow-hidden p-3">
             <ClientOnly>
-              <CardTerminalPanel v-if="activeTab === 'terminal'" :card-id="selectedCardId!" />
+              <CardActivityPanel v-if="activeTab === 'activity'" :card-id="selectedCardId!" />
+              <CardTerminalPanel v-else-if="activeTab === 'terminal'" :card-id="selectedCardId!" />
               <CardDiffViewer v-else-if="activeTab === 'diff'" :card-id="selectedCardId!" />
             </ClientOnly>
 

--- a/plugins/tt-agentboard/nuxt.config.ts
+++ b/plugins/tt-agentboard/nuxt.config.ts
@@ -14,7 +14,7 @@ export default defineNuxtConfig({
   },
   devServer: {
     host: process.env.AGENTBOARD_LAN === "1" ? "0.0.0.0" : "127.0.0.1",
-    port: 4200,
+    port: Number(process.env.AGENTBOARD_PORT) || 4200,
   },
   app: {
     head: {

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/diff.get.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/diff.get.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "~~/server/shared/db";
-import { workspaceSlots } from "~~/server/shared/db/schema";
+import { workspaceSlots, workflowRuns } from "~~/server/shared/db/schema";
 import { getCardId } from "~~/server/utils/params";
 
 interface DiffLine {
@@ -68,13 +68,45 @@ function parseDiff(raw: string): DiffFile[] {
 export default defineEventHandler(async (event) => {
   const cardId = getCardId(event);
 
-  const [slot] = await db
+  // Try claimed slot first (active execution), then fall back to workflow run record (completed)
+  let slotPath: string | null = null;
+  let branch: string | null = null;
+
+  const [claimedSlot] = await db
     .select()
     .from(workspaceSlots)
     .where(eq(workspaceSlots.claimedByCardId, cardId))
     .limit(1);
 
-  if (!slot) {
+  if (claimedSlot) {
+    slotPath = claimedSlot.path;
+    // Still look up branch from workflow run for active cards
+    const [run] = await db
+      .select({ branch: workflowRuns.branch })
+      .from(workflowRuns)
+      .where(eq(workflowRuns.cardId, cardId))
+      .limit(1);
+    branch = run?.branch ?? null;
+  } else {
+    // Slot was released after completion — look up via workflow run
+    const [run] = await db
+      .select({ slotId: workflowRuns.slotId, branch: workflowRuns.branch })
+      .from(workflowRuns)
+      .where(eq(workflowRuns.cardId, cardId))
+      .limit(1);
+
+    if (run?.slotId) {
+      const [slot] = await db
+        .select()
+        .from(workspaceSlots)
+        .where(eq(workspaceSlots.id, run.slotId))
+        .limit(1);
+      slotPath = slot?.path ?? null;
+      branch = run.branch;
+    }
+  }
+
+  if (!slotPath) {
     return { hasDiff: false, files: [], raw: "" };
   }
 
@@ -82,25 +114,21 @@ export default defineEventHandler(async (event) => {
 
   let raw = "";
   try {
-    // Try uncommitted changes first
-    raw = execSync("git diff HEAD", {
-      cwd: slot.path,
-      encoding: "utf-8",
-      timeout: 5000,
-    });
-
-    // If no uncommitted changes, try branch diff against origin/main
-    if (!raw.trim()) {
-      try {
-        raw = execSync("git diff origin/main...HEAD", {
-          cwd: slot.path,
-          encoding: "utf-8",
-          timeout: 5000,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
-      } catch {
-        // origin/main may not exist — ignore
-      }
+    if (branch) {
+      // Diff the card's branch against main — safe even if slot is reused by another card
+      raw = execSync(`git diff origin/main...${branch}`, {
+        cwd: slotPath,
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } else {
+      // No branch recorded — fall back to uncommitted changes (active execution)
+      raw = execSync("git diff HEAD", {
+        cwd: slotPath,
+        encoding: "utf-8",
+        timeout: 5000,
+      });
     }
   } catch {
     return { hasDiff: false, files: [], raw: "" };

--- a/plugins/tt-agentboard/server/domains/execution/agent-executor.ts
+++ b/plugins/tt-agentboard/server/domains/execution/agent-executor.ts
@@ -11,11 +11,10 @@ import { workflowOrchestrator as defaultWorkflowOrchestrator } from "./workflow-
 import { eventBus as defaultEventBus } from "../../shared/event-bus";
 import { logger as defaultLogger } from "../../utils/logger";
 import { writeHooks as defaultWriteHooks } from "../infra/hook-writer";
-import { buildStreamingCommand, shellEscape } from "./workflow-helpers";
-import { streamTailer as defaultStreamTailer } from "../infra/stream-tailer";
+import { shellEscape } from "./workflow-helpers";
 import { cardService as defaultCardService } from "../cards/card-service";
 import type { CardService } from "../cards/card-service";
-import type { Logger, EventBus, StreamTailer } from "./types";
+import type { Logger, EventBus } from "./types";
 
 export interface AgentExecutorDeps {
   db: typeof defaultDb;
@@ -38,7 +37,6 @@ export interface AgentExecutorDeps {
   workflowOrchestrator: { run: (cardId: number) => Promise<void> };
   writeHooks: typeof defaultWriteHooks;
   cardService: CardService;
-  streamTailer: StreamTailer;
   execSync: typeof defaultExecSync;
   existsSync: typeof defaultExistsSync;
 }
@@ -66,7 +64,6 @@ export class AgentExecutor {
       workflowOrchestrator: defaultWorkflowOrchestrator,
       writeHooks: defaultWriteHooks,
       cardService: defaultCardService,
-      streamTailer: defaultStreamTailer,
       execSync: defaultExecSync,
       existsSync: defaultExistsSync,
       ...deps,
@@ -306,32 +303,20 @@ export class AgentExecutor {
       })
       .returning();
 
-    // TODO: add --model flag from card config
-    // TODO: add --permission-mode instead of binary headless/interactive
-    // TODO: add --verbose flag option
-    // TODO: consider --append-system-prompt for card-level custom instructions
     const prompt = card.description ?? card.title;
-    const systemPrompt =
-      "You are an autonomous agent. Complete the task fully without asking clarifying questions. " +
-      "Make your best judgment and implement the solution. Do not ask the user for confirmation — just do the work. " +
-      "IMPORTANT: When you are done, you MUST commit your changes with git add and git commit. Do not leave uncommitted files.";
 
-    const args: string[] = [];
+    // Build the tmux command based on execution mode
+    let command: string;
     if (card.executionMode !== "interactive") {
-      args.push("--dangerously-skip-permissions");
+      // Headless: use `tt auto-claude` for structured terminal output
+      command = `tt auto-claude ${shellEscape(prompt)}`;
+    } else {
+      // Interactive: launch claude directly — user interacts via tmux attach
+      command = `claude`;
     }
-    args.push("--max-turns", "50");
-    args.push("--append-system-prompt", shellEscape(systemPrompt));
-    args.push("-p", shellEscape(prompt));
-
-    const logFilePath = join(slot.path, ".claude-stream.ndjson");
-    const command = buildStreamingCommand(args, logFilePath);
 
     this.deps.tmuxManager.sendCommand(sessionName, command);
     await this.deps.cardService.logEvent(cardId, "agent_command_sent", `session=${sessionName}`);
-
-    // Start tailing the stream-json output for structured activity events
-    await this.deps.streamTailer.startTailing(cardId, logFilePath);
 
     this.deps.tmuxManager.startCapture(sessionName, (output) => {
       this.deps.eventBus.emit("agent:output", { cardId, content: output });

--- a/plugins/tt-agentboard/server/domains/infra/stream-tailer.ts
+++ b/plugins/tt-agentboard/server/domains/infra/stream-tailer.ts
@@ -29,6 +29,7 @@ export class StreamTailer {
     let watcher: FSWatcher | null = null;
     let closed = false;
     let reading = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
     const readNewLines = async () => {
       if (closed || reading) return;
@@ -69,27 +70,40 @@ export class StreamTailer {
       reading = false;
     };
 
-    // Initial read from start of file
-    await readNewLines();
-
-    // Watch for file changes
-    try {
-      watcher = fsWatch(logFilePath, () => {
-        readNewLines();
-      });
-
-      watcher.on("error", (err) => {
+    const startWatching = () => {
+      try {
+        statSync(logFilePath);
+      } catch {
+        // File doesn't exist yet — retry until it appears or we're closed
         if (!closed) {
-          this.deps.logger.warn(`Stream tailer watcher error for card ${cardId}:`, err);
+          retryTimer = setTimeout(startWatching, 500);
         }
-      });
-    } catch (err) {
-      this.deps.logger.warn(`Could not watch ${logFilePath} for card ${cardId}:`, err);
-    }
+        return;
+      }
+
+      readNewLines();
+
+      try {
+        watcher = fsWatch(logFilePath, () => {
+          readNewLines();
+        });
+
+        watcher.on("error", (err) => {
+          if (!closed) {
+            this.deps.logger.warn(`Stream tailer watcher error for card ${cardId}:`, err);
+          }
+        });
+      } catch (err) {
+        this.deps.logger.warn(`Could not watch ${logFilePath} for card ${cardId}:`, err);
+      }
+    };
+
+    startWatching();
 
     const handle: TailHandle = {
       close: () => {
         closed = true;
+        if (retryTimer) clearTimeout(retryTimer);
         watcher?.close();
       },
     };

--- a/plugins/tt-agentboard/server/plugins/stream-completion.ts
+++ b/plugins/tt-agentboard/server/plugins/stream-completion.ts
@@ -1,0 +1,45 @@
+import { eventBus } from "../shared/event-bus";
+import { logger } from "../utils/logger";
+
+/**
+ * Detect agent completion from stream-json result events.
+ *
+ * Claude Code's HTTP Stop hooks don't fire in `-p` (print) mode.
+ * Instead, we watch the stream-tailer's parsed events for the `result`
+ * event which means Claude finished. When detected, we POST to the
+ * same complete/failure endpoint the Stop hook would have hit.
+ */
+export default defineNitroPlugin(() => {
+  const processed = new Set<string>();
+
+  eventBus.on("agent:activity", async (data) => {
+    const { cardId, event } = data as {
+      cardId: number;
+      event: { kind: string; isError?: boolean };
+    };
+
+    if (event.kind !== "result") return;
+
+    // Deduplicate — stream-tailer may re-read the same line on file change
+    const key = `${cardId}`;
+    if (processed.has(key)) return;
+    processed.add(key);
+    // Clean up after 60s to avoid unbounded growth
+    setTimeout(() => processed.delete(key), 60_000);
+
+    const endpoint = event.isError ? "failure" : "complete";
+    logger.info(`Stream detected ${endpoint} for card ${cardId}, triggering callback`);
+
+    try {
+      // Small delay to let any final stream lines flush
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      await $fetch(`/api/agents/${cardId}/${endpoint}`, {
+        method: "POST",
+        body: {},
+      });
+    } catch (err) {
+      logger.error(`Failed to trigger ${endpoint} for card ${cardId}:`, err);
+    }
+  });
+});

--- a/plugins/tt-agentboard/test/services/agent-executor.test.ts
+++ b/plugins/tt-agentboard/test/services/agent-executor.test.ts
@@ -9,7 +9,6 @@ import {
   createMockSlotAllocator,
   createMockWorkflowLoader,
   createMockWorkflowOrchestrator,
-  createMockStreamTailer,
   createMockExecSync,
   createMockCardService,
   setupSelectReturning,
@@ -49,7 +48,6 @@ describe("AgentExecutor", () => {
       workflowOrchestrator: mockWorkflowOrchestrator,
       writeHooks: mockWriteHooks as never,
       cardService: mockCardService as never,
-      streamTailer: createMockStreamTailer(),
       execSync: createMockExecSync() as never,
       existsSync: vi.fn().mockReturnValue(false) as never,
     });
@@ -176,11 +174,11 @@ describe("AgentExecutor", () => {
       expect(mockTmuxManager.createSession).toHaveBeenCalledWith(1, "/workspace/slot-1");
       expect(mockTmuxManager.startCapture).toHaveBeenCalled();
       const cmd = mockTmuxManager.sendCommand.mock.calls[0]![1] as string;
-      expect(cmd).toContain("claude");
-      expect(cmd).toContain("-p");
+      expect(cmd).toContain("tt auto-claude");
+      expect(cmd).toContain("Implement feature");
     });
 
-    it("uses --dangerously-skip-permissions for headless mode", async () => {
+    it("uses tt auto-claude for headless mode", async () => {
       const card = {
         id: 1,
         repoId: 1,
@@ -202,10 +200,10 @@ describe("AgentExecutor", () => {
       await executor.startExecution(1);
 
       const sendCommandCall = mockTmuxManager.sendCommand.mock.calls[0]!;
-      expect(sendCommandCall[1]).toContain("--dangerously-skip-permissions");
+      expect(sendCommandCall[1]).toContain("tt auto-claude");
     });
 
-    it("omits --dangerously-skip-permissions for interactive mode", async () => {
+    it("uses raw claude for interactive mode", async () => {
       const card = {
         id: 1,
         repoId: 1,
@@ -227,7 +225,8 @@ describe("AgentExecutor", () => {
       await executor.startExecution(1);
 
       const sendCommandCall = mockTmuxManager.sendCommand.mock.calls[0]!;
-      expect(sendCommandCall[1]).not.toContain("--dangerously-skip-permissions");
+      expect(sendCommandCall[1]).toContain("claude");
+      expect(sendCommandCall[1]).not.toContain("tt auto-claude");
     });
 
     it("uses card title as prompt when description is null", async () => {

--- a/src/commands/auto-claude/index.ts
+++ b/src/commands/auto-claude/index.ts
@@ -1,7 +1,8 @@
-import { rmSync } from "node:fs";
+import { rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-import { Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
 import consola from "consola";
 
 import { BaseCommand } from "../base.js";
@@ -14,6 +15,7 @@ import {
   initConfig,
   log,
   logBanner,
+  runClaude,
   runPipeline,
   sleep,
 } from "../../lib/auto-claude/index.js";
@@ -24,7 +26,18 @@ export default class AutoClaude extends BaseCommand {
 
   static override description = "Automated issue-to-PR pipeline using Claude Code";
 
+  static override args = {
+    prompt: Args.string({
+      description: "Run a single prompt (skips issue pipeline)",
+      required: false,
+    }),
+  };
+
   static override examples = [
+    {
+      description: "Run a single prompt",
+      command: '<%= config.bin %> auto-claude "Fix the login bug in auth.ts"',
+    },
     {
       description: "Process a specific issue",
       command: "<%= config.bin %> auto-claude --issue 42",
@@ -49,6 +62,10 @@ export default class AutoClaude extends BaseCommand {
 
   static override flags = {
     ...BaseCommand.baseFlags,
+    "max-turns": Flags.integer({
+      description: "Maximum conversation turns for prompt mode (default: 10)",
+      default: 10,
+    }),
     issue: Flags.integer({
       char: "i",
       description: "Process a specific issue number",
@@ -88,8 +105,29 @@ export default class AutoClaude extends BaseCommand {
   };
 
   async run(): Promise<void> {
-    const { flags } = await this.parse(AutoClaude);
+    const { args, flags } = await this.parse(AutoClaude);
 
+    // Prompt mode: run a single prompt with structured output, skip issue pipeline
+    if (args.prompt) {
+      await initConfig({ model: flags.model });
+
+      const promptDir = join(tmpdir(), "tt-auto-claude");
+      mkdirSync(promptDir, { recursive: true });
+      const promptFile = join(promptDir, `prompt-${Date.now()}.md`);
+      writeFileSync(promptFile, args.prompt);
+
+      const result = await runClaude({
+        promptFile,
+        maxTurns: flags["max-turns"],
+      });
+
+      if (result.is_error) {
+        this.error("Claude reported an error", { exit: 1 });
+      }
+      return;
+    }
+
+    // Issue pipeline mode
     const cfg = await initConfig({
       triggerLabel: flags.label,
       mainBranch: flags["main-branch"],

--- a/src/lib/auto-claude/index.ts
+++ b/src/lib/auto-claude/index.ts
@@ -1,4 +1,5 @@
 export { type AutoClaudeConfig, AutoClaudeConfigSchema, getConfig, initConfig } from "./config.js";
+export { type ClaudeResult, runClaude } from "./claude-cli.js";
 export { STEP_NAMES, runPipeline } from "./pipeline.js";
 export type { StepName } from "./prompt-templates/index.js";
 export { git } from "../../utils/git/exec.js";


### PR DESCRIPTION
## Summary

- Headless cards run `tt auto-claude "prompt"` in tmux for structured terminal output instead of raw `claude -p` with stream-json piping
- Add prompt mode to `tt auto-claude` command (accepts bare prompt arg, skips issue pipeline)
- Fix diff endpoint to use card's branch ref instead of working tree (safe when slot is reused)
- Redesign ActivityPanel with Claude Code TUI-style rendering
- Show all card details in sidebar (branch, repo, timestamps were hidden in compact mode)
- Add Activity tab to board sidebar, default to it for running cards
- Add AGENTBOARD_PORT env var, stream-completion plugin, gitignore ndjson

## Test plan

- [ ] Run `tt auto-claude "say hello"` — should show structured output
- [ ] Create headless card in agentboard — tmux should show auto-claude output
- [ ] Check diff tab on completed card — should show branch diff, not empty
- [ ] Verify sidebar shows branch, repo badge, timestamps
- [ ] Run `pnpm test` and agentboard unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)