### PR TITLE
feat: add tsx to doctor command dependency checks

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -34,6 +34,7 @@ export default class Doctor extends BaseCommand {
       this.checkCommand("node", ["--version"], /v?([\d.]+)/),
       this.checkCommand("bun", ["--version"], /([\d.]+)/),
       this.checkCommand("pnpm", ["--version"], /([\d.]+)/),
+      this.checkCommand("tsx", ["--version"], /([\d.]+)/),
       this.checkCommand("claude", ["--version"], /([\d.]+)/),
       this.checkCommand("tmux", ["-V"], /tmux ([\d.]+)/),
       this.checkCommand("ttyd", ["--version"], /ttyd version ([\d.]+)/, true),


### PR DESCRIPTION
## Summary

- Adds `tsx` to the `tt doctor` dependency checks, since `tsx` is used to run the CLI itself (`pnpm start` uses `tsx ./bin/run.ts`)

Closes #80