### PR TITLE
fix: default to terminal tab and auto-scroll to bottom on new output

### DIFF
--- a/plugins/tt-agentboard/app/components/card/TerminalPanel.vue
+++ b/plugins/tt-agentboard/app/components/card/TerminalPanel.vue
@@ -67,6 +67,7 @@ async function fetchTerminal() {
       if (terminal.value) {
         terminal.value.reset();
         terminal.value.write(data.output);
+        terminal.value.scrollToBottom();
       }
     }
   } catch {

--- a/plugins/tt-agentboard/app/pages/cards/[id].vue
+++ b/plugins/tt-agentboard/app/pages/cards/[id].vue
@@ -7,7 +7,7 @@ const cardId = computed(() => Number(route.params.id));
 const { data: card, refresh } = await useFetch<Card>(`/api/cards/${cardId.value}`);
 
 const router = useRouter();
-const activeTab = ref<"terminal" | "diff" | "activity">("activity");
+const activeTab = ref<"terminal" | "diff" | "activity">("terminal");
 
 // Switch tab based on card status
 watch(


### PR DESCRIPTION
When selecting a card, the terminal tab is now shown by default instead of
activity. Terminal also scrolls to bottom after each output update so the
latest commands are always visible.

https://claude.ai/code/session_012uNE8R6hiXYtz9oooABsU3