### PR TITLE
feat(agentboard): add simplify_review column

### DIFF
--- a/plugins/tt-agentboard/app/components/board/KanbanColumn.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanColumn.vue
@@ -20,6 +20,7 @@ const columnClasses: Record<Column, string> = {
   backlog: "border-t-zinc-600",
   ready: "border-t-cyan-500",
   in_progress: "border-t-blue-500",
+  simplify_review: "border-t-purple-500",
   review: "border-t-violet-500",
   done: "border-t-emerald-500",
 };

--- a/plugins/tt-agentboard/app/stores/cards.ts
+++ b/plugins/tt-agentboard/app/stores/cards.ts
@@ -47,6 +47,7 @@ export const useCardStore = defineStore("cards", () => {
       backlog: [],
       ready: [],
       in_progress: [],
+      simplify_review: [],
       review: [],
       done: [],
     };

--- a/plugins/tt-agentboard/app/utils/constants.ts
+++ b/plugins/tt-agentboard/app/utils/constants.ts
@@ -1,4 +1,11 @@
-export const COLUMNS = ["backlog", "ready", "in_progress", "simplify_review", "review", "done"] as const;
+export const COLUMNS = [
+  "backlog",
+  "ready",
+  "in_progress",
+  "simplify_review",
+  "review",
+  "done",
+] as const;
 export type Column = (typeof COLUMNS)[number];
 
 export const COLUMN_LABELS: Record<Column, string> = {

--- a/plugins/tt-agentboard/app/utils/constants.ts
+++ b/plugins/tt-agentboard/app/utils/constants.ts
@@ -1,10 +1,11 @@
-export const COLUMNS = ["backlog", "ready", "in_progress", "review", "done"] as const;
+export const COLUMNS = ["backlog", "ready", "in_progress", "simplify_review", "review", "done"] as const;
 export type Column = (typeof COLUMNS)[number];
 
 export const COLUMN_LABELS: Record<Column, string> = {
   backlog: "Backlog",
   ready: "Ready",
   in_progress: "In Progress",
+  simplify_review: "Simplify + Review",
   review: "Review",
   done: "Done",
 };
@@ -13,6 +14,7 @@ export const COLUMN_ICONS: Record<Column, string> = {
   backlog: "◇",
   ready: "◆",
   in_progress: "▶",
+  simplify_review: "⟳",
   review: "◉",
   done: "✓",
 };

--- a/plugins/tt-agentboard/server/api/cards/[id]/move.post.ts
+++ b/plugins/tt-agentboard/server/api/cards/[id]/move.post.ts
@@ -34,6 +34,35 @@ export default defineEventHandler(async (event) => {
 
   await cardService.logEvent(id, "card_moved", `${fromColumn} → ${body.column}`);
 
+  // If moved to simplify_review, override to simplify-review workflow on current branch
+  if (body.column === "simplify_review") {
+    await db
+      .update(cards)
+      .set({ workflowId: "simplify-review", branchMode: "current", updatedAt: new Date() })
+      .where(eq(cards.id, id));
+
+    // Release any stale slots from a previous run
+    const staleSlots = await db
+      .select()
+      .from(workspaceSlots)
+      .where(eq(workspaceSlots.claimedByCardId, id));
+    for (const slot of staleSlots) {
+      await db
+        .update(workspaceSlots)
+        .set({ status: "available", claimedByCardId: null })
+        .where(eq(workspaceSlots.id, slot.id));
+      eventBus.emit("slot:released", { slotId: slot.id });
+    }
+
+    const sessionName = `card-${id}`;
+    tmuxManager.stopCapture(sessionName);
+    tmuxManager.killSession(sessionName);
+
+    agentExecutor.startExecution(id).catch(() => {
+      cardService.updateStatus(id, "failed");
+    });
+  }
+
   // If moved to in_progress, clean up stale resources first, then trigger agent
   if (body.column === "in_progress") {
     // Release any stale slots from a previous run

--- a/plugins/tt-agentboard/server/domains/cards/card-service.ts
+++ b/plugins/tt-agentboard/server/domains/cards/card-service.ts
@@ -63,6 +63,12 @@ export class CardService {
 
   /** Mark card complete: status=review_ready, column=review */
   async markComplete(cardId: number): Promise<void> {
+    const rows = await this.deps.db
+      .select({ column: cards.column })
+      .from(cards)
+      .where(eq(cards.id, cardId));
+    const fromColumn = (rows[0]?.column ?? "in_progress") as Column;
+
     await this.deps.db
       .update(cards)
       .set({ status: "review_ready", column: "review", updatedAt: new Date() })
@@ -74,7 +80,7 @@ export class CardService {
     });
     this.deps.eventBus.emit("card:moved", {
       cardId,
-      fromColumn: "in_progress" as Column,
+      fromColumn,
       toColumn: "review" as Column,
     });
   }

--- a/plugins/tt-agentboard/server/domains/cards/schema.ts
+++ b/plugins/tt-agentboard/server/domains/cards/schema.ts
@@ -37,9 +37,9 @@ export const cards = sqliteTable("cards", {
   title: text("title").notNull(),
   description: text("description"),
   repoId: integer("repo_id").references(() => repositories.id, { onDelete: "set null" }),
-  column: text("column", { enum: ["backlog", "ready", "in_progress", "review", "done"] }).default(
-    "backlog",
-  ),
+  column: text("column", {
+    enum: ["backlog", "ready", "in_progress", "simplify_review", "review", "done"],
+  }).default("backlog"),
   position: integer("position").notNull().default(0),
   executionMode: text("execution_mode", { enum: ["headless", "interactive"] }).default("headless"),
   branchMode: text("branch_mode", { enum: ["create", "current"] }).default("create"),

--- a/plugins/tt-agentboard/server/domains/cards/types.ts
+++ b/plugins/tt-agentboard/server/domains/cards/types.ts
@@ -1,4 +1,4 @@
-export type Column = "backlog" | "ready" | "in_progress" | "review" | "done";
+export type Column = "backlog" | "ready" | "in_progress" | "simplify_review" | "review" | "done";
 export type CardStatus =
   | "idle"
   | "queued"

--- a/plugins/tt-agentboard/templates/workflows/simplify-review.yaml
+++ b/plugins/tt-agentboard/templates/workflows/simplify-review.yaml
@@ -1,0 +1,15 @@
+name: simplify-review
+description: Run simplify and review steps on the current branch (skips plan and implement)
+steps:
+  - id: simplify
+    prompt_template: .agentboard/prompts/simplify.md
+    artifact: .auto-claude/issue-{issue}/simplify-summary.md
+  - id: review
+    prompt_template: .agentboard/prompts/review.md
+    artifact: .auto-claude/issue-{issue}/review.md
+    pass_condition: "first_line_equals:PASS"
+    on_fail: "goto:simplify"
+    max_retries: 2
+post_steps:
+  create_pr: false
+artifact_dir: ".auto-claude/issue-{issue}"

--- a/plugins/tt-agentboard/test/domains/cards/card-service.test.ts
+++ b/plugins/tt-agentboard/test/domains/cards/card-service.test.ts
@@ -112,7 +112,12 @@ describe("CardService", () => {
   });
 
   describe("markComplete()", () => {
-    it("sets status=review_ready + column=review in a single update", async () => {
+    it("sets status=review_ready + column=review, emits actual fromColumn", async () => {
+      const selectChain: Record<string, unknown> = {};
+      selectChain.from = vi.fn().mockReturnValue(selectChain);
+      selectChain.where = vi.fn().mockResolvedValue([{ column: "in_progress" }]);
+      mockDb.select = vi.fn().mockReturnValue(selectChain);
+
       const updateChain: Record<string, unknown> = {};
       updateChain.set = vi.fn().mockReturnValue(updateChain);
       updateChain.where = vi.fn().mockResolvedValue(undefined);
@@ -128,6 +133,26 @@ describe("CardService", () => {
       expect(mockEventBus.emit).toHaveBeenCalledWith("card:moved", {
         cardId: 1,
         fromColumn: "in_progress",
+        toColumn: "review",
+      });
+    });
+
+    it("emits simplify_review as fromColumn when card was in that column", async () => {
+      const selectChain: Record<string, unknown> = {};
+      selectChain.from = vi.fn().mockReturnValue(selectChain);
+      selectChain.where = vi.fn().mockResolvedValue([{ column: "simplify_review" }]);
+      mockDb.select = vi.fn().mockReturnValue(selectChain);
+
+      const updateChain: Record<string, unknown> = {};
+      updateChain.set = vi.fn().mockReturnValue(updateChain);
+      updateChain.where = vi.fn().mockResolvedValue(undefined);
+      mockDb.update = vi.fn().mockReturnValue(updateChain);
+
+      await service.markComplete(1);
+
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:moved", {
+        cardId: 1,
+        fromColumn: "simplify_review",
         toColumn: "review",
       });
     });


### PR DESCRIPTION
## Summary
- Adds a new "Simplify + Review" column between In Progress and Review on the AgentBoard
- Cards moved to this column trigger only the simplify and review workflow steps on the current branch, skipping plan and implement
- On completion, cards automatically move to the Review column as review_ready
- Includes new `simplify-review.yaml` workflow template and updated `markComplete` to use actual fromColumn instead of hardcoded `in_progress`

## Test plan
- [x] All agentboard unit tests pass
- [x] All root tests pass
- [x] Lint and typecheck pass
- [ ] Manual: drag card to Simplify + Review column, verify agent starts with simplify-review workflow
- [ ] Manual: verify card moves to Review column on workflow completion

Closes #148