### PR TITLE
feat(agentboard): add slot lifecycle management with SlotPreparer

### DIFF
--- a/plugins/tt-agentboard/server/domains/execution/agent-executor.ts
+++ b/plugins/tt-agentboard/server/domains/execution/agent-executor.ts
@@ -1,11 +1,9 @@
 import { db as defaultDb } from "../../shared/db";
 import { cards, workflowRuns } from "../../shared/db/schema";
 import { eq } from "drizzle-orm";
-import { execSync as defaultExecSync } from "node:child_process";
-import { existsSync as defaultExistsSync } from "node:fs";
-import { join } from "node:path";
 import { tmuxManager as defaultTmuxManager } from "../infra/tmux-manager";
 import { slotAllocator as defaultSlotAllocator } from "./slot-allocator";
+import { slotPreparer as defaultSlotPreparer } from "./slot-preparer";
 import { workflowLoader as defaultWorkflowLoader } from "./workflow-loader";
 import { workflowOrchestrator as defaultWorkflowOrchestrator } from "./workflow-orchestrator";
 import { eventBus as defaultEventBus } from "../../shared/event-bus";
@@ -14,6 +12,7 @@ import { writeHooks as defaultWriteHooks } from "../infra/hook-writer";
 import { shellEscape } from "./workflow-helpers";
 import { cardService as defaultCardService } from "../cards/card-service";
 import type { CardService } from "../cards/card-service";
+import type { SlotPreparer } from "./slot-preparer";
 import type { Logger, EventBus } from "./types";
 
 export interface AgentExecutorDeps {
@@ -33,12 +32,11 @@ export interface AgentExecutorDeps {
     releaseSlot: (slotId: number) => Promise<void>;
     getSlotForCard: (cardId: number) => Promise<{ id: number; path: string } | null>;
   };
+  slotPreparer: SlotPreparer;
   workflowLoader: { get: (id: string) => unknown };
   workflowOrchestrator: { run: (cardId: number) => Promise<void> };
   writeHooks: typeof defaultWriteHooks;
   cardService: CardService;
-  execSync: typeof defaultExecSync;
-  existsSync: typeof defaultExistsSync;
 }
 
 /**
@@ -60,12 +58,11 @@ export class AgentExecutor {
       logger: defaultLogger,
       tmuxManager: defaultTmuxManager,
       slotAllocator: defaultSlotAllocator,
+      slotPreparer: defaultSlotPreparer,
       workflowLoader: defaultWorkflowLoader,
       workflowOrchestrator: defaultWorkflowOrchestrator,
       writeHooks: defaultWriteHooks,
       cardService: defaultCardService,
-      execSync: defaultExecSync,
-      existsSync: defaultExistsSync,
       ...deps,
     };
   }
@@ -167,9 +164,6 @@ export class AgentExecutor {
       );
     }
 
-    // Branch handling
-    let branch: string | null = null;
-
     // Check for existing branch from a previous run (resume/rerun case)
     const previousRuns = await this.deps.db
       .select({ branch: workflowRuns.branch })
@@ -177,118 +171,21 @@ export class AgentExecutor {
       .where(eq(workflowRuns.cardId, cardId));
     const existingBranch = previousRuns.find((r) => r.branch)?.branch ?? null;
 
-    if (existingBranch) {
-      // Reuse existing branch from previous run
-      try {
-        this.deps.execSync(`git checkout ${existingBranch}`, {
-          cwd: slot.path,
-          stdio: "ignore",
-          timeout: 10000,
-        });
-        branch = existingBranch;
-        await this.deps.cardService.logEvent(cardId, "branch_reused", existingBranch);
-      } catch {
-        await this.deps.cardService.logEvent(
-          cardId,
-          "warn",
-          `Could not checkout existing branch ${existingBranch}, creating new`,
-        );
-        // Fall through to normal branch creation
-      }
+    // Prepare the slot: sync git, set up branch, install deps
+    const branchName = `agentboard/card-${cardId}`;
+    const prepResult = await this.deps.slotPreparer.prepare({
+      slotPath: slot.path,
+      branchMode: card.branchMode as "create" | "current",
+      branch: branchName,
+      existingBranch,
+    });
+
+    // Log all prep events
+    for (const event of prepResult.events) {
+      await this.deps.cardService.logEvent(cardId, event.type, event.detail);
     }
 
-    if (!branch && card.branchMode === "create") {
-      // Clean working tree of leftover files from previous agents
-      try {
-        this.deps.execSync("git checkout -- . && git clean -fd", {
-          cwd: slot.path,
-          stdio: "ignore",
-          timeout: 5000,
-        });
-      } catch {
-        /* non-fatal */
-      }
-
-      // Start from a clean, up-to-date main before branching
-      const branchName = `agentboard/card-${cardId}`;
-      try {
-        this.deps.execSync("git checkout main && git pull --ff-only", {
-          cwd: slot.path,
-          stdio: "ignore",
-          timeout: 15000,
-        });
-      } catch {
-        await this.deps.cardService.logEvent(
-          cardId,
-          "warn",
-          "Could not checkout/pull main before branching",
-        );
-      }
-      try {
-        this.deps.execSync(`git checkout -b ${branchName}`, { cwd: slot.path, stdio: "ignore" });
-        branch = branchName;
-        await this.deps.cardService.logEvent(cardId, "branch_created", branchName);
-      } catch {
-        // Branch may exist — try switching to it
-        try {
-          this.deps.execSync(`git checkout ${branchName}`, { cwd: slot.path, stdio: "ignore" });
-          branch = branchName;
-        } catch {
-          // Fall back to current branch
-          try {
-            branch = (
-              this.deps.execSync("git rev-parse --abbrev-ref HEAD", {
-                cwd: slot.path,
-                encoding: "utf-8",
-                timeout: 3000,
-              }) as unknown as string
-            ).trim();
-          } catch {
-            /* not a git repo */
-          }
-        }
-      }
-    } else if (!branch) {
-      // Stay on current branch
-      try {
-        branch = (
-          this.deps.execSync("git rev-parse --abbrev-ref HEAD", {
-            cwd: slot.path,
-            encoding: "utf-8",
-            timeout: 3000,
-          }) as unknown as string
-        ).trim();
-      } catch {
-        /* not a git repo */
-      }
-    }
-
-    // Run package installer if a lockfile exists
-    const lockfile = this.deps.existsSync(join(slot.path, "pnpm-lock.yaml"))
-      ? "pnpm"
-      : this.deps.existsSync(join(slot.path, "bun.lock"))
-        ? "bun"
-        : this.deps.existsSync(join(slot.path, "package-lock.json"))
-          ? "npm"
-          : null;
-
-    if (lockfile) {
-      try {
-        const cmds = {
-          pnpm: "pnpm install --frozen-lockfile",
-          bun: "bun install --frozen-lockfile",
-          npm: "npm ci",
-        };
-        this.deps.execSync(cmds[lockfile], { cwd: slot.path, stdio: "ignore", timeout: 60000 });
-        await this.deps.cardService.logEvent(cardId, "deps_installed", `${lockfile} install`);
-      } catch {
-        await this.deps.cardService.logEvent(
-          cardId,
-          "warn",
-          "Package install failed — continuing anyway",
-        );
-      }
-    }
+    const branch = prepResult.branch;
 
     // Create workflow run record
     await this.deps.db

