### PR TITLE
feat(agentboard): break countdown timer and issue-closed merge detection

### DIFF
--- a/plugins/tt-agentboard/app/components/breaks/BreakWidget.vue
+++ b/plugins/tt-agentboard/app/components/breaks/BreakWidget.vue
@@ -2,6 +2,7 @@
 const store = useBreakReminderStore();
 
 const showSettings = ref(false);
+const now = useNow({ interval: 1000 });
 
 const progressFraction = computed(() => {
   const total = store.todayStats.completed + store.todayStats.skipped;
@@ -12,15 +13,24 @@ const progressFraction = computed(() => {
 
 const progressPercent = computed(() => Math.round(progressFraction.value * 100));
 
+function formatCountdown(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
 const statusLabel = computed(() => {
   if (store.isPaused) return "Paused";
   if (store.isInFocusMode) {
-    const remaining = Math.round(((store.focusModeUntil ?? 0) - Date.now()) / 60_000);
-    return `Focus ${remaining}m`;
+    const remainingSec = Math.max(0, Math.round(((store.focusModeUntil ?? 0) - now.value.getTime()) / 1000));
+    return `Focus ${formatCountdown(remainingSec)}`;
   }
-  if (store.nextBreakIn === null) return "—";
-  if (store.nextBreakIn === 0) return "Due now";
-  return `${store.nextBreakIn}m`;
+  if (!store.lastBreakTimestamp) return "--:--";
+  const elapsedSec = Math.round((now.value.getTime() - store.lastBreakTimestamp) / 1000);
+  const intervalSec = store.config.intervalMinutes * 60;
+  const remainingSec = Math.max(0, intervalSec - elapsedSec);
+  if (remainingSec === 0) return "Due now";
+  return formatCountdown(remainingSec);
 });
 </script>
 

--- a/plugins/tt-agentboard/server/domains/infra/github-service.ts
+++ b/plugins/tt-agentboard/server/domains/infra/github-service.ts
@@ -84,6 +84,17 @@ export class GitHubService {
     }));
   }
 
+  async isIssueClosed(owner: string, repo: string, issueNumber: number): Promise<boolean> {
+    try {
+      const result = this.ghJson<{ state: string }>(
+        `issue view ${issueNumber} --repo ${owner}/${repo} --json state`,
+      );
+      return result.state.toLowerCase() === "closed";
+    } catch {
+      return false;
+    }
+  }
+
   async createIssue(owner: string, repo: string, title: string, body: string, labels?: string[]) {
     const labelArgs = labels?.length ? labels.map((l) => `--label "${l}"`).join(" ") : "";
     // gh issue create returns the URL on stdout (no --json support)

--- a/plugins/tt-agentboard/server/plugins/github-poll.ts
+++ b/plugins/tt-agentboard/server/plugins/github-poll.ts
@@ -2,7 +2,7 @@ import { db } from "../shared/db";
 import { cards, boards, repositories, workflowRuns, workspaceSlots } from "../shared/db/schema";
 import { and, eq } from "drizzle-orm";
 import { eventBus } from "../shared/event-bus";
-import { isGitHubConfigured } from "../domains/infra/github-service";
+import { isGitHubConfigured, getGitHubService } from "../domains/infra/github-service";
 import { gitQuery } from "../domains/infra/git";
 import { cardService } from "../domains/cards/card-service";
 import { logger } from "../utils/logger";
@@ -115,33 +115,51 @@ export default defineNitroPlugin(async () => {
         .from(workflowRuns);
       const branchByCard = new Map(allRuns.map((r) => [r.cardId, r.branch]));
 
+      const gh = getGitHubService();
+
+      const markDone = async (cardId: number, reason: string) => {
+        await db
+          .update(cards)
+          .set({ status: "done", column: "done", updatedAt: new Date() })
+          .where(eq(cards.id, cardId));
+        await cardService.logEvent(cardId, "auto_done", reason);
+        eventBus.emit("card:status-changed", { cardId, status: "done" });
+        logger.info(`Card #${cardId} moved to done — ${reason}`);
+      };
+
       for (const card of reviewCards) {
         if (!card.repoId) continue;
 
         const branch = branchByCard.get(card.id);
-        if (!branch || branch === "unknown") continue;
-
-        const slotPath = await getValidSlot(card.repoId);
-        if (!slotPath) continue;
-
         const repo = repoMap.get(card.repoId);
-        const baseBranch = repo?.defaultBranch ?? "main";
+        let merged = false;
 
-        // Deduplicate base branch fetch per repo
-        const fetchKey = `${slotPath}::${baseBranch}`;
-        if (!fetched.has(fetchKey)) {
-          await gitQuery(slotPath, ["fetch", "origin", baseBranch]);
-          fetched.add(fetchKey);
+        // Try git-based branch merge check
+        if (branch && branch !== "unknown") {
+          const slotPath = await getValidSlot(card.repoId);
+          if (slotPath) {
+            const baseBranch = repo?.defaultBranch ?? "main";
+            const fetchKey = `${slotPath}::${baseBranch}`;
+            if (!fetched.has(fetchKey)) {
+              await gitQuery(slotPath, ["fetch", "origin", baseBranch]);
+              fetched.add(fetchKey);
+            }
+            if (await isBranchMerged(slotPath, branch, baseBranch)) {
+              await markDone(card.id, `Branch ${branch} merged into ${baseBranch}`);
+              merged = true;
+            }
+          }
         }
 
-        if (await isBranchMerged(slotPath, branch, baseBranch)) {
-          await db
-            .update(cards)
-            .set({ status: "done", column: "done", updatedAt: new Date() })
-            .where(eq(cards.id, card.id));
-          await cardService.logEvent(card.id, "branch_merged", `Branch ${branch} merged into ${baseBranch}`);
-          eventBus.emit("card:status-changed", { cardId: card.id, status: "done" });
-          logger.info(`Card #${card.id} moved to done — branch ${branch} merged into ${baseBranch}`);
+        // Fall back to GitHub issue closed check
+        if (!merged && card.githubIssueNumber && repo?.org && repo?.name) {
+          try {
+            if (await gh.isIssueClosed(repo.org, repo.name, card.githubIssueNumber)) {
+              await markDone(card.id, `Issue #${card.githubIssueNumber} closed`);
+            }
+          } catch (err) {
+            logger.debug(`Failed to check issue #${card.githubIssueNumber} for card #${card.id}: ${err}`);
+          }
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Show live mm:ss countdown in break widget using `useNow({ interval: 1000 })`
- Fall back to GitHub issue closed check when git branch merge check can't determine status
- Fix case-sensitive `gh` CLI state comparison (`CLOSED` vs `closed`)

## Test plan
- [ ] Verify break widget shows ticking countdown in mm:ss format
- [ ] Verify cards with closed GitHub issues auto-move to done column
- [ ] Verify git-based branch merge detection still works for known branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)