### PR TITLE
chore: apply skill-and-prompt-guide best practices to prompt templates

### DIFF
--- a/plugins/tt-core/commands/refine-text.md
+++ b/plugins/tt-core/commands/refine-text.md
@@ -1,35 +1,30 @@
 ---
-description: refine writing and fix grammar and spelling
+description: Fix grammar, spelling, and cut filler in writing. Use when asked to "proofread", "edit my writing", "fix grammar", or "clean up this text".
 allowed-tools: Read(*), Edit(*)
 ---
 
-<role>
-You are a professional copy editor. You fix errors and cut filler — nothing more. You never rewrite or rephrase working sentences.
-</role>
+You are a professional copy editor. Fix errors and cut filler — nothing more. Never rewrite or rephrase working sentences.
 
-<context>
 File to edit: $ARGUMENTS
-</context>
 
-<instruction>
-Apply these edits:
+## Edits to Apply
 
 1. **Fix spelling and typos**
 2. **Fix grammar** — agreement, apostrophes, tense
 3. **Fix punctuation**
-4. **Cut filler words** — "in order to" -> "to", doubled adjectives -> pick one. Just delete filler.
-5. **Passive -> active** — only when actor is named ("was updated by X" -> "X updated")
+4. **Cut filler words** — "in order to" → "to", doubled adjectives → pick one. Just delete filler.
+5. **Passive → active** — only when actor is named ("was updated by X" → "X updated")
 
-Critical rules:
+## Preserve
 
-- Casual language (slang, "gonna", "kinda") is voice — keep it
+- Casual language (slang, "gonna", "kinda") — this is voice, keep it
 - Rhetorical questions, deliberate fragments — keep them
 - Code fences, inline code, URLs, markdown links — never modify
 - Headings, labels, bullet structure — preserve exactly
 - Never add content, never reorder or restructure
-  </instruction>
 
-<output_format>
+## Output
+
 Output ONLY the corrected text. No introduction, no sign-off, no list of changes.
+
 When used with a file, edit the file directly using the Edit tool.
-</output_format>

--- a/plugins/tt-core/commands/task.md
+++ b/plugins/tt-core/commands/task.md
@@ -1,5 +1,5 @@
 ---
-description: Create, list, and manage Claude Code tasks in the current session
+description: Create, list, and manage Claude Code tasks in the current session. Use when asked to "create tasks", "track work", "list tasks", or "mark task done".
 allowed-tools: TaskCreate(*), TaskUpdate(*), TaskList(*), TaskGet(*)
 ---
 

--- a/plugins/tt-core/commands/tdd.md
+++ b/plugins/tt-core/commands/tdd.md
@@ -1,5 +1,5 @@
 ---
-description: Implement a feature or fix using strict red-green-refactor TDD
+description: Implement a feature or fix using strict red-green-refactor TDD. Use when asked to "write tests first", "use TDD", "red-green-refactor", or "test-driven".
 allowed-tools: Read(*), Edit(*), Write(*), Glob(*), Grep(*), Bash(*), AskUserQuestion(*)
 ---
 

--- a/plugins/tt-core/skills/towles-tool/SKILL.md
+++ b/plugins/tt-core/skills/towles-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: towles-tool
-description: Use towles-tool (`tt`) CLI for git helpers, journaling, and developer utilities.
+description: Use towles-tool (`tt`) CLI for git helpers, journaling, and developer utilities. Use when asked about "tt commands", "create branch from issue", "daily notes", "meeting notes", or "check dependencies".
 ---
 
 # towles-tool CLI


### PR DESCRIPTION
## Summary
- Removes XML angle brackets from prompt templates per skill-and-prompt-guide rules
- Replaces `<role>`, `<context>`, `<instruction>` tags with markdown headers
- Unifies arrow style to `→` across templates
- Adds trigger phrases to skill description frontmatter

Closes #93

## Test plan
- [ ] Prompt templates render correctly without XML tags
- [ ] Skill descriptions trigger properly with new phrases

🤖 Generated with [Claude Code](https://claude.com/claude-code)