### PR TITLE
feat(agentboard): server-side open for URLs, VS Code, and files

### DIFF
--- a/plugins/tt-agentboard/app/components/board/KanbanCard.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanCard.vue
@@ -14,6 +14,7 @@ const emit = defineEmits<{
 
 const cardRef = computed(() => props.card);
 const { issueUrl, prUrl } = useCardUrls(cardRef);
+const { openUrl } = useServerOpen();
 
 const borderClass = computed(
   () => STATUS_BORDER_CLASSES[props.card.status as CardStatus] ?? "border-zinc-700",
@@ -131,27 +132,23 @@ watch(
         <span v-if="elapsedTime" class="text-[10px] font-mono tabular-nums text-zinc-500">
           {{ elapsedTime }}
         </span>
-        <a
+        <button
           v-if="card.githubIssueNumber && issueUrl"
-          :href="issueUrl"
-          target="_blank"
           class="text-[10px] font-mono text-zinc-500 hover:text-blue-400"
-          @click.stop
+          @click.stop="openUrl(issueUrl!)"
         >
           #{{ card.githubIssueNumber }}
-        </a>
+        </button>
         <span v-else-if="card.githubIssueNumber" class="text-[10px] font-mono text-zinc-500">
           #{{ card.githubIssueNumber }}
         </span>
-        <a
+        <button
           v-if="card.githubPrNumber && prUrl"
-          :href="prUrl"
-          target="_blank"
           class="rounded-full bg-purple-500/15 px-1.5 py-0.5 text-[9px] font-mono text-purple-400 hover:bg-purple-500/25"
-          @click.stop
+          @click.stop="openUrl(prUrl!)"
         >
           PR #{{ card.githubPrNumber }}
-        </a>
+        </button>
         <span
           v-else-if="card.githubPrNumber"
           class="rounded-full bg-purple-500/15 px-1.5 py-0.5 text-[9px] font-mono text-purple-400"

--- a/plugins/tt-agentboard/app/components/card/CardActions.vue
+++ b/plugins/tt-agentboard/app/components/card/CardActions.vue
@@ -12,6 +12,7 @@ const emit = defineEmits<{
   deleted: [];
 }>();
 
+const { openUrl } = useServerOpen();
 const open = ref(false);
 const toast = ref("");
 const toastTimeout = ref<ReturnType<typeof setTimeout> | null>(null);
@@ -94,10 +95,15 @@ const branchUrl = computed(() => {
   return null;
 });
 
-function viewOnGitHub() {
+async function viewOnGitHub() {
   closeMenu();
   if (branchUrl.value) {
-    window.open(branchUrl.value, "_blank");
+    try {
+      await openUrl(branchUrl.value);
+      showToast("Opened in browser");
+    } catch {
+      showToast("Failed to open browser");
+    }
   }
 }
 

--- a/plugins/tt-agentboard/app/components/card/CardDetail.vue
+++ b/plugins/tt-agentboard/app/components/card/CardDetail.vue
@@ -16,6 +16,11 @@ const emit = defineEmits<{
 const agentInput = ref("");
 const cardRef = computed(() => props.card);
 const { branchUrl, issueUrl, prUrl } = useCardUrls(cardRef);
+const { openUrl } = useServerOpen();
+
+function serverOpen(url: string | null) {
+  if (url) openUrl(url);
+}
 
 function sendResponse() {
   if (!agentInput.value.trim()) return;
@@ -60,14 +65,13 @@ function sendResponse() {
       <!-- Branch -->
       <div v-if="card.branch" class="flex items-center gap-1.5 text-xs font-mono">
         <span class="text-zinc-600">branch</span>
-        <a
+        <button
           v-if="branchUrl"
-          :href="branchUrl"
-          target="_blank"
-          class="rounded bg-zinc-800 px-1.5 py-0.5 text-blue-400 hover:text-blue-300 hover:underline"
+          class="cursor-pointer rounded bg-zinc-800 px-1.5 py-0.5 text-blue-400 hover:text-blue-300 hover:underline"
+          @click="serverOpen(branchUrl)"
         >
           {{ card.branch }}
-        </a>
+        </button>
         <span v-else class="rounded bg-zinc-800 px-1.5 py-0.5 text-zinc-300">{{
           card.branch
         }}</span>
@@ -80,27 +84,25 @@ function sendResponse() {
       >
         <template v-if="card.githubIssueNumber">
           <span>Issue</span>
-          <a
+          <button
             v-if="issueUrl"
-            :href="issueUrl"
-            target="_blank"
-            class="text-blue-400 hover:text-blue-300 hover:underline"
+            class="cursor-pointer text-blue-400 hover:text-blue-300 hover:underline"
+            @click="serverOpen(issueUrl)"
           >
             #{{ card.githubIssueNumber }}
-          </a>
+          </button>
           <span v-else>#{{ card.githubIssueNumber }}</span>
         </template>
         <template v-if="card.githubPrNumber">
           <span v-if="card.githubIssueNumber">·</span>
           <span>PR</span>
-          <a
+          <button
             v-if="prUrl"
-            :href="prUrl"
-            target="_blank"
-            class="rounded-full bg-purple-500/15 px-1.5 py-0.5 text-purple-400 hover:bg-purple-500/25 hover:underline"
+            class="cursor-pointer rounded-full bg-purple-500/15 px-1.5 py-0.5 text-purple-400 hover:bg-purple-500/25 hover:underline"
+            @click="serverOpen(prUrl)"
           >
             #{{ card.githubPrNumber }}
-          </a>
+          </button>
           <span v-else>#{{ card.githubPrNumber }}</span>
         </template>
       </div>

--- a/plugins/tt-agentboard/app/composables/useServerOpen.ts
+++ b/plugins/tt-agentboard/app/composables/useServerOpen.ts
@@ -1,0 +1,20 @@
+/**
+ * Composable for opening assets via the local server.
+ * Since AgentBoard runs on the user's machine, the server can directly
+ * launch browsers, editors, and files — no need for client-side window.open().
+ */
+export function useServerOpen() {
+  async function openUrl(url: string) {
+    await $fetch("/api/open", { method: "POST", body: { type: "url", target: url } });
+  }
+
+  async function openInVscode(path: string) {
+    await $fetch("/api/open", { method: "POST", body: { type: "vscode", target: path } });
+  }
+
+  async function openFile(path: string) {
+    await $fetch("/api/open", { method: "POST", body: { type: "file", target: path } });
+  }
+
+  return { openUrl, openInVscode, openFile };
+}

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/open-vscode.get.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/open-vscode.get.ts
@@ -1,7 +1,7 @@
 import { db } from "~~/server/shared/db";
 import { workspaceSlots, workflowRuns } from "~~/server/shared/db/schema";
 import { eq, desc } from "drizzle-orm";
-import { execSync } from "node:child_process";
+import { openInVscode } from "~~/server/domains/infra/opener";
 import { logger } from "~~/server/utils/logger";
 import { getCardId } from "~~/server/utils/params";
 
@@ -46,7 +46,7 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    execSync(`code ${JSON.stringify(slotPath)}`, { stdio: "ignore" });
+    openInVscode(slotPath);
     logger.info(`Opened VS Code for card ${cardId} at ${slotPath}`);
     return { ok: true, path: slotPath };
   } catch (err) {

--- a/plugins/tt-agentboard/server/api/open.post.ts
+++ b/plugins/tt-agentboard/server/api/open.post.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { openUrl, openInVscode, openFile } from "~~/server/domains/infra/opener";
+import { logger } from "~~/server/utils/logger";
+
+const OpenRequestSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("url"), target: z.string().url() }),
+  z.object({ type: z.literal("vscode"), target: z.string().min(1) }),
+  z.object({ type: z.literal("file"), target: z.string().min(1) }),
+]);
+
+/**
+ * POST /api/open
+ * Opens a URL, VS Code path, or file using the host machine's applications.
+ * This works because the server runs locally on the user's machine.
+ */
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  const req = OpenRequestSchema.parse(body);
+
+  try {
+    switch (req.type) {
+      case "url":
+        openUrl(req.target);
+        break;
+      case "vscode":
+        openInVscode(req.target);
+        break;
+      case "file":
+        openFile(req.target);
+        break;
+    }
+    return { ok: true, type: req.type, target: req.target };
+  } catch (err) {
+    logger.error(`Failed to open ${req.type}: ${req.target}`, err);
+    throw createError({ statusCode: 500, statusMessage: `Failed to open ${req.type}` });
+  }
+});

--- a/plugins/tt-agentboard/server/domains/infra/opener.ts
+++ b/plugins/tt-agentboard/server/domains/infra/opener.ts
@@ -1,15 +1,18 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { platform } from "node:os";
 import { logger } from "~~/server/utils/logger";
+
+function systemOpen(): string {
+  return platform() === "darwin" ? "open" : "xdg-open";
+}
 
 /**
  * Opens a URL in the system default browser.
  * Works on Linux (xdg-open) and macOS (open).
  */
 export function openUrl(url: string) {
-  const cmd = platform() === "darwin" ? "open" : "xdg-open";
   logger.info(`Opening URL: ${url}`);
-  execSync(`${cmd} ${JSON.stringify(url)}`, { stdio: "ignore" });
+  execFileSync(systemOpen(), [url], { stdio: "ignore" });
 }
 
 /**
@@ -17,14 +20,13 @@ export function openUrl(url: string) {
  */
 export function openInVscode(path: string) {
   logger.info(`Opening in VS Code: ${path}`);
-  execSync(`code ${JSON.stringify(path)}`, { stdio: "ignore" });
+  execFileSync("code", [path], { stdio: "ignore" });
 }
 
 /**
  * Opens a file with the system default application.
  */
 export function openFile(path: string) {
-  const cmd = platform() === "darwin" ? "open" : "xdg-open";
   logger.info(`Opening file: ${path}`);
-  execSync(`${cmd} ${JSON.stringify(path)}`, { stdio: "ignore" });
+  execFileSync(systemOpen(), [path], { stdio: "ignore" });
 }

--- a/plugins/tt-agentboard/server/domains/infra/opener.ts
+++ b/plugins/tt-agentboard/server/domains/infra/opener.ts
@@ -1,0 +1,30 @@
+import { execSync } from "node:child_process";
+import { platform } from "node:os";
+import { logger } from "~~/server/utils/logger";
+
+/**
+ * Opens a URL in the system default browser.
+ * Works on Linux (xdg-open) and macOS (open).
+ */
+export function openUrl(url: string) {
+  const cmd = platform() === "darwin" ? "open" : "xdg-open";
+  logger.info(`Opening URL: ${url}`);
+  execSync(`${cmd} ${JSON.stringify(url)}`, { stdio: "ignore" });
+}
+
+/**
+ * Opens a directory or file in VS Code.
+ */
+export function openInVscode(path: string) {
+  logger.info(`Opening in VS Code: ${path}`);
+  execSync(`code ${JSON.stringify(path)}`, { stdio: "ignore" });
+}
+
+/**
+ * Opens a file with the system default application.
+ */
+export function openFile(path: string) {
+  const cmd = platform() === "darwin" ? "open" : "xdg-open";
+  logger.info(`Opening file: ${path}`);
+  execSync(`${cmd} ${JSON.stringify(path)}`, { stdio: "ignore" });
+}


### PR DESCRIPTION
Leverage the local server to open assets directly on the host machine
instead of using client-side window.open(). Since AgentBoard runs locally,
the server can shell out to xdg-open/open and code commands.

- Add opener utility (server/domains/infra/opener.ts) with platform detection
- Add generic POST /api/open endpoint supporting url/vscode/file types
- Add useServerOpen() composable for client-side usage
- Refactor open-vscode endpoint to use shared opener utility
- Update CardActions, CardDetail, KanbanCard to use server-side open
  for GitHub branch/issue/PR links

https://claude.ai/code/session_01BS3Hv3brzPSFrTGYRkcz55