### PR TITLE
feat(agentboard): add kanban filter search bar

### DIFF
--- a/plugins/tt-agentboard/app/components/board/KanbanBoard.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanBoard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { COLUMNS } from "~/utils/constants";
 import type { Column } from "~/utils/constants";
+import type { Card } from "~/stores/cards";
 
 const store = useCardStore();
 const { cards, loading, error, columnCards, totalCards, activeCards } = storeToRefs(store);
@@ -97,6 +98,23 @@ useIntervalFn(() => store.fetchCards(), 60_000);
       </ClientOnly>
 
       <div class="flex items-center gap-2">
+        <div class="relative">
+          <input
+            v-model="filterQuery"
+            type="text"
+            placeholder="Filter cards..."
+            class="w-48 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 pl-8 text-xs text-zinc-200 placeholder-zinc-500 transition-colors focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+          />
+          <span class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-500 text-xs">⌕</span>
+          <button
+            v-if="filterQuery"
+            class="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 text-xs"
+            @click="filterQuery = ''"
+            title="Clear filter"
+          >
+            ✕
+          </button>
+        </div>
         <button
           class="rounded-lg border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-600 hover:bg-zinc-700 hover:text-zinc-200"
           title="Keyboard shortcuts (?)"
@@ -243,7 +261,7 @@ useIntervalFn(() => store.fetchCards(), 60_000);
         v-for="col in COLUMNS"
         :key="col"
         :column="col"
-        :cards="columnCards[col]"
+        :cards="filteredColumnCards[col]"
         class="shrink-0"
         @card-moved="handleCardMoved"
         @card-selected="(id: number) => emit('cardSelected', id)"

--- a/plugins/tt-agentboard/app/components/board/KanbanBoard.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanBoard.vue
@@ -70,6 +70,42 @@ async function handleClearDone() {
   await store.fetchCards();
 }
 
+// --- Filter / search ---
+const filterQuery = ref("");
+
+const filteredColumnCards = computed(() => {
+  const q = filterQuery.value.trim().toLowerCase();
+  if (!q) return columnCards.value;
+
+  const result: Record<Column, Card[]> = {
+    backlog: [],
+    ready: [],
+    in_progress: [],
+    review: [],
+    done: [],
+  };
+
+  for (const col of COLUMNS) {
+    result[col] = columnCards.value[col].filter((card) => {
+      const haystack = [
+        `#${card.id}`,
+        card.title,
+        card.description,
+        card.status,
+        card.branch,
+        card.repo?.name,
+        card.repo?.org,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }
+
+  return result;
+});
+
 // Stale-data fallback — WS handles real-time, this catches missed events
 useIntervalFn(() => store.fetchCards(), 60_000);
 </script>
@@ -105,7 +141,10 @@ useIntervalFn(() => store.fetchCards(), 60_000);
             placeholder="Filter cards..."
             class="w-48 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 pl-8 text-xs text-zinc-200 placeholder-zinc-500 transition-colors focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50"
           />
-          <span class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-500 text-xs">⌕</span>
+          <span
+            class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-500 text-xs"
+            >⌕</span
+          >
           <button
             v-if="filterQuery"
             class="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 text-xs"


### PR DESCRIPTION
## Summary\n\n- Adds a filter/search input to the KanbanBoard header (top nav) that filters visible cards across all columns in real-time\n- Matches against card ID, title, description, status, branch, repo name, and org\n- Includes clear button when filter is active; shows all cards when empty\n\n## Test plan\n\n- [ ] Open AgentBoard with multiple cards across columns\n- [ ] Type in the filter box and verify cards are filtered across all columns\n- [ ] Verify matching works on card ID (`#123`), title, description, status, branch, and repo name\n- [ ] Click the ✕ button to clear the filter and confirm all cards reappear\n- [ ] Verify drag-and-drop still works on filtered cards\n\nhttps://claude.ai/code/session_01YQP3zQF31CZ1NJycKw7XZc