--- a/plugins/tt-agentboard/server/domains/execution/slot-allocator.ts
+++ b/plugins/tt-agentboard/server/domains/execution/slot-allocator.ts
@@ -3,18 +3,21 @@ import { workspaceSlots } from "../../shared/db/schema";
 import { eq, and } from "drizzle-orm";
 import { eventBus } from "../../shared/event-bus";
 import { logger } from "../../utils/logger";
+import { slotPreparer as defaultSlotPreparer } from "./slot-preparer";
+import type { SlotPreparer } from "./slot-preparer";
 
 export interface SlotAllocatorDeps {
   db: typeof db;
   eventBus: typeof eventBus;
   logger: typeof logger;
+  slotPreparer: SlotPreparer;
 }
 
 export class SlotAllocator {
   private deps: SlotAllocatorDeps;
 
   constructor(deps: Partial<SlotAllocatorDeps> = {}) {
-    this.deps = { db, eventBus, logger, ...deps };
+    this.deps = { db, eventBus, logger, slotPreparer: defaultSlotPreparer, ...deps };
   }
 
   /** Find and claim an available slot for a repo */
@@ -52,8 +55,16 @@ export class SlotAllocator {
     } as typeof workspaceSlots.$inferSelect;
   }
 
-  /** Release a slot when work is done */
+  /** Release a slot when work is done, then reset it for the next use */
   async releaseSlot(slotId: number): Promise<void> {
+    // Look up the slot path before releasing
+    const slotRows = await this.deps.db
+      .select()
+      .from(workspaceSlots)
+      .where(eq(workspaceSlots.id, slotId))
+      .limit(1);
+    const slotPath = slotRows[0]?.path;
+
     await this.deps.db
       .update(workspaceSlots)
       .set({
@@ -64,6 +75,13 @@ export class SlotAllocator {
 
     this.deps.eventBus.emit("slot:released", { slotId });
     this.deps.logger.info(`Slot ${slotId} released`);
+
+    // Reset slot in the background: sync to main + install deps
+    if (slotPath) {
+      this.deps.slotPreparer.reset(slotPath).catch((err) => {
+        this.deps.logger.error(`Slot ${slotId} reset failed:`, err);
+      });
+    }
   }
 
   /** Get the slot currently claimed by a card */

--- a/plugins/tt-agentboard/server/domains/execution/slot-preparer.ts
+++ b/plugins/tt-agentboard/server/domains/execution/slot-preparer.ts
@@ -1,0 +1,234 @@
+import { execSync as defaultExecSync } from "node:child_process";
+import { existsSync as defaultExistsSync } from "node:fs";
+import { join } from "node:path";
+import { logger as defaultLogger } from "../../utils/logger";
+import type { Logger } from "./types";
+
+export interface SlotPreparerDeps {
+  logger: Logger;
+  execSync: typeof defaultExecSync;
+  existsSync: typeof defaultExistsSync;
+}
+
+export interface PrepareSlotOptions {
+  slotPath: string;
+  branchMode: "create" | "current";
+  /** Branch name to create (branchMode="create") or checkout (branchMode="current") */
+  branch: string;
+  /** Existing branch from a previous run — takes precedence if set */
+  existingBranch?: string | null;
+}
+
+export interface SlotEvent {
+  type: string;
+  detail: string;
+}
+
+export interface PrepareSlotResult {
+  branch: string;
+  depsInstalled: boolean;
+  packageManager: string | null;
+  events: SlotEvent[];
+}
+
+export interface ResetSlotResult {
+  depsInstalled: boolean;
+  packageManager: string | null;
+  events: SlotEvent[];
+}
+
+interface LockfileEntry {
+  file: string;
+  manager: string;
+  command: string;
+}
+
+const LOCKFILES: LockfileEntry[] = [
+  { file: "pnpm-lock.yaml", manager: "pnpm", command: "pnpm install --frozen-lockfile" },
+  { file: "bun.lock", manager: "bun", command: "bun install --frozen-lockfile" },
+  { file: "package-lock.json", manager: "npm", command: "npm ci" },
+  { file: "uv.lock", manager: "uv", command: "uv sync --frozen" },
+  { file: "requirements.txt", manager: "pip", command: "pip install -r requirements.txt" },
+];
+
+/**
+ * Manages slot workspace preparation for agent execution.
+ *
+ * Two entry points:
+ * - reset(): Called when a slot is released back to the pool.
+ *   Syncs with main and installs deps so the slot is ready for the next card.
+ * - prepare(): Called when a slot is claimed for a new card.
+ *   Re-syncs main + installs deps (in case of manual changes), then sets up the branch.
+ */
+export class SlotPreparer {
+  private deps: SlotPreparerDeps;
+
+  constructor(deps: Partial<SlotPreparerDeps> = {}) {
+    this.deps = {
+      logger: defaultLogger,
+      execSync: defaultExecSync,
+      existsSync: defaultExistsSync,
+      ...deps,
+    };
+  }
+
+  /**
+   * Reset a slot after release: clean working tree, checkout main, pull, install deps.
+   * This runs at release time so the slot is warm and ready for the next claim.
+   */
+  async reset(slotPath: string): Promise<ResetSlotResult> {
+    const events: SlotEvent[] = [];
+
+    this.syncToMain(slotPath, events);
+    const { installed, packageManager } = this.installDeps(slotPath, events);
+
+    this.deps.logger.info(`Slot reset complete: ${slotPath}`);
+    return { depsInstalled: installed, packageManager, events };
+  }
+
+  /**
+   * Prepare a slot for a specific card: sync git, set up branch, install deps.
+   * Called at claim time before the agent starts working.
+   */
+  async prepare(options: PrepareSlotOptions): Promise<PrepareSlotResult> {
+    const events: SlotEvent[] = [];
+    let branch: string;
+
+    if (options.existingBranch) {
+      // Resume case: checkout existing branch from previous run
+      branch = this.checkoutBranch(options.slotPath, options.existingBranch, events);
+    } else if (options.branchMode === "create") {
+      // New work: sync with main, then create branch
+      branch = this.syncMainAndBranch(options.slotPath, options.branch, events);
+    } else {
+      // branchMode="current": checkout the specified branch
+      branch = this.checkoutBranch(options.slotPath, options.branch, events);
+    }
+
+    // Install deps (cached from reset, so typically fast)
+    const { installed, packageManager } = this.installDeps(options.slotPath, events);
+
+    return { branch, depsInstalled: installed, packageManager, events };
+  }
+
+  /** Clean working tree, checkout main, pull latest */
+  private syncToMain(slotPath: string, events: SlotEvent[]): void {
+    // Discard any leftover changes
+    try {
+      this.deps.execSync("git checkout -- . && git clean -fd", {
+        cwd: slotPath,
+        stdio: "ignore",
+        timeout: 5000,
+      });
+    } catch {
+      /* non-fatal */
+    }
+
+    // Checkout main and pull
+    try {
+      this.deps.execSync("git checkout main && git pull --ff-only", {
+        cwd: slotPath,
+        stdio: "ignore",
+        timeout: 15000,
+      });
+      events.push({ type: "main_synced", detail: "Checked out and pulled main" });
+    } catch {
+      events.push({ type: "warn", detail: "Could not checkout/pull main" });
+    }
+  }
+
+  /** Sync with main then create a new branch */
+  private syncMainAndBranch(slotPath: string, branchName: string, events: SlotEvent[]): string {
+    this.syncToMain(slotPath, events);
+
+    // Create branch
+    try {
+      this.deps.execSync(`git checkout -b ${branchName}`, { cwd: slotPath, stdio: "ignore" });
+      events.push({ type: "branch_created", detail: branchName });
+      return branchName;
+    } catch {
+      // Branch may exist — try switching to it
+      try {
+        this.deps.execSync(`git checkout ${branchName}`, { cwd: slotPath, stdio: "ignore" });
+        events.push({ type: "branch_reused", detail: branchName });
+        return branchName;
+      } catch {
+        return this.getCurrentBranch(slotPath, events);
+      }
+    }
+  }
+
+  /** Checkout an existing branch (for branchMode="current" or resume) */
+  private checkoutBranch(slotPath: string, branch: string, events: SlotEvent[]): string {
+    try {
+      this.deps.execSync(`git fetch origin ${branch}`, {
+        cwd: slotPath,
+        stdio: "ignore",
+        timeout: 15000,
+      });
+    } catch {
+      /* non-fatal — branch may be local only */
+    }
+
+    try {
+      this.deps.execSync(`git checkout ${branch}`, {
+        cwd: slotPath,
+        stdio: "ignore",
+        timeout: 10000,
+      });
+      events.push({ type: "branch_checked_out", detail: branch });
+      return branch;
+    } catch {
+      events.push({ type: "warn", detail: `Could not checkout branch ${branch}` });
+      return this.getCurrentBranch(slotPath, events);
+    }
+  }
+
+  private getCurrentBranch(slotPath: string, events: SlotEvent[]): string {
+    try {
+      const current = (
+        this.deps.execSync("git rev-parse --abbrev-ref HEAD", {
+          cwd: slotPath,
+          encoding: "utf-8",
+          timeout: 3000,
+        }) as unknown as string
+      ).trim();
+      events.push({ type: "branch_fallback", detail: current });
+      return current;
+    } catch {
+      return "unknown";
+    }
+  }
+
+  /** Detect and run the appropriate package manager */
+  private installDeps(
+    slotPath: string,
+    events: SlotEvent[],
+  ): { installed: boolean; packageManager: string | null } {
+    for (const { file, manager, command } of LOCKFILES) {
+      if (this.deps.existsSync(join(slotPath, file))) {
+        return this.runInstall(slotPath, manager, command, events);
+      }
+    }
+
+    return { installed: false, packageManager: null };
+  }
+
+  private runInstall(
+    slotPath: string,
+    name: string,
+    command: string,
+    events: SlotEvent[],
+  ): { installed: boolean; packageManager: string } {
+    try {
+      this.deps.execSync(command, { cwd: slotPath, stdio: "ignore", timeout: 120000 });
+      events.push({ type: "deps_installed", detail: `${name}: ${command}` });
+      return { installed: true, packageManager: name };
+    } catch {
+      events.push({ type: "warn", detail: `${name} install failed — continuing anyway` });
+      return { installed: false, packageManager: name };
+    }
+  }
+}
+
+export const slotPreparer = new SlotPreparer();

--- a/plugins/tt-agentboard/server/domains/execution/workflow-orchestrator.ts
+++ b/plugins/tt-agentboard/server/domains/execution/workflow-orchestrator.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { execSync as defaultExecSync } from "node:child_process";
 import { tmuxManager as defaultTmuxManager } from "../infra/tmux-manager";
 import { slotAllocator as defaultSlotAllocator } from "./slot-allocator";
+import { slotPreparer as defaultSlotPreparer } from "./slot-preparer";
 import { workflowLoader as defaultWorkflowLoader } from "./workflow-loader";
 import { contextBundler as defaultContextBundler } from "./context-bundler";
 import type { WorkflowDefinition } from "./workflow-loader";
@@ -11,6 +12,7 @@ import { eventBus as defaultEventBus } from "../../shared/event-bus";
 import { logger as defaultLogger } from "../../utils/logger";
 import { cardService as defaultCardService } from "../cards/card-service";
 import type { CardService } from "../cards/card-service";
+import type { SlotPreparer } from "./slot-preparer";
 import { streamTailer as defaultStreamTailer } from "../infra/stream-tailer";
 import { stepExecutor as defaultStepExecutor, clearPendingCallback } from "./step-executor";
 import type { StepExecutor, WorkflowContext } from "./step-executor";
@@ -32,6 +34,7 @@ export interface WorkflowOrchestratorDeps {
     claimSlot: (repoId: number, cardId: number) => Promise<{ id: number; path: string } | null>;
     releaseSlot: (slotId: number) => Promise<void>;
   };
+  slotPreparer: SlotPreparer;
   workflowLoader: { get: (id: string) => WorkflowDefinition | undefined };
   contextBundler: { buildPrompt: (opts: unknown) => string };
   cardService: CardService;
@@ -50,6 +53,7 @@ export class WorkflowOrchestrator {
       logger: defaultLogger,
       tmuxManager: defaultTmuxManager,
       slotAllocator: defaultSlotAllocator,
+      slotPreparer: defaultSlotPreparer,
       workflowLoader: defaultWorkflowLoader,
       contextBundler: defaultContextBundler,
       cardService: defaultCardService,
@@ -66,11 +70,6 @@ export class WorkflowOrchestrator {
     if (!ctx) return;
 
     try {
-      // Create git branch (skip if branchMode is "current")
-      if (ctx.card.branchMode !== "current") {
-        this.createBranch(ctx);
-      }
-
       // Execute each step in sequence
       for (let i = 0; i < ctx.workflow.steps.length; i++) {
         const step = ctx.workflow.steps[i]!;
@@ -174,6 +173,24 @@ export class WorkflowOrchestrator {
     // Update card to running
     await this.deps.cardService.updateStatus(cardId, "running");
 
+    // Build branch name
+    const branch = renderTemplate(workflow.branch_template ?? "agentboard/card-{card_id}", {
+      card_id: String(cardId),
+      issue: String(card.githubIssueNumber ?? ""),
+      issue_title: card.title,
+    });
+
+    // Prepare the slot: sync git, set up branch, install deps
+    const prepResult = await this.deps.slotPreparer.prepare({
+      slotPath: slot.path,
+      branchMode: card.branchMode as "create" | "current",
+      branch,
+    });
+
+    for (const event of prepResult.events) {
+      await this.deps.cardService.logEvent(cardId, event.type, event.detail);
+    }
+
     // Create tmux session
     const { sessionName, created } = this.deps.tmuxManager.createSession(cardId, slot.path);
     if (created) {
@@ -189,12 +206,8 @@ export class WorkflowOrchestrator {
       this.deps.eventBus.emit("agent:output", { cardId, content: output });
     });
 
-    // Build branch name
-    const branch = renderTemplate(workflow.branch_template ?? "agentboard/card-{card_id}", {
-      card_id: String(cardId),
-      issue: String(card.githubIssueNumber ?? ""),
-      issue_title: card.title,
-    });
+    // Use the actual branch from prep (may differ if fallback occurred)
+    const actualBranch = prepResult.branch;
 
     // Create workflow run record
     const runRows = await this.deps.db
@@ -204,7 +217,7 @@ export class WorkflowOrchestrator {
         workflowId: card.workflowId,
         slotId: slot.id,
         tmuxSession: sessionName,
-        branch,
+        branch: actualBranch,
         startedAt: new Date(),
       })
       .returning();
@@ -218,30 +231,9 @@ export class WorkflowOrchestrator {
       slotId: slot.id,
       sessionName,
       workflowRunId: runRows[0]!.id,
-      branch,
+      branch: actualBranch,
       previousArtifacts: new Map(),
     };
-  }
-
-  /** Create a git branch in the slot directory */
-  private createBranch(ctx: WorkflowContext): void {
-    try {
-      this.deps.execSync(`git checkout -b ${ctx.branch}`, {
-        cwd: ctx.slotPath,
-        stdio: "ignore",
-      });
-      this.deps.logger.info(`Created branch ${ctx.branch} in ${ctx.slotPath}`);
-    } catch {
-      // Branch may already exist -- try checking it out
-      try {
-        this.deps.execSync(`git checkout ${ctx.branch}`, {
-          cwd: ctx.slotPath,
-          stdio: "ignore",
-        });
-      } catch (err) {
-        this.deps.logger.error(`Failed to create/checkout branch ${ctx.branch}:`, err);
-      }
-    }
   }
 
   /** Execute post-workflow steps (create PR, update labels) */

--- a/plugins/tt-agentboard/test/services/slot-preparer.test.ts
+++ b/plugins/tt-agentboard/test/services/slot-preparer.test.ts
@@ -24,9 +24,7 @@ describe("SlotPreparer", () => {
     it("syncs to main and installs deps", async () => {
       deps.existsSync.mockReturnValue(false);
       // pnpm-lock.yaml exists
-      deps.existsSync.mockImplementation((path: string) =>
-        path.endsWith("pnpm-lock.yaml"),
-      );
+      deps.existsSync.mockImplementation((path: string) => path.endsWith("pnpm-lock.yaml"));
 
       const result = await preparer.reset("/workspace/slot-1");
 
@@ -50,9 +48,7 @@ describe("SlotPreparer", () => {
         type: "main_synced",
         detail: "Checked out and pulled main",
       });
-      expect(result.events).toContainEqual(
-        expect.objectContaining({ type: "deps_installed" }),
-      );
+      expect(result.events).toContainEqual(expect.objectContaining({ type: "deps_installed" }));
     });
 
     it("handles git sync failure gracefully", async () => {
@@ -81,9 +77,7 @@ describe("SlotPreparer", () => {
     });
 
     it("detects uv.lock for Python projects", async () => {
-      deps.existsSync.mockImplementation((path: string) =>
-        path.endsWith("uv.lock"),
-      );
+      deps.existsSync.mockImplementation((path: string) => path.endsWith("uv.lock"));
 
       const result = await preparer.reset("/workspace/slot-1");
 
@@ -95,9 +89,7 @@ describe("SlotPreparer", () => {
     });
 
     it("detects bun.lock", async () => {
-      deps.existsSync.mockImplementation((path: string) =>
-        path.endsWith("bun.lock"),
-      );
+      deps.existsSync.mockImplementation((path: string) => path.endsWith("bun.lock"));
 
       const result = await preparer.reset("/workspace/slot-1");
 
@@ -109,9 +101,7 @@ describe("SlotPreparer", () => {
     });
 
     it("detects package-lock.json for npm", async () => {
-      deps.existsSync.mockImplementation((path: string) =>
-        path.endsWith("package-lock.json"),
-      );
+      deps.existsSync.mockImplementation((path: string) => path.endsWith("package-lock.json"));
 
       const result = await preparer.reset("/workspace/slot-1");
 
@@ -123,9 +113,7 @@ describe("SlotPreparer", () => {
     });
 
     it("detects requirements.txt for pip", async () => {
-      deps.existsSync.mockImplementation((path: string) =>
-        path.endsWith("requirements.txt"),
-      );
+      deps.existsSync.mockImplementation((path: string) => path.endsWith("requirements.txt"));
 
       const result = await preparer.reset("/workspace/slot-1");
 
@@ -237,9 +225,7 @@ describe("SlotPreparer", () => {
     });
 
     it("installs deps after branch setup", async () => {
-      deps.existsSync.mockImplementation((path: string) =>
-        path.endsWith("pnpm-lock.yaml"),
-      );
+      deps.existsSync.mockImplementation((path: string) => path.endsWith("pnpm-lock.yaml"));
 
       const result = await preparer.prepare({
         slotPath: "/workspace/slot-1",
@@ -252,9 +238,7 @@ describe("SlotPreparer", () => {
     });
 
     it("continues when install fails", async () => {
-      deps.existsSync.mockImplementation((path: string) =>
-        path.endsWith("pnpm-lock.yaml"),
-      );
+      deps.existsSync.mockImplementation((path: string) => path.endsWith("pnpm-lock.yaml"));
       deps.execSync.mockImplementation((cmd: string) => {
         if (typeof cmd === "string" && cmd.includes("pnpm install")) {
           throw new Error("install failed");
@@ -271,7 +255,10 @@ describe("SlotPreparer", () => {
       expect(result.depsInstalled).toBe(false);
       expect(result.packageManager).toBe("pnpm");
       expect(result.events).toContainEqual(
-        expect.objectContaining({ type: "warn", detail: expect.stringContaining("install failed") }),
+        expect.objectContaining({
+          type: "warn",
+          detail: expect.stringContaining("install failed"),
+        }),
       );
     });
   });

--- a/plugins/tt-agentboard/test/services/slot-preparer.test.ts
+++ b/plugins/tt-agentboard/test/services/slot-preparer.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SlotPreparer } from "../../server/domains/execution/slot-preparer";
+import { createMockLogger } from "../helpers/mock-deps";
+
+function createMockDeps() {
+  return {
+    logger: createMockLogger() as never,
+    execSync: vi.fn().mockReturnValue(Buffer.from("")),
+    existsSync: vi.fn().mockReturnValue(false),
+  };
+}
+
+describe("SlotPreparer", () => {
+  let preparer: SlotPreparer;
+  let deps: ReturnType<typeof createMockDeps>;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+    preparer = new SlotPreparer(deps);
+    vi.clearAllMocks();
+  });
+
+  describe("reset()", () => {
+    it("syncs to main and installs deps", async () => {
+      deps.existsSync.mockReturnValue(false);
+      // pnpm-lock.yaml exists
+      deps.existsSync.mockImplementation((path: string) =>
+        path.endsWith("pnpm-lock.yaml"),
+      );
+
+      const result = await preparer.reset("/workspace/slot-1");
+
+      // Should clean, checkout main, pull
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git checkout -- . && git clean -fd",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git checkout main && git pull --ff-only",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      // Should install deps
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "pnpm install --frozen-lockfile",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(result.depsInstalled).toBe(true);
+      expect(result.packageManager).toBe("pnpm");
+      expect(result.events).toContainEqual({
+        type: "main_synced",
+        detail: "Checked out and pulled main",
+      });
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: "deps_installed" }),
+      );
+    });
+
+    it("handles git sync failure gracefully", async () => {
+      deps.execSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("git checkout main")) {
+          throw new Error("not a git repo");
+        }
+        return Buffer.from("");
+      });
+
+      const result = await preparer.reset("/workspace/slot-1");
+
+      expect(result.events).toContainEqual({
+        type: "warn",
+        detail: "Could not checkout/pull main",
+      });
+    });
+
+    it("skips install when no lockfile found", async () => {
+      deps.existsSync.mockReturnValue(false);
+
+      const result = await preparer.reset("/workspace/slot-1");
+
+      expect(result.depsInstalled).toBe(false);
+      expect(result.packageManager).toBeNull();
+    });
+
+    it("detects uv.lock for Python projects", async () => {
+      deps.existsSync.mockImplementation((path: string) =>
+        path.endsWith("uv.lock"),
+      );
+
+      const result = await preparer.reset("/workspace/slot-1");
+
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "uv sync --frozen",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(result.packageManager).toBe("uv");
+    });
+
+    it("detects bun.lock", async () => {
+      deps.existsSync.mockImplementation((path: string) =>
+        path.endsWith("bun.lock"),
+      );
+
+      const result = await preparer.reset("/workspace/slot-1");
+
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "bun install --frozen-lockfile",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(result.packageManager).toBe("bun");
+    });
+
+    it("detects package-lock.json for npm", async () => {
+      deps.existsSync.mockImplementation((path: string) =>
+        path.endsWith("package-lock.json"),
+      );
+
+      const result = await preparer.reset("/workspace/slot-1");
+
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "npm ci",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(result.packageManager).toBe("npm");
+    });
+
+    it("detects requirements.txt for pip", async () => {
+      deps.existsSync.mockImplementation((path: string) =>
+        path.endsWith("requirements.txt"),
+      );
+
+      const result = await preparer.reset("/workspace/slot-1");
+
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "pip install -r requirements.txt",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(result.packageManager).toBe("pip");
+    });
+  });
+
+  describe("prepare()", () => {
+    it("syncs main and creates branch for branchMode=create", async () => {
+      const result = await preparer.prepare({
+        slotPath: "/workspace/slot-1",
+        branchMode: "create",
+        branch: "agentboard/card-42",
+      });
+
+      // Should clean + checkout main + pull
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git checkout -- . && git clean -fd",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git checkout main && git pull --ff-only",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      // Should create branch
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git checkout -b agentboard/card-42",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(result.branch).toBe("agentboard/card-42");
+      expect(result.events).toContainEqual({
+        type: "branch_created",
+        detail: "agentboard/card-42",
+      });
+    });
+
+    it("checks out existing branch for branchMode=current", async () => {
+      const result = await preparer.prepare({
+        slotPath: "/workspace/slot-1",
+        branchMode: "current",
+        branch: "feature/my-branch",
+      });
+
+      // Should NOT sync to main
+      expect(deps.execSync).not.toHaveBeenCalledWith(
+        "git checkout main && git pull --ff-only",
+        expect.anything(),
+      );
+      // Should fetch and checkout the branch
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git fetch origin feature/my-branch",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git checkout feature/my-branch",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(result.branch).toBe("feature/my-branch");
+    });
+
+    it("uses existingBranch when provided (resume case)", async () => {
+      const result = await preparer.prepare({
+        slotPath: "/workspace/slot-1",
+        branchMode: "create",
+        branch: "agentboard/card-42",
+        existingBranch: "agentboard/card-42-prev",
+      });
+
+      // Should checkout the existing branch, NOT sync to main
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git checkout agentboard/card-42-prev",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(deps.execSync).not.toHaveBeenCalledWith(
+        "git checkout main && git pull --ff-only",
+        expect.anything(),
+      );
+      expect(result.branch).toBe("agentboard/card-42-prev");
+    });
+
+    it("falls back to existing branch when create fails", async () => {
+      deps.execSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("checkout -b")) {
+          throw new Error("branch already exists");
+        }
+        return Buffer.from("");
+      });
+
+      const result = await preparer.prepare({
+        slotPath: "/workspace/slot-1",
+        branchMode: "create",
+        branch: "agentboard/card-42",
+      });
+
+      // Should try checkout -b, fail, then checkout existing
+      expect(deps.execSync).toHaveBeenCalledWith(
+        "git checkout agentboard/card-42",
+        expect.objectContaining({ cwd: "/workspace/slot-1" }),
+      );
+      expect(result.branch).toBe("agentboard/card-42");
+      expect(result.events).toContainEqual({
+        type: "branch_reused",
+        detail: "agentboard/card-42",
+      });
+    });
+
+    it("installs deps after branch setup", async () => {
+      deps.existsSync.mockImplementation((path: string) =>
+        path.endsWith("pnpm-lock.yaml"),
+      );
+
+      const result = await preparer.prepare({
+        slotPath: "/workspace/slot-1",
+        branchMode: "create",
+        branch: "agentboard/card-42",
+      });
+
+      expect(result.depsInstalled).toBe(true);
+      expect(result.packageManager).toBe("pnpm");
+    });
+
+    it("continues when install fails", async () => {
+      deps.existsSync.mockImplementation((path: string) =>
+        path.endsWith("pnpm-lock.yaml"),
+      );
+      deps.execSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("pnpm install")) {
+          throw new Error("install failed");
+        }
+        return Buffer.from("");
+      });
+
+      const result = await preparer.prepare({
+        slotPath: "/workspace/slot-1",
+        branchMode: "create",
+        branch: "agentboard/card-42",
+      });
+
+      expect(result.depsInstalled).toBe(false);
+      expect(result.packageManager).toBe("pnpm");
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: "warn", detail: expect.stringContaining("install failed") }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Extract git sync and dependency installation into a dedicated SlotPreparer
class that runs at both release and claim time, ensuring slots are always
ready for the next agent. On release, slots reset to main with deps
installed. On claim, slots re-sync (catching manual changes) then set up
the target branch. Supports pnpm, bun, npm, uv, and pip.

https://claude.ai/code/session_01XPQ5QbTyvJCNPUVyCG9X9c