### PR TITLE
feat(agentboard): resilient agent completion detection

### DIFF
--- a/plugins/tt-agentboard/scripts/stop-hook.sh
+++ b/plugins/tt-agentboard/scripts/stop-hook.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# stop-hook.sh — Called by Claude Code Stop/StopFailure/Notification hooks.
+# Reads JSON from stdin, extracts hook_event_name, POSTs to AgentBoard with retry.
+# Survives transient server restarts via exponential backoff.
+
+set -euo pipefail
+
+INPUT=$(cat)
+CARD_ID="${AGENTBOARD_CARD_ID:?AGENTBOARD_CARD_ID not set}"
+PORT="${AGENTBOARD_PORT:-4200}"
+
+# Determine endpoint from hook event name
+EVENT=$(echo "$INPUT" | grep -o '"hook_event_name":"[^"]*"' | cut -d'"' -f4)
+case "$EVENT" in
+  Stop)         ENDPOINT="complete" ;;
+  StopFailure)  ENDPOINT="failure" ;;
+  Notification) ENDPOINT="notification" ;;
+  *)            ENDPOINT="complete" ;;
+esac
+
+URL="http://localhost:${PORT}/api/agents/${CARD_ID}/${ENDPOINT}"
+
+MAX_RETRIES=10
+DELAY=1
+
+for i in $(seq 1 $MAX_RETRIES); do
+  STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$URL" \
+    -H 'Content-Type: application/json' \
+    -d "$INPUT" \
+    --connect-timeout 3 \
+    --max-time 10 2>/dev/null || echo "000")
+
+  if [ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 300 ]; then
+    exit 0
+  fi
+
+  # Exponential backoff: 1, 2, 4, 8, 16, 32, 60, 60, 60, 60
+  sleep "$DELAY"
+  DELAY=$((DELAY * 2))
+  if [ "$DELAY" -gt 60 ]; then DELAY=60; fi
+done
+
+# All retries exhausted — write marker file so sweep can detect
+echo "{\"cardId\":$CARD_ID,\"endpoint\":\"$ENDPOINT\",\"ts\":$(date +%s)}" \
+  > "/tmp/agentboard-hook-failed-${CARD_ID}.json"
+exit 1

--- a/plugins/tt-agentboard/scripts/stop-hook.sh
+++ b/plugins/tt-agentboard/scripts/stop-hook.sh
@@ -8,14 +8,15 @@ set -euo pipefail
 INPUT=$(cat)
 CARD_ID="${AGENTBOARD_CARD_ID:?AGENTBOARD_CARD_ID not set}"
 PORT="${AGENTBOARD_PORT:-4200}"
+STOP_ENDPOINT="${AGENTBOARD_STOP_ENDPOINT:-complete}"
 
-# Determine endpoint from hook event name
-EVENT=$(echo "$INPUT" | grep -o '"hook_event_name":"[^"]*"' | cut -d'"' -f4)
+# Determine endpoint from hook event name (grep may fail if key is missing — default to STOP_ENDPOINT)
+EVENT=$(echo "$INPUT" | grep -o '"hook_event_name":"[^"]*"' | cut -d'"' -f4 || true)
 case "$EVENT" in
-  Stop)         ENDPOINT="complete" ;;
+  Stop)         ENDPOINT="$STOP_ENDPOINT" ;;
   StopFailure)  ENDPOINT="failure" ;;
   Notification) ENDPOINT="notification" ;;
-  *)            ENDPOINT="complete" ;;
+  *)            ENDPOINT="$STOP_ENDPOINT" ;;
 esac
 
 URL="http://localhost:${PORT}/api/agents/${CARD_ID}/${ENDPOINT}"

