### PR TITLE
feat(agentboard): auto-claude headless, voice dictation, activity panel UI

### DIFF
--- a/plugins/tt-agentboard/app/components/board/NewCardForm.vue
+++ b/plugins/tt-agentboard/app/components/board/NewCardForm.vue
@@ -26,6 +26,26 @@ const submitError = ref("");
 
 const { data: repos } = useFetch<Repo[]>("/api/repos");
 const { createCard } = useCardStore();
+const { isListening, transcript, interimTranscript, isSupported, toggle } = useVoice();
+
+// Snapshot prompt text before dictation starts so we can append to it
+const promptBeforeDictation = ref("");
+
+function toggleVoice() {
+  if (!isListening.value) {
+    // Capture current prompt BEFORE toggle clears transcript
+    promptBeforeDictation.value = prompt.value;
+  }
+  toggle();
+}
+
+// Sync transcript + interim into prompt textarea in real-time
+watch([transcript, interimTranscript], ([final, interim]) => {
+  if (!isListening.value && !final) return;
+  const base = promptBeforeDictation.value;
+  const combined = `${final}${interim}`;
+  prompt.value = base ? `${base} ${combined}` : combined;
+});
 
 function generateTitle(text: string): string {
   const firstLine = text.split("\n")[0]?.trim() ?? text.trim();
@@ -82,16 +102,9 @@ async function submit() {
       <form class="space-y-4 px-5 py-4" @submit.prevent="submit">
         <!-- Prompt -->
         <div>
-          <div class="mb-1.5 flex items-center justify-between">
-            <label class="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
-              Prompt <span class="text-red-400">*</span>
-            </label>
-            <ClientOnly>
-              <VoiceInput
-                @transcription="(text: string) => (prompt = prompt ? `${prompt} ${text}` : text)"
-              />
-            </ClientOnly>
-          </div>
+          <label class="mb-1.5 block text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+            Prompt <span class="text-red-400">*</span>
+          </label>
           <textarea
             v-model="prompt"
             rows="4"
@@ -99,9 +112,25 @@ async function submit() {
             autofocus
             class="w-full resize-none rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 focus:border-blue-500 focus:outline-none"
           />
-          <p class="mt-1 text-[10px] text-zinc-600">
-            First line becomes the card title. Full text is sent as the prompt to Claude.
-          </p>
+          <div class="mt-1.5 flex items-center justify-between">
+            <p class="text-[10px] text-zinc-600">
+              First line becomes the card title. Full text is sent as the prompt to Claude.
+            </p>
+            <button
+              v-if="isSupported"
+              type="button"
+              class="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-all"
+              :class="
+                isListening
+                  ? 'border-red-500 bg-red-500/10 text-red-400 animate-pulse'
+                  : 'border-zinc-700 bg-zinc-800 text-zinc-300 hover:border-zinc-600 hover:bg-zinc-700'
+              "
+              @click="toggleVoice"
+            >
+              <span class="text-sm">{{ isListening ? "●" : "🎤" }}</span>
+              {{ isListening ? "Stop" : "Dictate" }}
+            </button>
+          </div>
         </div>
 
         <!-- Repo selector -->

--- a/plugins/tt-agentboard/app/components/board/NewCardForm.vue
+++ b/plugins/tt-agentboard/app/components/board/NewCardForm.vue
@@ -102,7 +102,9 @@ async function submit() {
       <form class="space-y-4 px-5 py-4" @submit.prevent="submit">
         <!-- Prompt -->
         <div>
-          <label class="mb-1.5 block text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+          <label
+            class="mb-1.5 block text-[11px] font-semibold uppercase tracking-wider text-zinc-400"
+          >
             Prompt <span class="text-red-400">*</span>
           </label>
           <textarea

--- a/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
+++ b/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
@@ -56,26 +56,29 @@ function handleScroll() {
   autoScroll.value = scrollHeight - scrollTop - clientHeight < 40;
 }
 
-/** Map tool names to display labels matching Claude Code TUI style */
+const TOOL_COLORS = {
+  blue: "text-blue-400 border-blue-500/30 bg-blue-500/5",
+  amber: "text-amber-400 border-amber-500/30 bg-amber-500/5",
+  emerald: "text-emerald-400 border-emerald-500/30 bg-emerald-500/5",
+  cyan: "text-cyan-400 border-cyan-500/30 bg-cyan-500/5",
+  purple: "text-purple-400 border-purple-500/30 bg-purple-500/5",
+  violet: "text-violet-400 border-violet-500/30 bg-violet-500/5",
+  sky: "text-sky-400 border-sky-500/30 bg-sky-500/5",
+} as const;
+
 const TOOL_ICONS: Record<string, { label: string; color: string }> = {
-  Read: { label: "Read", color: "text-blue-400 border-blue-500/30 bg-blue-500/5" },
-  Edit: { label: "Edit", color: "text-amber-400 border-amber-500/30 bg-amber-500/5" },
-  Write: { label: "Write", color: "text-amber-400 border-amber-500/30 bg-amber-500/5" },
-  Bash: { label: "Bash", color: "text-emerald-400 border-emerald-500/30 bg-emerald-500/5" },
-  Glob: { label: "Glob", color: "text-cyan-400 border-cyan-500/30 bg-cyan-500/5" },
-  Grep: { label: "Grep", color: "text-cyan-400 border-cyan-500/30 bg-cyan-500/5" },
-  Agent: { label: "Agent", color: "text-purple-400 border-purple-500/30 bg-purple-500/5" },
-  TodoWrite: { label: "TodoWrite", color: "text-violet-400 border-violet-500/30 bg-violet-500/5" },
-  TaskCreate: {
-    label: "TaskCreate",
-    color: "text-violet-400 border-violet-500/30 bg-violet-500/5",
-  },
-  TaskUpdate: {
-    label: "TaskUpdate",
-    color: "text-violet-400 border-violet-500/30 bg-violet-500/5",
-  },
-  WebFetch: { label: "WebFetch", color: "text-sky-400 border-sky-500/30 bg-sky-500/5" },
-  WebSearch: { label: "WebSearch", color: "text-sky-400 border-sky-500/30 bg-sky-500/5" },
+  Read: { label: "Read", color: TOOL_COLORS.blue },
+  Edit: { label: "Edit", color: TOOL_COLORS.amber },
+  Write: { label: "Write", color: TOOL_COLORS.amber },
+  Bash: { label: "Bash", color: TOOL_COLORS.emerald },
+  Glob: { label: "Glob", color: TOOL_COLORS.cyan },
+  Grep: { label: "Grep", color: TOOL_COLORS.cyan },
+  Agent: { label: "Agent", color: TOOL_COLORS.purple },
+  TodoWrite: { label: "TodoWrite", color: TOOL_COLORS.violet },
+  TaskCreate: { label: "TaskCreate", color: TOOL_COLORS.violet },
+  TaskUpdate: { label: "TaskUpdate", color: TOOL_COLORS.violet },
+  WebFetch: { label: "WebFetch", color: TOOL_COLORS.sky },
+  WebSearch: { label: "WebSearch", color: TOOL_COLORS.sky },
 };
 
 function getToolStyle(name: string) {
@@ -85,14 +88,6 @@ function getToolStyle(name: string) {
 }
 
 function formatDetail(event: ActivityEvent & { kind: "tool_use" }) {
-  const input = event.input;
-  if (!input) return event.detail;
-
-  const filePath = input.file_path ?? input.path;
-  if (typeof filePath === "string") return filePath;
-  if (typeof input.command === "string") return input.command;
-  if (typeof input.pattern === "string") return input.pattern;
-  if (typeof input.subject === "string") return input.subject;
   return event.detail;
 }
 

--- a/plugins/tt-agentboard/app/components/card/CardDetail.vue
+++ b/plugins/tt-agentboard/app/components/card/CardDetail.vue
@@ -107,9 +107,7 @@ function sendResponse() {
     </div>
 
     <!-- Timestamps + branch mode -->
-    <div
-      class="mb-4 flex flex-wrap gap-x-4 gap-y-1 text-[10px] font-mono text-zinc-500"
-    >
+    <div class="mb-4 flex flex-wrap gap-x-4 gap-y-1 text-[10px] font-mono text-zinc-500">
       <span>Created {{ new Date(card.createdAt).toLocaleString() }}</span>
       <span>Updated {{ new Date(card.updatedAt).toLocaleString() }}</span>
     </div>

--- a/plugins/tt-agentboard/app/composables/useVoice.ts
+++ b/plugins/tt-agentboard/app/composables/useVoice.ts
@@ -1,102 +1,107 @@
 export type VoiceContext = "card-response" | "new-card" | "idle";
 
-export function useVoice() {
-  const isListening = ref(false);
-  const transcript = ref("");
-  const interimTranscript = ref("");
-  const isSupported = ref(false);
-  const error = ref<string | null>(null);
-  const currentContext = ref<VoiceContext>("idle");
+// Module-scope singleton state — shared across all callers
+const isListening = ref(false);
+const transcript = ref("");
+const interimTranscript = ref("");
+const isSupported = ref(false);
+const error = ref<string | null>(null);
+const currentContext = ref<VoiceContext>("idle");
 
-  let recognition: SpeechRecognition | null = null;
+let recognition: SpeechRecognition | null = null;
+let initialized = false;
 
-  function init() {
-    const SpeechRecognition = window.SpeechRecognition || (window as any).webkitSpeechRecognition;
-    if (!SpeechRecognition) {
-      isSupported.value = false;
+function init() {
+  if (initialized) return;
+  initialized = true;
+
+  const SpeechRecognition = window.SpeechRecognition || (window as any).webkitSpeechRecognition;
+  if (!SpeechRecognition) {
+    isSupported.value = false;
+    return;
+  }
+
+  isSupported.value = true;
+  recognition = new SpeechRecognition();
+  recognition.continuous = true;
+  recognition.interimResults = true;
+  recognition.lang = "en-US";
+
+  recognition.onresult = (event: SpeechRecognitionEvent) => {
+    let finalText = "";
+    let interimText = "";
+
+    for (let i = event.resultIndex; i < event.results.length; i++) {
+      const result = event.results[i];
+      if (result.isFinal) {
+        finalText += result[0].transcript;
+      } else {
+        interimText += result[0].transcript;
+      }
+    }
+
+    if (finalText) {
+      transcript.value += finalText;
+    }
+    interimTranscript.value = interimText;
+  };
+
+  recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+    error.value = event.error;
+    isListening.value = false;
+  };
+
+  recognition.onend = () => {
+    // In continuous mode, restart if still supposed to be listening
+    if (isListening.value && recognition) {
+      recognition.start();
       return;
     }
-
-    isSupported.value = true;
-    recognition = new SpeechRecognition();
-    recognition.continuous = true;
-    recognition.interimResults = true;
-    recognition.lang = "en-US";
-
-    recognition.onresult = (event: SpeechRecognitionEvent) => {
-      let finalText = "";
-      let interimText = "";
-
-      for (let i = event.resultIndex; i < event.results.length; i++) {
-        const result = event.results[i];
-        if (result.isFinal) {
-          finalText += result[0].transcript;
-        } else {
-          interimText += result[0].transcript;
-        }
-      }
-
-      if (finalText) {
-        transcript.value += finalText;
-      }
-      interimTranscript.value = interimText;
-    };
-
-    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-      error.value = event.error;
-      isListening.value = false;
-    };
-
-    recognition.onend = () => {
-      // In continuous mode, restart if still supposed to be listening
-      if (isListening.value && recognition) {
-        recognition.start();
-        return;
-      }
-      isListening.value = false;
-    };
-  }
-
-  function setContext(ctx: VoiceContext) {
-    currentContext.value = ctx;
-  }
-
-  function startListening() {
-    if (!recognition) init();
-    if (!recognition) return;
-
-    error.value = null;
-    transcript.value = "";
-    interimTranscript.value = "";
-    recognition.start();
-    isListening.value = true;
-  }
-
-  function stopListening() {
     isListening.value = false;
-    interimTranscript.value = "";
-    recognition?.stop();
-  }
+  };
+}
 
-  function toggleListening() {
-    if (isListening.value) {
-      stopListening();
-    } else {
-      startListening();
-    }
-  }
+function setContext(ctx: VoiceContext) {
+  currentContext.value = ctx;
+}
 
-  function clear() {
-    transcript.value = "";
-    interimTranscript.value = "";
-  }
+function startListening() {
+  if (!recognition) init();
+  if (!recognition) return;
 
-  function cancelDictation() {
+  error.value = null;
+  transcript.value = "";
+  interimTranscript.value = "";
+  recognition.start();
+  isListening.value = true;
+}
+
+function stopListening() {
+  isListening.value = false;
+  interimTranscript.value = "";
+  recognition?.stop();
+}
+
+function toggleListening() {
+  if (isListening.value) {
     stopListening();
-    clear();
-    currentContext.value = "idle";
+  } else {
+    startListening();
   }
+}
 
+function clear() {
+  transcript.value = "";
+  interimTranscript.value = "";
+}
+
+function cancelDictation() {
+  stopListening();
+  clear();
+  currentContext.value = "idle";
+}
+
+export function useVoice() {
   onMounted(init);
 
   return {
@@ -112,7 +117,6 @@ export function useVoice() {
     toggleListening,
     cancelDictation,
     clear,
-    // Keep old names as aliases for existing VoiceInput component
     start: startListening,
     stop: stopListening,
     toggle: toggleListening,

--- a/plugins/tt-agentboard/app/pages/index.vue
+++ b/plugins/tt-agentboard/app/pages/index.vue
@@ -53,6 +53,9 @@ function handleToggleDictation() {
 // When transcript is finalized and user stops dictation, route it
 watch(isListening, async (listening) => {
   if (listening) return;
+  // When NewCardForm is open, VoiceInput handles transcription directly
+  if (showNewCardForm.value) return;
+
   const text = transcript.value.trim();
   if (!text) return;
 
@@ -61,8 +64,6 @@ watch(isListening, async (listening) => {
       method: "POST",
       body: { response: text },
     });
-  } else if (currentContext.value === "new-card") {
-    // Form is already open, prefill handled by watcher below
   } else {
     // idle: open new card form with transcript as title
     newCardPrefill.value = text;
@@ -437,9 +438,10 @@ useKeyboardShortcuts({
       </Transition>
     </div>
 
-    <!-- Dictation Bar -->
+    <!-- Dictation Bar — hidden when NewCardForm is open (it has its own VoiceInput) -->
     <ClientOnly>
       <SharedDictationBar
+        v-if="!showNewCardForm"
         :is-listening="isListening"
         :interim-transcript="interimTranscript"
         :transcript="transcript"

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/diff.get.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/diff.get.ts
@@ -68,42 +68,31 @@ function parseDiff(raw: string): DiffFile[] {
 export default defineEventHandler(async (event) => {
   const cardId = getCardId(event);
 
-  // Try claimed slot first (active execution), then fall back to workflow run record (completed)
+  // Fetch claimed slot and workflow run in parallel
   let slotPath: string | null = null;
   let branch: string | null = null;
 
-  const [claimedSlot] = await db
-    .select()
-    .from(workspaceSlots)
-    .where(eq(workspaceSlots.claimedByCardId, cardId))
-    .limit(1);
-
-  if (claimedSlot) {
-    slotPath = claimedSlot.path;
-    // Still look up branch from workflow run for active cards
-    const [run] = await db
-      .select({ branch: workflowRuns.branch })
-      .from(workflowRuns)
-      .where(eq(workflowRuns.cardId, cardId))
-      .limit(1);
-    branch = run?.branch ?? null;
-  } else {
-    // Slot was released after completion — look up via workflow run
-    const [run] = await db
+  const [[claimedSlot], [run]] = await Promise.all([
+    db.select().from(workspaceSlots).where(eq(workspaceSlots.claimedByCardId, cardId)).limit(1),
+    db
       .select({ slotId: workflowRuns.slotId, branch: workflowRuns.branch })
       .from(workflowRuns)
       .where(eq(workflowRuns.cardId, cardId))
-      .limit(1);
+      .limit(1),
+  ]);
 
-    if (run?.slotId) {
-      const [slot] = await db
-        .select()
-        .from(workspaceSlots)
-        .where(eq(workspaceSlots.id, run.slotId))
-        .limit(1);
-      slotPath = slot?.path ?? null;
-      branch = run.branch;
-    }
+  if (claimedSlot) {
+    slotPath = claimedSlot.path;
+    branch = run?.branch ?? null;
+  } else if (run?.slotId) {
+    // Slot was released after completion — look up via workflow run's slotId
+    const [slot] = await db
+      .select()
+      .from(workspaceSlots)
+      .where(eq(workspaceSlots.id, run.slotId))
+      .limit(1);
+    slotPath = slot?.path ?? null;
+    branch = run.branch;
   }
 
   if (!slotPath) {

--- a/plugins/tt-agentboard/server/domains/infra/stream-tailer.ts
+++ b/plugins/tt-agentboard/server/domains/infra/stream-tailer.ts
@@ -1,5 +1,6 @@
 import type { FSWatcher } from "node:fs";
 import { watch as fsWatch, createReadStream, statSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import { parseStreamLine } from "./stream-parser";
 import { eventBus } from "../../shared/event-bus";
@@ -70,11 +71,10 @@ export class StreamTailer {
       reading = false;
     };
 
-    const startWatching = () => {
+    const startWatching = async () => {
       try {
-        statSync(logFilePath);
+        await stat(logFilePath);
       } catch {
-        // File doesn't exist yet — retry until it appears or we're closed
         if (!closed) {
           retryTimer = setTimeout(startWatching, 500);
         }

--- a/plugins/tt-agentboard/server/plugins/stream-completion.ts
+++ b/plugins/tt-agentboard/server/plugins/stream-completion.ts
@@ -1,4 +1,5 @@
 import { eventBus } from "../shared/event-bus";
+import type { EventMap } from "../shared/event-bus";
 import { logger } from "../utils/logger";
 
 /**
@@ -12,19 +13,15 @@ import { logger } from "../utils/logger";
 export default defineNitroPlugin(() => {
   const processed = new Set<string>();
 
-  eventBus.on("agent:activity", async (data) => {
-    const { cardId, event } = data as {
-      cardId: number;
-      event: { kind: string; isError?: boolean };
-    };
+  eventBus.on("agent:activity", async (data: EventMap["agent:activity"]) => {
+    const { cardId, event, timestamp } = data;
 
     if (event.kind !== "result") return;
 
-    // Deduplicate — stream-tailer may re-read the same line on file change
-    const key = `${cardId}`;
+    // Deduplicate with timestamp to allow reruns of the same card
+    const key = `${cardId}:${timestamp}`;
     if (processed.has(key)) return;
     processed.add(key);
-    // Clean up after 60s to avoid unbounded growth
     setTimeout(() => processed.delete(key), 60_000);
 
     const endpoint = event.isError ? "failure" : "complete";


### PR DESCRIPTION
## Summary
- **Headless cards use `tt auto-claude`** instead of raw `claude -p` — structured terminal output with stream-json parsing
- **Voice dictation streams into prompt textarea** in real-time (interim + final transcript), replacing the old batch-on-stop VoiceInput component
- **Activity panel redesigned** with Claude Code TUI-style tool badges, edit previews, bash command display, and result banners
- **Diff endpoint works after card completion** — falls back to workflow run record when slot is released
- **Stream-completion plugin** detects agent finish from stream-json result events (for `-p` mode where HTTP Stop hooks don't fire)
- **Code cleanup**: dedup TOOL_COLORS, parallelize DB queries, async file polling, typed EventMap usage

## Test plan
- [x] Typecheck passes
- [x] 145 agentboard unit tests pass
- [x] Lint clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)