### PR TITLE
feat(agentboard): add Zod form validation

### DIFF
--- a/plugins/tt-agentboard/server/domains/execution/agent-executor.ts
+++ b/plugins/tt-agentboard/server/domains/execution/agent-executor.ts
@@ -9,7 +9,7 @@ import { workflowOrchestrator as defaultWorkflowOrchestrator } from "./workflow-
 import { eventBus as defaultEventBus } from "../../shared/event-bus";
 import { logger as defaultLogger } from "../../utils/logger";
 import { writeHooks as defaultWriteHooks } from "../infra/hook-writer";
-import { shellEscape } from "./workflow-helpers";
+import { buildAgentBranchName, shellEscape } from "./workflow-helpers";
 import { cardService as defaultCardService } from "../cards/card-service";
 import type { CardService } from "../cards/card-service";
 import type { SlotPreparer } from "./slot-preparer";
@@ -172,7 +172,7 @@ export class AgentExecutor {
     const existingBranch = previousRuns.find((r) => r.branch)?.branch ?? null;
 
     // Prepare the slot: sync git, set up branch, install deps
-    const branchName = `agentboard/card-${cardId}`;
+    const branchName = buildAgentBranchName(cardId, card.title);
     const prepResult = await this.deps.slotPreparer.prepare({
       slotPath: slot.path,
       branchMode: card.branchMode as "create" | "current",

--- a/plugins/tt-agentboard/server/domains/execution/workflow-helpers.ts
+++ b/plugins/tt-agentboard/server/domains/execution/workflow-helpers.ts
@@ -26,6 +26,18 @@ export function renderTemplate(template: string, vars: Record<string, string>): 
   return result;
 }
 
+/** Build an agentboard branch name from card ID and title */
+export function buildAgentBranchName(cardId: number, title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50)
+    .replace(/-$/, "");
+
+  return slug ? `agentboard/${cardId}-${slug}` : `agentboard/card-${cardId}`;
+}
+
 /** Escape a string for safe use in shell commands */
 export function shellEscape(str: string): string {
   return `'${str.replace(/'/g, "'\\''")}'`;

--- a/plugins/tt-agentboard/server/domains/execution/workflow-orchestrator.ts
+++ b/plugins/tt-agentboard/server/domains/execution/workflow-orchestrator.ts
@@ -16,7 +16,7 @@ import type { SlotPreparer } from "./slot-preparer";
 import { streamTailer as defaultStreamTailer } from "../infra/stream-tailer";
 import { stepExecutor as defaultStepExecutor, clearPendingCallback } from "./step-executor";
 import type { StepExecutor, WorkflowContext } from "./step-executor";
-import { renderTemplate, shellEscape } from "./workflow-helpers";
+import { buildAgentBranchName, renderTemplate, shellEscape } from "./workflow-helpers";
 import type { Logger, EventBus, StreamTailer } from "./types";
 
 export interface WorkflowOrchestratorDeps {
@@ -174,11 +174,13 @@ export class WorkflowOrchestrator {
     await this.deps.cardService.updateStatus(cardId, "running");
 
     // Build branch name
-    const branch = renderTemplate(workflow.branch_template ?? "agentboard/card-{card_id}", {
-      card_id: String(cardId),
-      issue: String(card.githubIssueNumber ?? ""),
-      issue_title: card.title,
-    });
+    const branch = workflow.branch_template
+      ? renderTemplate(workflow.branch_template, {
+          card_id: String(cardId),
+          issue: String(card.githubIssueNumber ?? ""),
+          issue_title: card.title,
+        })
+      : buildAgentBranchName(cardId, card.title);
 
     // Prepare the slot: sync git, set up branch, install deps
     const prepResult = await this.deps.slotPreparer.prepare({

--- a/plugins/tt-agentboard/test/services/workflow-runner.test.ts
+++ b/plugins/tt-agentboard/test/services/workflow-runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildAgentBranchName,
   checkPassCondition,
   renderTemplate,
   shellEscape,
@@ -69,6 +70,41 @@ describe("workflow-helpers", () => {
 
     it("handles empty value", () => {
       expect(renderTemplate("issue-{issue}", { issue: "" })).toBe("issue-");
+    });
+  });
+
+  describe("buildAgentBranchName()", () => {
+    it("slugifies card title into branch name", () => {
+      expect(buildAgentBranchName(2, "Fix login bug in auth")).toBe(
+        "agentboard/2-fix-login-bug-in-auth",
+      );
+    });
+
+    it("strips special characters", () => {
+      expect(buildAgentBranchName(5, "feat: add @user auth!")).toBe(
+        "agentboard/5-feat-add-user-auth",
+      );
+    });
+
+    it("truncates long titles to 50 chars", () => {
+      const longTitle = "This is a very long card title that exceeds the fifty character slug limit by quite a lot";
+      const result = buildAgentBranchName(10, longTitle);
+      const slug = result.replace("agentboard/10-", "");
+      expect(slug.length).toBeLessThanOrEqual(50);
+    });
+
+    it("falls back to card-{id} for empty title", () => {
+      expect(buildAgentBranchName(7, "")).toBe("agentboard/card-7");
+    });
+
+    it("falls back to card-{id} for title with only special chars", () => {
+      expect(buildAgentBranchName(3, "!!!@@@###")).toBe("agentboard/card-3");
+    });
+
+    it("collapses consecutive hyphens", () => {
+      expect(buildAgentBranchName(1, "fix   multiple    spaces")).toBe(
+        "agentboard/1-fix-multiple-spaces",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds Zod schemas for card creation, agent response input, and repo path validation
- Creates reusable `useFormValidation` composable for schema-based validation with inline error display
- Wires validation into NewCardForm (prompt min 3 chars), CardDetail agent response (non-empty), and OnboardingWizard path input (must be absolute path)
- Red border + inline error messages on invalid fields, cleared on input

## Test plan
- [x] All unit tests pass
- [x] Lint and typecheck pass
- [ ] Manual: submit NewCardForm with empty/short prompt, verify error shown
- [ ] Manual: type relative path in OnboardingWizard, verify error
- [ ] Manual: try empty agent response, verify error

Closes #142