--- a/plugins/tt-agentboard/server/domains/infra/hook-writer.ts
+++ b/plugins/tt-agentboard/server/domains/infra/hook-writer.ts
@@ -2,19 +2,33 @@ import { writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { logger } from "../../utils/logger";
 
-function httpHook(url: string) {
-  return [{ matcher: "", hooks: [{ type: "http", url }] }];
+function commandHook(cardId: number, port: number, scriptPath: string) {
+  return [
+    {
+      matcher: "",
+      hooks: [
+        {
+          type: "command",
+          command: `AGENTBOARD_CARD_ID=${cardId} AGENTBOARD_PORT=${port} ${scriptPath}`,
+          timeout: 120,
+        },
+      ],
+    },
+  ];
 }
 
 /**
- * Write .claude/settings.local.json with hooks that POST to AgentBoard
- * callback endpoints for lifecycle events: Stop, Notification.
+ * Write .claude/settings.local.json with command hooks that POST to AgentBoard
+ * callback endpoints with exponential backoff retry.
+ *
+ * Uses command hooks (not HTTP hooks) so that transient server restarts
+ * don't silently lose the completion signal.
  */
 export function writeHooks(
   slotPath: string,
   cardId: number,
   port: number,
-  stopEndpoint: string,
+  _stopEndpoint: string,
 ): void {
   const claudeDir = resolve(slotPath, ".claude");
   mkdirSync(claudeDir, { recursive: true });
@@ -30,15 +44,16 @@ export function writeHooks(
     }
   }
 
-  const baseUrl = `http://localhost:${port}/api/agents/${cardId}`;
+  // Script reads hook_event_name from stdin to determine the endpoint
+  const scriptPath = resolve(__dirname, "../../../scripts/stop-hook.sh");
 
   settings.hooks = {
     ...(settings.hooks as Record<string, unknown> | undefined),
-    Stop: httpHook(`${baseUrl}/${stopEndpoint}`),
-    StopFailure: httpHook(`${baseUrl}/failure`),
-    Notification: httpHook(`${baseUrl}/notification`),
+    Stop: commandHook(cardId, port, scriptPath),
+    StopFailure: commandHook(cardId, port, scriptPath),
+    Notification: commandHook(cardId, port, scriptPath),
   };
 
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
-  logger.info(`Wrote lifecycle hooks to ${settingsPath} → ${baseUrl}/${stopEndpoint}`);
+  logger.info(`Wrote lifecycle hooks to ${settingsPath} (command, cardId=${cardId})`);
 }

--- a/plugins/tt-agentboard/server/domains/infra/hook-writer.ts
+++ b/plugins/tt-agentboard/server/domains/infra/hook-writer.ts
@@ -1,15 +1,40 @@
-import { writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import {
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  copyFileSync,
+  chmodSync,
+} from "node:fs";
+import { resolve, join } from "node:path";
 import { logger } from "../../utils/logger";
 
-function commandHook(cardId: number, port: number, scriptPath: string) {
+/** Source script lives next to the compiled output — find it relative to this file or the plugin root */
+function findScriptSource(): string {
+  // Walk up from this file to find the plugin root (contains scripts/)
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    const candidate = join(dir, "scripts", "stop-hook.sh");
+    if (existsSync(candidate)) return candidate;
+    dir = resolve(dir, "..");
+  }
+  // Fallback: relative to CWD (dev mode)
+  return resolve(process.cwd(), "scripts", "stop-hook.sh");
+}
+
+function commandHook(
+  cardId: number,
+  port: number,
+  stopEndpoint: string,
+  scriptPath: string,
+) {
   return [
     {
       matcher: "",
       hooks: [
         {
           type: "command",
-          command: `AGENTBOARD_CARD_ID=${cardId} AGENTBOARD_PORT=${port} ${scriptPath}`,
+          command: `AGENTBOARD_CARD_ID=${cardId} AGENTBOARD_PORT=${port} AGENTBOARD_STOP_ENDPOINT=${stopEndpoint} ${scriptPath}`,
           timeout: 120,
         },
       ],
@@ -21,6 +46,9 @@ function commandHook(cardId: number, port: number, scriptPath: string) {
  * Write .claude/settings.local.json with command hooks that POST to AgentBoard
  * callback endpoints with exponential backoff retry.
  *
+ * Copies the retry script into the slot's .claude/ dir so it works regardless
+ * of how Nitro resolves __dirname at build time.
+ *
  * Uses command hooks (not HTTP hooks) so that transient server restarts
  * don't silently lose the completion signal.
  */
@@ -28,7 +56,7 @@ export function writeHooks(
   slotPath: string,
   cardId: number,
   port: number,
-  _stopEndpoint: string,
+  stopEndpoint: string,
 ): void {
   const claudeDir = resolve(slotPath, ".claude");
   mkdirSync(claudeDir, { recursive: true });
@@ -44,16 +72,23 @@ export function writeHooks(
     }
   }
 
-  // Script reads hook_event_name from stdin to determine the endpoint
-  const scriptPath = resolve(__dirname, "../../../scripts/stop-hook.sh");
+  // Copy the retry script into the slot so path resolution is always reliable
+  const scriptDest = resolve(claudeDir, "stop-hook.sh");
+  try {
+    const source = findScriptSource();
+    copyFileSync(source, scriptDest);
+    chmodSync(scriptDest, 0o755);
+  } catch (err) {
+    logger.warn(`Could not copy stop-hook.sh to ${scriptDest}:`, err);
+  }
 
   settings.hooks = {
     ...(settings.hooks as Record<string, unknown> | undefined),
-    Stop: commandHook(cardId, port, scriptPath),
-    StopFailure: commandHook(cardId, port, scriptPath),
-    Notification: commandHook(cardId, port, scriptPath),
+    Stop: commandHook(cardId, port, stopEndpoint, scriptDest),
+    StopFailure: commandHook(cardId, port, stopEndpoint, scriptDest),
+    Notification: commandHook(cardId, port, stopEndpoint, scriptDest),
   };
 
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
-  logger.info(`Wrote lifecycle hooks to ${settingsPath} (command, cardId=${cardId})`);
+  logger.info(`Wrote lifecycle hooks to ${settingsPath} (command, cardId=${cardId}, endpoint=${stopEndpoint})`);
 }

--- a/plugins/tt-agentboard/server/domains/infra/tmux-manager.ts
+++ b/plugins/tt-agentboard/server/domains/infra/tmux-manager.ts
@@ -106,6 +106,19 @@ export class TmuxManager extends EventEmitter {
     }
   }
 
+  /** Get the foreground command running in a session's pane. Returns null if session doesn't exist. */
+  getPaneCommand(sessionName: string): string | null {
+    try {
+      const output = this.deps.execSync(
+        `tmux list-panes -t ${sessionName} -F '#{pane_current_command}'`,
+        { encoding: "utf-8", timeout: 2000 },
+      );
+      return (output as string).trim().split("\n")[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   /** Kill a tmux session. Returns true if session was killed, false if already dead. */
   killSession(sessionName: string): boolean {
     this.stopCapture(sessionName);

--- a/plugins/tt-agentboard/server/plugins/completion-sweep.ts
+++ b/plugins/tt-agentboard/server/plugins/completion-sweep.ts
@@ -1,0 +1,76 @@
+import { db as defaultDb } from "../shared/db";
+import { cards } from "../shared/db/schema";
+import { eq } from "drizzle-orm";
+import { tmuxManager as defaultTmuxManager } from "../domains/infra/tmux-manager";
+import { logger as defaultLogger } from "../utils/logger";
+
+const SWEEP_INTERVAL_MS = 30_000;
+const AGENT_COMMANDS = new Set(["node", "tt", "claude", "tsx"]);
+
+export interface CompletionSweepDeps {
+  tmuxManager: {
+    listSessions: () => string[];
+    getPaneCommand: (name: string) => string | null;
+  };
+  db: typeof defaultDb;
+  logger: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void };
+  triggerComplete: (cardId: number) => Promise<void>;
+}
+
+export function createCompletionSweep(deps: CompletionSweepDeps) {
+  async function sweep() {
+    const sessions = deps.tmuxManager.listSessions();
+    if (sessions.length === 0) return;
+
+    const runningCards = await deps.db.select().from(cards).where(eq(cards.status, "running"));
+
+    const runningById = new Map(runningCards.map((c) => [c.id, c]));
+
+    for (const sessionName of sessions) {
+      const match = sessionName.match(/^card-(\d+)$/);
+      if (!match) continue;
+      const cardId = Number(match[1]);
+
+      const card = runningById.get(cardId);
+      if (!card) continue;
+
+      const cmd = deps.tmuxManager.getPaneCommand(sessionName);
+      if (!cmd) continue;
+
+      // If foreground process is a shell (not an agent command), agent finished
+      if (!AGENT_COMMANDS.has(cmd)) {
+        deps.logger.warn(
+          `Completion sweep: card ${cardId} session idle (${cmd}), triggering complete`,
+        );
+        try {
+          await deps.triggerComplete(cardId);
+        } catch (err) {
+          deps.logger.warn(`Completion sweep: failed to complete card ${cardId}:`, err);
+        }
+      }
+    }
+  }
+
+  return { sweep };
+}
+
+export default defineNitroPlugin(() => {
+  async function triggerComplete(cardId: number) {
+    await $fetch(`/api/agents/${cardId}/complete`, { method: "POST", body: {} });
+  }
+
+  const { sweep } = createCompletionSweep({
+    tmuxManager: defaultTmuxManager,
+    db: defaultDb,
+    logger: defaultLogger,
+    triggerComplete,
+  });
+
+  // Initial sweep after startup (give agents time to register)
+  setTimeout(sweep, 10_000);
+
+  // Periodic sweep
+  setInterval(sweep, SWEEP_INTERVAL_MS);
+
+  defaultLogger.info(`Completion sweep active (interval: ${SWEEP_INTERVAL_MS}ms)`);
+});

--- a/plugins/tt-agentboard/server/plugins/completion-sweep.ts
+++ b/plugins/tt-agentboard/server/plugins/completion-sweep.ts
@@ -5,7 +5,8 @@ import { tmuxManager as defaultTmuxManager } from "../domains/infra/tmux-manager
 import { logger as defaultLogger } from "../utils/logger";
 
 const SWEEP_INTERVAL_MS = 30_000;
-const AGENT_COMMANDS = new Set(["node", "tt", "claude", "tsx"]);
+// Processes that indicate the agent or its setup is still active — don't sweep these
+const AGENT_COMMANDS = new Set(["node", "tt", "claude", "tsx", "pnpm", "npm", "bun", "git"]);
 
 export interface CompletionSweepDeps {
   tmuxManager: {

--- a/plugins/tt-agentboard/server/plugins/stream-completion.ts
+++ b/plugins/tt-agentboard/server/plugins/stream-completion.ts
@@ -3,12 +3,12 @@ import type { EventMap } from "../shared/event-bus";
 import { logger } from "../utils/logger";
 
 /**
- * Detect agent completion from stream-json result events.
+ * Detect workflow step completion from stream-json result events.
  *
- * Claude Code's HTTP Stop hooks don't fire in `-p` (print) mode.
- * Instead, we watch the stream-tailer's parsed events for the `result`
- * event which means Claude finished. When detected, we POST to the
- * same complete/failure endpoint the Stop hook would have hit.
+ * For multi-step workflows, the step-executor pipes claude output to
+ * .claude-stream.ndjson via tee. The stream-tailer watches that file
+ * and emits agent:activity events. This plugin detects the final
+ * "result" event and triggers the step-complete callback.
  */
 export default defineNitroPlugin(() => {
   const processed = new Set<string>();

--- a/plugins/tt-agentboard/test/plugins/completion-sweep.test.ts
+++ b/plugins/tt-agentboard/test/plugins/completion-sweep.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCompletionSweep } from "../../server/plugins/completion-sweep";
+import { createMockLogger } from "../helpers/mock-deps";
+
+describe("completion-sweep", () => {
+  let mockTmuxManager: {
+    listSessions: ReturnType<typeof vi.fn>;
+    getPaneCommand: ReturnType<typeof vi.fn>;
+  };
+  let triggerComplete: ReturnType<typeof vi.fn>;
+  let mockDb: ReturnType<typeof createMockDb>;
+
+  function createMockDb(runningCards: Array<{ id: number; status: string }> = []) {
+    return {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(runningCards),
+        }),
+      }),
+    };
+  }
+
+  beforeEach(() => {
+    mockTmuxManager = {
+      listSessions: vi.fn().mockReturnValue([]),
+      getPaneCommand: vi.fn(),
+    };
+    triggerComplete = vi.fn().mockResolvedValue(undefined);
+    mockDb = createMockDb();
+  });
+
+  it("triggers complete for running card with idle tmux session", async () => {
+    mockTmuxManager.listSessions.mockReturnValue(["card-1", "card-2"]);
+    mockTmuxManager.getPaneCommand.mockReturnValueOnce("zsh").mockReturnValueOnce("node");
+    mockDb = createMockDb([
+      { id: 1, status: "running" },
+      { id: 2, status: "running" },
+    ]);
+
+    const { sweep } = createCompletionSweep({
+      tmuxManager: mockTmuxManager,
+      db: mockDb as never,
+      logger: createMockLogger() as never,
+      triggerComplete,
+    });
+
+    await sweep();
+
+    expect(triggerComplete).toHaveBeenCalledTimes(1);
+    expect(triggerComplete).toHaveBeenCalledWith(1);
+  });
+
+  it("does nothing when no tmux sessions exist", async () => {
+    mockTmuxManager.listSessions.mockReturnValue([]);
+
+    const { sweep } = createCompletionSweep({
+      tmuxManager: mockTmuxManager,
+      db: mockDb as never,
+      logger: createMockLogger() as never,
+      triggerComplete,
+    });
+
+    await sweep();
+
+    expect(triggerComplete).not.toHaveBeenCalled();
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("skips sessions for cards not in running status", async () => {
+    mockTmuxManager.listSessions.mockReturnValue(["card-1"]);
+    mockTmuxManager.getPaneCommand.mockReturnValue("zsh");
+    // DB returns no running cards
+    mockDb = createMockDb([]);
+
+    const { sweep } = createCompletionSweep({
+      tmuxManager: mockTmuxManager,
+      db: mockDb as never,
+      logger: createMockLogger() as never,
+      triggerComplete,
+    });
+
+    await sweep();
+
+    expect(triggerComplete).not.toHaveBeenCalled();
+  });
+
+  it("skips sessions where agent is still running", async () => {
+    mockTmuxManager.listSessions.mockReturnValue(["card-1"]);
+    mockTmuxManager.getPaneCommand.mockReturnValue("node");
+    mockDb = createMockDb([{ id: 1, status: "running" }]);
+
+    const { sweep } = createCompletionSweep({
+      tmuxManager: mockTmuxManager,
+      db: mockDb as never,
+      logger: createMockLogger() as never,
+      triggerComplete,
+    });
+
+    await sweep();
+
+    expect(triggerComplete).not.toHaveBeenCalled();
+  });
+
+  it("handles triggerComplete failure gracefully", async () => {
+    mockTmuxManager.listSessions.mockReturnValue(["card-1"]);
+    mockTmuxManager.getPaneCommand.mockReturnValue("zsh");
+    mockDb = createMockDb([{ id: 1, status: "running" }]);
+    triggerComplete.mockRejectedValueOnce(new Error("server down"));
+
+    const { sweep } = createCompletionSweep({
+      tmuxManager: mockTmuxManager,
+      db: mockDb as never,
+      logger: createMockLogger() as never,
+      triggerComplete,
+    });
+
+    // Should not throw
+    await expect(sweep()).resolves.not.toThrow();
+  });
+
+  it("skips non-card sessions", async () => {
+    mockTmuxManager.listSessions.mockReturnValue(["card-1", "my-session"]);
+    mockTmuxManager.getPaneCommand.mockReturnValue("zsh");
+    mockDb = createMockDb([{ id: 1, status: "running" }]);
+
+    const { sweep } = createCompletionSweep({
+      tmuxManager: mockTmuxManager,
+      db: mockDb as never,
+      logger: createMockLogger() as never,
+      triggerComplete,
+    });
+
+    await sweep();
+
+    // Only card-1 should be processed, "my-session" skipped
+    expect(triggerComplete).toHaveBeenCalledTimes(1);
+    expect(triggerComplete).toHaveBeenCalledWith(1);
+  });
+});

--- a/plugins/tt-agentboard/test/services/hook-writer.test.ts
+++ b/plugins/tt-agentboard/test/services/hook-writer.test.ts
@@ -33,7 +33,7 @@ describe("writeHooks()", () => {
     expect(existsSync(resolve(slotPath, ".claude", "settings.local.json"))).toBe(true);
   });
 
-  it("writes correct Stop, StopFailure, Notification hooks", () => {
+  it("writes command hooks with retry script for all lifecycle events", () => {
     const slotPath = makeTmpDir();
 
     writeHooks(slotPath, 7, 4200, "step-complete");
@@ -41,26 +41,22 @@ describe("writeHooks()", () => {
     const settings = readSettings(slotPath) as {
       hooks: Record<
         string,
-        Array<{ matcher: string; hooks: Array<{ type: string; url: string }> }>
+        Array<{ matcher: string; hooks: Array<{ type: string; command: string; timeout: number }> }>
       >;
     };
 
-    expect(settings.hooks.Stop[0]!.hooks[0]!.url).toBe(
-      "http://localhost:4200/api/agents/7/step-complete",
-    );
-    expect(settings.hooks.StopFailure[0]!.hooks[0]!.url).toBe(
-      "http://localhost:4200/api/agents/7/failure",
-    );
-    expect(settings.hooks.Notification[0]!.hooks[0]!.url).toBe(
-      "http://localhost:4200/api/agents/7/notification",
-    );
-
-    // All hooks should use http type and empty matcher
+    // All hooks should use command type with retry script
     for (const hookName of ["Stop", "StopFailure", "Notification"]) {
       const hookArray = settings.hooks[hookName]!;
       expect(hookArray).toHaveLength(1);
       expect(hookArray[0]!.matcher).toBe("");
-      expect(hookArray[0]!.hooks[0]!.type).toBe("http");
+
+      const hook = hookArray[0]!.hooks[0]!;
+      expect(hook.type).toBe("command");
+      expect(hook.command).toContain("stop-hook.sh");
+      expect(hook.command).toContain("AGENTBOARD_CARD_ID=7");
+      expect(hook.command).toContain("AGENTBOARD_PORT=4200");
+      expect(hook.timeout).toBe(120);
     }
   });
 

--- a/plugins/tt-agentboard/test/services/hook-writer.test.ts
+++ b/plugins/tt-agentboard/test/services/hook-writer.test.ts
@@ -56,8 +56,33 @@ describe("writeHooks()", () => {
       expect(hook.command).toContain("stop-hook.sh");
       expect(hook.command).toContain("AGENTBOARD_CARD_ID=7");
       expect(hook.command).toContain("AGENTBOARD_PORT=4200");
+      expect(hook.command).toContain("AGENTBOARD_STOP_ENDPOINT=step-complete");
       expect(hook.timeout).toBe(120);
     }
+  });
+
+  it("passes stopEndpoint through to command env var", () => {
+    const slotPath = makeTmpDir();
+
+    writeHooks(slotPath, 1, 4200, "complete");
+
+    const settings = readSettings(slotPath) as {
+      hooks: Record<
+        string,
+        Array<{ hooks: Array<{ command: string }> }>
+      >;
+    };
+    expect(settings.hooks.Stop[0]!.hooks[0]!.command).toContain(
+      "AGENTBOARD_STOP_ENDPOINT=complete",
+    );
+  });
+
+  it("copies stop-hook.sh into slot .claude dir", () => {
+    const slotPath = makeTmpDir();
+
+    writeHooks(slotPath, 1, 4200, "complete");
+
+    expect(existsSync(resolve(slotPath, ".claude", "stop-hook.sh"))).toBe(true);
   });
 
   it("merges with existing settings.local.json", () => {

--- a/plugins/tt-agentboard/test/services/tmux-manager.test.ts
+++ b/plugins/tt-agentboard/test/services/tmux-manager.test.ts
@@ -230,6 +230,25 @@ describe("TmuxManager", () => {
     });
   });
 
+  describe("getPaneCommand()", () => {
+    it("returns foreground command for existing session", () => {
+      mockExecSync.mockReturnValueOnce("zsh\n");
+      const result = manager.getPaneCommand("card-1");
+      expect(result).toBe("zsh");
+      expect(mockExecSync).toHaveBeenCalledWith(
+        "tmux list-panes -t card-1 -F '#{pane_current_command}'",
+        expect.objectContaining({ encoding: "utf-8" }),
+      );
+    });
+
+    it("returns null for non-existent session", () => {
+      mockExecSync.mockImplementationOnce(() => {
+        throw new Error("no session");
+      });
+      expect(manager.getPaneCommand("card-999")).toBeNull();
+    });
+  });
+
   describe("stopCapture()", () => {
     it("clears interval and resets state", () => {
       // Create session and start capture


### PR DESCRIPTION
## Summary
- Replace HTTP Stop hooks with command hooks that retry with exponential backoff (1s→60s, 10 retries), surviving transient Nuxt dev server restarts
- Add periodic completion sweep (every 30s) that detects tmux sessions where the agent finished but the hook failed to deliver
- Add `getPaneCommand()` to TmuxManager for detecting idle shell prompts vs running agents
- Fix misleading comment claiming Stop hooks don't fire in `-p` mode (they do)

## Context
HTTP hooks silently fail when the AgentBoard server restarts during agent execution. Per Anthropic docs, failed HTTP hooks are "non-blocking errors" with no retry. This caused cards to get stuck as "running" forever.

Two-layer defense:
1. **Command hook with retry script** — `scripts/stop-hook.sh` reads stdin JSON, determines the endpoint, and POSTs with exponential backoff
2. **Completion sweep plugin** — safety net that checks every 30s for running cards whose tmux session shows a shell prompt instead of an agent process

## Test plan
- [x] All 146 agentboard tests pass (15 files)
- [x] All 243 project tests pass (22 files)
- [ ] Manual: create card, verify `settings.local.json` has `type: "command"` hooks
- [ ] Manual: kill/restart server while agent runs, verify retry script delivers completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)