### PR TITLE
Add interactive database reset with selective clearing options

### DIFF
--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -4,6 +4,8 @@ import { existsSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { networkInterfaces } from "node:os";
 import consola from "consola";
+import { colors } from "consola/utils";
+import prompts from "prompts";
 import { BaseCommand } from "./base.js";
 
 function getLocalIp(): string {
@@ -40,6 +42,14 @@ export default class Agentboard extends BaseCommand {
       description: "Attach to a running card tmux session",
       command: "<%= config.bin %> ag attach 42",
     },
+    {
+      description: "Selectively clear database (interactive)",
+      command: "<%= config.bin %> ag reset",
+    },
+    {
+      description: "Delete entire database without prompting",
+      command: "<%= config.bin %> ag reset --all",
+    },
   ];
 
   static override flags = {
@@ -60,6 +70,10 @@ export default class Agentboard extends BaseCommand {
     }),
     lan: Flags.boolean({
       description: "Listen on all interfaces (0.0.0.0) for LAN access. Default: localhost only.",
+      default: false,
+    }),
+    all: Flags.boolean({
+      description: "Reset entire database without prompting (for tt ag reset --all)",
       default: false,
     }),
   };
@@ -96,22 +110,18 @@ export default class Agentboard extends BaseCommand {
       );
       const dataDir = flags["data-dir"] ? resolve(flags["data-dir"]) : defaultDataDir;
       const dbPath = join(dataDir, "agentboard.db");
-      const walPath = `${dbPath}-wal`;
-      const shmPath = `${dbPath}-shm`;
 
       if (!existsSync(dbPath)) {
         consola.info("No database found — nothing to reset.");
         return;
       }
 
-      consola.warn(`This will delete: ${dbPath}`);
-      for (const f of [dbPath, walPath, shmPath]) {
-        if (existsSync(f)) {
-          const { unlinkSync } = await import("node:fs");
-          unlinkSync(f);
-        }
+      if (flags.all) {
+        await this.resetEntireDatabase(dbPath);
+        return;
       }
-      consola.success("Database reset. Start AgentBoard to create a fresh DB.");
+
+      await this.selectiveClear(dbPath);
       return;
     }
 
@@ -172,5 +182,152 @@ export default class Agentboard extends BaseCommand {
     }
 
     proc.on("exit", (code) => process.exit(code ?? 0));
