### PR TITLE
Auto-move cards to done when GitHub PRs are merged

### DIFF
--- a/plugins/tt-agentboard/server/domains/cards/card-service.ts
+++ b/plugins/tt-agentboard/server/domains/cards/card-service.ts
@@ -79,6 +79,28 @@ export class CardService {
     });
   }
 
+  /** Mark card done: status=done, column=done */
+  async markDone(cardId: number): Promise<void> {
+    const rows = await this.deps.db.select().from(cards).where(eq(cards.id, cardId));
+    if (rows.length === 0) return;
+    const fromColumn = (rows[0]!.column ?? "review") as Column;
+
+    await this.deps.db
+      .update(cards)
+      .set({ status: "done", column: "done", updatedAt: new Date() })
+      .where(eq(cards.id, cardId));
+
+    this.deps.eventBus.emit("card:status-changed", {
+      cardId,
+      status: "done" as CardStatus,
+    });
+    this.deps.eventBus.emit("card:moved", {
+      cardId,
+      fromColumn,
+      toColumn: "done" as Column,
+    });
+  }
+
   /** Insert a row into the cardEvents table */
   async logEvent(cardId: number, event: string, detail?: string): Promise<void> {
     await this.deps.db.insert(cardEvents).values({ cardId, event, detail });

--- a/plugins/tt-agentboard/server/domains/infra/github-service.ts
+++ b/plugins/tt-agentboard/server/domains/infra/github-service.ts
@@ -132,6 +132,17 @@ export class GitHubService {
     return { branchName, sha: typeof sha === "string" ? sha : sha.object.sha };
   }
 
+  async isPrMerged(owner: string, repo: string, prNumber: number): Promise<boolean> {
+    try {
+      const result = this.ghJson<{ state: string; mergedAt: string | null }>(
+        `pr view ${prNumber} --repo ${owner}/${repo} --json state,mergedAt`,
+      );
+      return result.state === "MERGED" || result.mergedAt !== null;
+    } catch {
+      return false;
+    }
+  }
+
   async createPr({ owner, repo, title, body, head, base }: CreatePrOptions) {
     // gh pr create returns the URL on stdout (no --json support)
     const url = this.ghExec(

--- a/plugins/tt-agentboard/server/domains/infra/hook-writer.ts
+++ b/plugins/tt-agentboard/server/domains/infra/hook-writer.ts
@@ -22,12 +22,7 @@ function findScriptSource(): string {
   return resolve(process.cwd(), "scripts", "stop-hook.sh");
 }
 
-function commandHook(
-  cardId: number,
-  port: number,
-  stopEndpoint: string,
-  scriptPath: string,
-) {
+function commandHook(cardId: number, port: number, stopEndpoint: string, scriptPath: string) {
   return [
     {
       matcher: "",
@@ -90,5 +85,7 @@ export function writeHooks(
   };
 
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
-  logger.info(`Wrote lifecycle hooks to ${settingsPath} (command, cardId=${cardId}, endpoint=${stopEndpoint})`);
+  logger.info(
+    `Wrote lifecycle hooks to ${settingsPath} (command, cardId=${cardId}, endpoint=${stopEndpoint})`,
+  );
 }

--- a/plugins/tt-agentboard/server/plugins/github-pr-merge-watch.ts
+++ b/plugins/tt-agentboard/server/plugins/github-pr-merge-watch.ts
@@ -1,0 +1,124 @@
+import { db } from "../shared/db";
+import { cards, repositories, workspaceSlots } from "../shared/db/schema";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { getGitHubService, isGitHubConfigured } from "../domains/infra/github-service";
+import { cardService } from "../domains/cards/card-service";
+import { tmuxManager } from "../domains/infra/tmux-manager";
+import { eventBus } from "../shared/event-bus";
+import { logger } from "../utils/logger";
+import { existsSync, unlinkSync } from "node:fs";
+import { resolve } from "node:path";
+
+const POLL_INTERVAL_MS = Number(process.env.PR_MERGE_POLL_INTERVAL_MS) || 60_000;
+
+/**
+ * Polls cards in the "review" column that have a githubPrNumber.
+ * When the PR is merged, automatically moves the card to "done"
+ * and cleans up resources (tmux session, workspace slots).
+ */
+export default defineNitroPlugin(() => {
+  if (!isGitHubConfigured()) {
+    logger.info("gh CLI not authenticated — PR merge watch disabled");
+    return;
+  }
+
+  const timer = setInterval(async () => {
+    try {
+      await checkMergedPrs();
+    } catch (error) {
+      logger.error("PR merge watch poll failed:", error);
+    }
+  }, POLL_INTERVAL_MS);
+
+  // Also run once on startup (after a short delay to let DB initialize)
+  setTimeout(() => checkMergedPrs().catch(() => {}), 5_000);
+
+  logger.info(`PR merge watch plugin loaded (interval: ${POLL_INTERVAL_MS}ms)`);
+
+  // Clean up on shutdown
+  if (typeof globalThis.onBeforeExit === "function") {
+    globalThis.onBeforeExit(() => clearInterval(timer));
+  }
+});
+
+async function checkMergedPrs(): Promise<void> {
+  // Find all cards in "review" column that have a PR number
+  const reviewCards = await db
+    .select({
+      id: cards.id,
+      githubPrNumber: cards.githubPrNumber,
+      repoId: cards.repoId,
+    })
+    .from(cards)
+    .where(
+      and(
+        eq(cards.column, "review"),
+        isNotNull(cards.githubPrNumber),
+        isNotNull(cards.repoId),
+      ),
+    );
+
+  if (reviewCards.length === 0) return;
+
+  const github = getGitHubService();
+
+  for (const card of reviewCards) {
+    if (!card.githubPrNumber || !card.repoId) continue;
+
+    const repo = await db
+      .select()
+      .from(repositories)
+      .where(eq(repositories.id, card.repoId))
+      .get();
+
+    if (!repo?.org) continue;
+
+    try {
+      const merged = await github.isPrMerged(repo.org, repo.name, card.githubPrNumber);
+      if (!merged) continue;
+
+      logger.info(
+        `PR #${card.githubPrNumber} merged — moving card ${card.id} to done`,
+      );
+
+      // Clean up resources (same as move.post.ts done block)
+      const sessionName = `card-${card.id}`;
+      tmuxManager.stopCapture(sessionName);
+      tmuxManager.killSession(sessionName);
+
+      const claimedSlots = await db
+        .select()
+        .from(workspaceSlots)
+        .where(eq(workspaceSlots.claimedByCardId, card.id));
+
+      for (const slot of claimedSlots) {
+        await db
+          .update(workspaceSlots)
+          .set({ status: "available", claimedByCardId: null })
+          .where(eq(workspaceSlots.id, slot.id));
+
+        const settingsPath = resolve(slot.path, ".claude", "settings.local.json");
+        try {
+          if (existsSync(settingsPath)) {
+            unlinkSync(settingsPath);
+          }
+        } catch {
+          // Non-fatal
+        }
+
+        eventBus.emit("slot:released", { slotId: slot.id });
+      }
+
+      await cardService.markDone(card.id);
+      await cardService.logEvent(
+        card.id,
+        "pr_merged",
+        `PR #${card.githubPrNumber} was merged — auto-moved to done`,
+      );
+    } catch (error) {
+      logger.debug(
+        `Failed to check PR #${card.githubPrNumber} for card ${card.id}: ${error}`,
+      );
+    }
+  }
+}

--- a/plugins/tt-agentboard/server/plugins/github-pr-merge-watch.ts
+++ b/plugins/tt-agentboard/server/plugins/github-pr-merge-watch.ts
@@ -51,11 +51,7 @@ async function checkMergedPrs(): Promise<void> {
     })
     .from(cards)
     .where(
-      and(
-        eq(cards.column, "review"),
-        isNotNull(cards.githubPrNumber),
-        isNotNull(cards.repoId),
-      ),
+      and(eq(cards.column, "review"), isNotNull(cards.githubPrNumber), isNotNull(cards.repoId)),
     );
 
   if (reviewCards.length === 0) return;
@@ -65,11 +61,7 @@ async function checkMergedPrs(): Promise<void> {
   for (const card of reviewCards) {
     if (!card.githubPrNumber || !card.repoId) continue;
 
-    const repo = await db
-      .select()
-      .from(repositories)
-      .where(eq(repositories.id, card.repoId))
-      .get();
+    const repo = await db.select().from(repositories).where(eq(repositories.id, card.repoId)).get();
 
     if (!repo?.org) continue;
 
@@ -77,9 +69,7 @@ async function checkMergedPrs(): Promise<void> {
       const merged = await github.isPrMerged(repo.org, repo.name, card.githubPrNumber);
       if (!merged) continue;
 
-      logger.info(
-        `PR #${card.githubPrNumber} merged — moving card ${card.id} to done`,
-      );
+      logger.info(`PR #${card.githubPrNumber} merged — moving card ${card.id} to done`);
 
       // Clean up resources (same as move.post.ts done block)
       const sessionName = `card-${card.id}`;
@@ -116,9 +106,7 @@ async function checkMergedPrs(): Promise<void> {
         `PR #${card.githubPrNumber} was merged — auto-moved to done`,
       );
     } catch (error) {
-      logger.debug(
-        `Failed to check PR #${card.githubPrNumber} for card ${card.id}: ${error}`,
-      );
+      logger.debug(`Failed to check PR #${card.githubPrNumber} for card ${card.id}: ${error}`);
     }
   }
 }

--- a/plugins/tt-agentboard/test/domains/cards/card-service.test.ts
+++ b/plugins/tt-agentboard/test/domains/cards/card-service.test.ts
@@ -133,6 +133,48 @@ describe("CardService", () => {
     });
   });
 
+  describe("markDone()", () => {
+    it("sets status=done + column=done and emits both events", async () => {
+      const selectChain: Record<string, unknown> = {};
+      selectChain.from = vi.fn().mockReturnValue(selectChain);
+      selectChain.where = vi.fn().mockResolvedValue([{ id: 1, column: "review" }]);
+      mockDb.select = vi.fn().mockReturnValue(selectChain);
+
+      const updateChain: Record<string, unknown> = {};
+      updateChain.set = vi.fn().mockReturnValue(updateChain);
+      updateChain.where = vi.fn().mockResolvedValue(undefined);
+      mockDb.update = vi.fn().mockReturnValue(updateChain);
+
+      await service.markDone(1);
+
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+      expect(updateChain.set).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "done", column: "done" }),
+      );
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:status-changed", {
+        cardId: 1,
+        status: "done",
+      });
+      expect(mockEventBus.emit).toHaveBeenCalledWith("card:moved", {
+        cardId: 1,
+        fromColumn: "review",
+        toColumn: "done",
+      });
+    });
+
+    it("does nothing if card not found", async () => {
+      const selectChain: Record<string, unknown> = {};
+      selectChain.from = vi.fn().mockReturnValue(selectChain);
+      selectChain.where = vi.fn().mockResolvedValue([]);
+      mockDb.select = vi.fn().mockReturnValue(selectChain);
+
+      await service.markDone(999);
+
+      expect(mockDb.update).not.toHaveBeenCalled();
+      expect(mockEventBus.emit).not.toHaveBeenCalled();
+    });
+  });
+
   describe("logEvent()", () => {
     it("inserts into cardEvents table", async () => {
       const insertChain: Record<string, unknown> = {};

--- a/plugins/tt-agentboard/test/helpers/mock-deps.ts
+++ b/plugins/tt-agentboard/test/helpers/mock-deps.ts
@@ -90,6 +90,7 @@ export function createMockCardService() {
     moveToColumn: vi.fn().mockResolvedValue(undefined),
     markFailed: vi.fn().mockResolvedValue(undefined),
     markComplete: vi.fn().mockResolvedValue(undefined),
+    markDone: vi.fn().mockResolvedValue(undefined),
     logEvent: vi.fn().mockResolvedValue(undefined),
     resolveDependencies: vi.fn().mockResolvedValue([]),
     getDepsMap: vi.fn().mockResolvedValue(new Map()),

--- a/plugins/tt-agentboard/test/services/github-service.test.ts
+++ b/plugins/tt-agentboard/test/services/github-service.test.ts
@@ -143,9 +143,7 @@ describe("GitHubService", () => {
     });
 
     it("returns false when PR is still open", async () => {
-      mockExecSync.mockReturnValueOnce(
-        JSON.stringify({ state: "OPEN", mergedAt: null }),
-      );
+      mockExecSync.mockReturnValueOnce(JSON.stringify({ state: "OPEN", mergedAt: null }));
 
       const result = await service.isPrMerged("org", "repo", 42);
 

--- a/plugins/tt-agentboard/test/services/github-service.test.ts
+++ b/plugins/tt-agentboard/test/services/github-service.test.ts
@@ -127,6 +127,42 @@ describe("GitHubService", () => {
     });
   });
 
+  describe("isPrMerged()", () => {
+    it("returns true when PR state is MERGED", async () => {
+      mockExecSync.mockReturnValueOnce(
+        JSON.stringify({ state: "MERGED", mergedAt: "2026-03-28T00:00:00Z" }),
+      );
+
+      const result = await service.isPrMerged("org", "repo", 42);
+
+      expect(result).toBe(true);
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining("pr view 42 --repo org/repo"),
+        expect.objectContaining({ encoding: "utf-8" }),
+      );
+    });
+
+    it("returns false when PR is still open", async () => {
+      mockExecSync.mockReturnValueOnce(
+        JSON.stringify({ state: "OPEN", mergedAt: null }),
+      );
+
+      const result = await service.isPrMerged("org", "repo", 42);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when gh command fails", async () => {
+      mockExecSync.mockImplementationOnce(() => {
+        throw new Error("gh not found");
+      });
+
+      const result = await service.isPrMerged("org", "repo", 42);
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe("createBranch()", () => {
     it("creates branch via gh api", async () => {
       // First call: get ref SHA

--- a/plugins/tt-agentboard/test/services/hook-writer.test.ts
+++ b/plugins/tt-agentboard/test/services/hook-writer.test.ts
@@ -67,10 +67,7 @@ describe("writeHooks()", () => {
     writeHooks(slotPath, 1, 4200, "complete");
 
     const settings = readSettings(slotPath) as {
-      hooks: Record<
-        string,
-        Array<{ hooks: Array<{ command: string }> }>
-      >;
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
     };
     expect(settings.hooks.Stop[0]!.hooks[0]!.command).toContain(
       "AGENTBOARD_STOP_ENDPOINT=complete",


### PR DESCRIPTION
## Summary
Adds automatic card progression when associated GitHub pull requests are merged. This feature polls cards in the "review" column and moves them to "done" when their linked PR is merged, while cleaning up associated resources.

## Key Changes
- **New plugin**: `github-pr-merge-watch.ts` - Polls cards in the "review" column at configurable intervals (default 60s) and checks if their associated GitHub PRs have been merged
- **Resource cleanup**: When a PR is merged, the plugin automatically:
  - Stops and kills the tmux session for the card
  - Releases claimed workspace slots and marks them as available
  - Cleans up local settings files
  - Emits slot release events
- **CardService enhancement**: Added `markDone()` method to atomically set card status and column to "done" while emitting appropriate events
- **GitHubService enhancement**: Added `isPrMerged()` method to check PR merge status via `gh pr view` command
- **Test coverage**: Added comprehensive tests for `markDone()` and `isPrMerged()` methods
- **Code formatting**: Minor formatting improvements in `hook-writer.ts` and test files

## Implementation Details
- The plugin gracefully handles missing GitHub configuration and logs appropriately
- Runs an initial check 5 seconds after startup, then polls at the configured interval
- Errors during polling are logged but don't interrupt the polling loop
- Resource cleanup mirrors the existing cleanup logic in `move.post.ts` for consistency
- The `isPrMerged()` method returns `false` on any errors, preventing false positives

https://claude.ai/code/session_01DrsiTJY7niXiLfE6DAhCJG