### PR TITLE
refactor(agentboard): replace manual reactive patterns with VueUse

### DIFF
--- a/plugins/tt-agentboard/app/components/board/KanbanBoard.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanBoard.vue
@@ -64,13 +64,7 @@ async function handleCardMoved(cardId: number, column: Column, position: number)
 }
 
 // Stale-data fallback — WS handles real-time, this catches missed events
-const refreshInterval = ref<ReturnType<typeof setInterval> | null>(null);
-onMounted(() => {
-  refreshInterval.value = setInterval(() => store.fetchCards(), 60_000);
-});
-onUnmounted(() => {
-  if (refreshInterval.value) clearInterval(refreshInterval.value);
-});
+useIntervalFn(() => store.fetchCards(), 60_000);
 </script>
 
 <template>

--- a/plugins/tt-agentboard/app/components/board/KanbanCard.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanCard.vue
@@ -20,12 +20,13 @@ const borderClass = computed(
   () => STATUS_BORDER_CLASSES[props.card.status as CardStatus] ?? "border-zinc-700",
 );
 
+const now = useNow({ interval: 1000 });
+
 const elapsedTime = computed(() => {
   if (props.card.status === "idle") return null;
   const ref = props.card.status === "running" ? props.card.updatedAt : props.card.createdAt;
   const start = new Date(ref).getTime();
-  const now = Date.now();
-  const seconds = Math.floor((now - start) / 1000);
+  const seconds = Math.floor((now.value.getTime() - start) / 1000);
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m`;

--- a/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
+++ b/plugins/tt-agentboard/app/components/card/ActivityPanel.vue
@@ -25,9 +25,10 @@ type ActivityEvent =
 const MAX_EVENTS = 500;
 const events = ref<ActivityEvent[]>([]);
 const container = ref<HTMLElement>();
-const autoScroll = ref(true);
-
 const { on, off, subscribeActivity, unsubscribeActivity } = useWebSocket();
+
+const { arrivedState } = useScroll(container, { offset: { bottom: 40 } });
+const autoScroll = computed(() => arrivedState.bottom);
 
 function handleActivity(raw: { type: string; [key: string]: unknown }) {
   const evt = raw as unknown as AgentActivityEvent;
@@ -48,12 +49,6 @@ function handleActivity(raw: { type: string; [key: string]: unknown }) {
       container.value?.scrollTo({ top: container.value.scrollHeight });
     });
   }
-}
-
-function handleScroll() {
-  if (!container.value) return;
-  const { scrollTop, scrollHeight, clientHeight } = container.value;
-  autoScroll.value = scrollHeight - scrollTop - clientHeight < 40;
 }
 
 const TOOL_COLORS = {
@@ -115,7 +110,6 @@ onUnmounted(() => {
   <div
     ref="container"
     class="h-full overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-950 font-mono text-[13px]"
-    @scroll="handleScroll"
   >
     <!-- Empty state -->
     <div

--- a/plugins/tt-agentboard/app/components/card/DiffViewer.vue
+++ b/plugins/tt-agentboard/app/components/card/DiffViewer.vue
@@ -54,29 +54,13 @@ async function fetchDiff() {
 }
 
 // Poll every 5s, but stop when status is terminal
-const pollInterval = ref<ReturnType<typeof setInterval> | null>(null);
-
-function stopPolling() {
-  if (pollInterval.value) {
-    clearInterval(pollInterval.value);
-    pollInterval.value = null;
-  }
-}
-
-function startPolling() {
-  stopPolling();
-  pollInterval.value = setInterval(fetchDiff, 5000);
-}
+const { pause, resume } = useIntervalFn(fetchDiff, 5000, { immediate: false });
 
 onMounted(() => {
   fetchDiff();
   if (!props.status || !TERMINAL_STATUSES.has(props.status)) {
-    startPolling();
+    resume();
   }
-});
-
-onUnmounted(() => {
-  stopPolling();
 });
 
 // Stop polling when status becomes terminal; do one final fetch then stop
@@ -85,9 +69,9 @@ watch(
   (newStatus) => {
     if (newStatus && TERMINAL_STATUSES.has(newStatus)) {
       fetchDiff();
-      stopPolling();
-    } else if (!pollInterval.value) {
-      startPolling();
+      pause();
+    } else {
+      resume();
     }
   },
 );

--- a/plugins/tt-agentboard/app/components/card/TerminalPanel.vue
+++ b/plugins/tt-agentboard/app/components/card/TerminalPanel.vue
@@ -76,29 +76,19 @@ async function fetchTerminal() {
 }
 
 // Handle resize
-const resizeObserver = ref<ResizeObserver | null>(null);
+useResizeObserver(terminalRef, () => {
+  fitAddon.value?.fit();
+});
 
 onMounted(() => {
   initTerminal();
   fetchTerminal();
-
-  resizeObserver.value = new ResizeObserver(() => {
-    fitAddon.value?.fit();
-  });
-  if (terminalRef.value) {
-    resizeObserver.value.observe(terminalRef.value);
-  }
 });
 
 // Poll for updates
-const pollInterval = ref<ReturnType<typeof setInterval> | null>(null);
-onMounted(() => {
-  pollInterval.value = setInterval(fetchTerminal, 2000);
-});
+useIntervalFn(fetchTerminal, 2000);
 
 onUnmounted(() => {
-  if (pollInterval.value) clearInterval(pollInterval.value);
-  resizeObserver.value?.disconnect();
   terminal.value?.dispose();
 });
 

--- a/plugins/tt-agentboard/app/pages/cards/[id].vue
+++ b/plugins/tt-agentboard/app/pages/cards/[id].vue
@@ -49,13 +49,7 @@ async function sendAgentResponse(response: string) {
   }).catch(() => {});
 }
 
-const refreshInterval = ref<ReturnType<typeof setInterval> | null>(null);
-onMounted(() => {
-  refreshInterval.value = setInterval(refresh, 2000);
-});
-onUnmounted(() => {
-  if (refreshInterval.value) clearInterval(refreshInterval.value);
-});
+useIntervalFn(refresh, 2000);
 </script>
 
 <template>

--- a/plugins/tt-agentboard/app/pages/index.vue
+++ b/plugins/tt-agentboard/app/pages/index.vue
@@ -179,17 +179,15 @@ function onCardCreated() {
 }
 
 // Refresh selected card periodically (client-only)
-const detailInterval = ref<ReturnType<typeof setInterval> | null>(null);
-onMounted(() => {
-  watch(selectedCardId, (id) => {
-    if (detailInterval.value) clearInterval(detailInterval.value);
-    if (id) {
-      detailInterval.value = setInterval(fetchSelectedCard, 2000);
-    }
-  });
+const { pause: pauseDetail, resume: resumeDetail } = useIntervalFn(fetchSelectedCard, 2000, {
+  immediate: false,
 });
-onUnmounted(() => {
-  if (detailInterval.value) clearInterval(detailInterval.value);
+watch(selectedCardId, (id) => {
+  if (id) {
+    resumeDetail();
+  } else {
+    pauseDetail();
+  }
 });
 
 // Break reminders — start timer and track input

--- a/plugins/tt-agentboard/nuxt.config.ts
+++ b/plugins/tt-agentboard/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   compatibilityDate: "2025-01-01",
   devtools: { enabled: true },
-  modules: ["@nuxtjs/tailwindcss", "@pinia/nuxt"],
+  modules: ["@nuxtjs/tailwindcss", "@pinia/nuxt", "@vueuse/nuxt"],
   vite: {
     optimizeDeps: {
       include: ["vuedraggable", "@xterm/xterm", "@xterm/addon-fit", "@vueuse/core"],

--- a/plugins/tt-agentboard/package.json
+++ b/plugins/tt-agentboard/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@pinia/nuxt": "^0.11.3",
     "@vueuse/core": "^14.2.1",
+    "@vueuse/nuxt": "^14.2.1",
     "chokidar": "^5.0.0",
     "consola": "^3.4.2",
     "nuxt": "^4.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@vueuse/core':
         specifier: ^14.2.1
         version: 14.2.1(vue@3.5.31(typescript@5.8.3))
+      '@vueuse/nuxt':
+        specifier: ^14.2.1
+        version: 14.2.1(magicast@0.5.2)(nuxt@4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.31(typescript@5.8.3))
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -3899,6 +3902,12 @@ packages:
 
   '@vueuse/metadata@14.2.1':
     resolution: {integrity: sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==}
+
+  '@vueuse/nuxt@14.2.1':
+    resolution: {integrity: sha512-DHgFMUpyH98M1YM9pbnRjFXMAMKEsHntJeOp8rOXs8QN2cvJBzEZ+TTWIBSPESNFOEwM02RA6BDsaTL35OK4Mw==}
+    peerDependencies:
+      nuxt: ^3.0.0 || ^4.0.0-0
+      vue: ^3.5.0
 
   '@vueuse/shared@14.2.1':
     resolution: {integrity: sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==}
@@ -12871,6 +12880,17 @@ snapshots:
       vue: 3.5.31(typescript@5.8.3)
 
   '@vueuse/metadata@14.2.1': {}
+
+  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.31(typescript@5.8.3))':
+    dependencies:
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.8.3))
+      '@vueuse/metadata': 14.2.1
+      local-pkg: 1.1.2
+      nuxt: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      vue: 3.5.31(typescript@5.8.3)
+    transitivePeerDependencies:
+      - magicast
 
   '@vueuse/shared@14.2.1(vue@3.5.31(typescript@5.8.3))':
     dependencies:


### PR DESCRIPTION
## Summary
- Replace manual `setInterval`/`clearInterval` with `useIntervalFn` across 5 components
- Replace manual `ResizeObserver` with `useResizeObserver` in TerminalPanel
- Replace manual scroll tracking with `useScroll` in ActivityPanel
- Fix non-reactive `Date.now()` bug in KanbanCard with `useNow` (elapsed time now updates live)
- Add `@vueuse/nuxt` module for auto-imports

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — clean
- [x] AgentBoard unit tests — 174/174 pass

Closes #156