+  }
+
+  private async resetEntireDatabase(dbPath: string): Promise<void> {
+    const walPath = `${dbPath}-wal`;
+    const shmPath = `${dbPath}-shm`;
+    consola.warn(`This will delete: ${dbPath}`);
+    const { unlinkSync } = await import("node:fs");
+    for (const f of [dbPath, walPath, shmPath]) {
+      if (existsSync(f)) {
+        unlinkSync(f);
+      }
+    }
+    consola.success("Database reset. Start AgentBoard to create a fresh DB.");
+  }
+
+  private async selectiveClear(dbPath: string): Promise<void> {
+    const { createRequire } = await import("node:module");
+    const require = createRequire(import.meta.url);
+    const Database = require("better-sqlite3");
+    const sqlite = new Database(dbPath) as {
+      pragma(stmt: string): void;
+      prepare(sql: string): {
+        get(): unknown;
+        run(): { changes: number };
+      };
+      close(): void;
+    };
+    sqlite.pragma("foreign_keys = ON");
+
+    const counts = {
+      doneCards: sqlite.prepare("SELECT COUNT(*) as c FROM cards WHERE column = 'done'").get() as {
+        c: number;
+      },
+      failedCards: sqlite
+        .prepare("SELECT COUNT(*) as c FROM cards WHERE status = 'failed'")
+        .get() as { c: number },
+      allCards: sqlite.prepare("SELECT COUNT(*) as c FROM cards").get() as { c: number },
+      workflowRuns: sqlite.prepare("SELECT COUNT(*) as c FROM workflow_runs").get() as {
+        c: number;
+      },
+      cardEvents: sqlite.prepare("SELECT COUNT(*) as c FROM card_events").get() as { c: number },
+      agentLogs: sqlite.prepare("SELECT COUNT(*) as c FROM agent_logs").get() as { c: number },
+    };
+
+    const choices = [
+      {
+        title: `Completed cards ${colors.dim(`(${counts.doneCards.c} cards in "done" column + events/runs)`)}`,
+        value: "done_cards",
+        disabled: counts.doneCards.c === 0,
+      },
+      {
+        title: `Failed cards ${colors.dim(`(${counts.failedCards.c} cards with "failed" status + events/runs)`)}`,
+        value: "failed_cards",
+        disabled: counts.failedCards.c === 0,
+      },
+      {
+        title: `Execution history ${colors.dim(`(${counts.workflowRuns.c} workflow runs, step runs, ${counts.agentLogs.c} agent logs)`)}`,
+        value: "execution_history",
+        disabled: counts.workflowRuns.c === 0,
+      },
+      {
+        title: `Event logs ${colors.dim(`(${counts.cardEvents.c} card events)`)}`,
+        value: "event_logs",
+        disabled: counts.cardEvents.c === 0,
+      },
+      {
+        title: `All cards ${colors.dim(`(${counts.allCards.c} cards — keeps repos, boards, slots)`)}`,
+        value: "all_cards",
+        disabled: counts.allCards.c === 0,
+      },
+      {
+        title: colors.red(`Everything (delete entire database)`),
+        value: "everything",
+      },
+    ];
+
+    const result = await prompts(
+      {
+        name: "selected",
+        message: "What would you like to clear?",
+        type: "multiselect",
+        choices,
+        instructions: false,
+        hint: "- Space to select, Enter to confirm",
+      },
+      {
+        onCancel: () => {
+          consola.info(colors.dim("Canceled"));
+          process.exit(0);
+        },
+      },
+    );
+
+    const selected: string[] = result.selected;
+    if (!selected || selected.length === 0) {
+      consola.info("Nothing selected.");
+      sqlite.close();
+      return;
+    }
+
+    if (selected.includes("everything")) {
+      sqlite.close();
+      await this.resetEntireDatabase(dbPath);
+      return;
+    }
+
+    let totalDeleted = 0;
+
+    if (selected.includes("done_cards")) {
+      // Cascade deletes handle events, dependencies, workflow_runs, step_runs, agent_logs
+      const deleted = sqlite.prepare("DELETE FROM cards WHERE column = 'done'").run();
+      consola.success(`Cleared ${deleted.changes} completed card(s)`);
+      totalDeleted += deleted.changes;
+    }
+
+    if (selected.includes("failed_cards")) {
+      const deleted = sqlite.prepare("DELETE FROM cards WHERE status = 'failed'").run();
+      consola.success(`Cleared ${deleted.changes} failed card(s)`);
+      totalDeleted += deleted.changes;
+    }
+
+    if (selected.includes("execution_history")) {
+      // agent_logs and step_runs cascade from workflow_runs
+      const deleted = sqlite.prepare("DELETE FROM workflow_runs").run();
+      consola.success(`Cleared ${deleted.changes} workflow run(s) and associated logs`);
+      totalDeleted += deleted.changes;
+    }
+
+    if (selected.includes("event_logs")) {
+      const deleted = sqlite.prepare("DELETE FROM card_events").run();
+      consola.success(`Cleared ${deleted.changes} event log(s)`);
+      totalDeleted += deleted.changes;
+    }
+
+    if (selected.includes("all_cards")) {
+      const deleted = sqlite.prepare("DELETE FROM cards").run();
+      consola.success(`Cleared ${deleted.changes} card(s)`);
+      totalDeleted += deleted.changes;
+    }
+
+    sqlite.close();
+
+    if (totalDeleted === 0) {
+      consola.info("Nothing to clear.");
+    } else {
+      consola.success("Done.");
+    }
   }
 }


### PR DESCRIPTION
## Summary
Enhanced the `ag reset` command to support both interactive selective clearing and non-interactive full database deletion. Users can now choose what data to clear from the database without losing everything.

## Key Changes
- **Interactive reset mode** (default): Prompts users to select what to clear:
  - Completed cards (in "done" column)
  - Failed cards (with "failed" status)
  - Execution history (workflow runs and agent logs)
  - Event logs (card events)
  - All cards (preserves repos, boards, slots)
  - Entire database

- **Non-interactive mode** (`--all` flag): Deletes entire database without prompting (useful for automation)

- **New dependencies**: Added `prompts` for interactive CLI prompts and imported `colors` from consola for better terminal output

- **Refactored reset logic**: Extracted database deletion into `resetEntireDatabase()` method for reuse

- **Smart deletion**: Leverages SQLite foreign key constraints for cascade deletes, ensuring data consistency

- **User feedback**: Shows counts of items to be deleted and confirmation messages for each operation

## Implementation Details
- The `selectiveClear()` method uses `better-sqlite3` to query database counts and perform targeted deletions
- Cascade deletes are enabled via `PRAGMA foreign_keys = ON` to maintain referential integrity
- The interactive prompt uses multiselect to allow clearing multiple categories at once
- Graceful handling of cancellation and empty selections

https://claude.ai/code/session_012XC5tQSLz7U6qKFzcrEQoq