### PR TITLE
feat(agentboard): add simplify_review column

### DIFF
--- a/plugins/tt-agentboard/app/components/board/KanbanColumn.vue
+++ b/plugins/tt-agentboard/app/components/board/KanbanColumn.vue
@@ -20,6 +20,7 @@ const columnClasses: Record<Column, string> = {
   backlog: "border-t-zinc-600",
   ready: "border-t-cyan-500",
   in_progress: "border-t-blue-500",
+  simplify_review: "border-t-amber-500",
   review: "border-t-violet-500",
   done: "border-t-emerald-500",
 };

--- a/plugins/tt-agentboard/app/stores/cards.ts
+++ b/plugins/tt-agentboard/app/stores/cards.ts
@@ -47,6 +47,7 @@ export const useCardStore = defineStore("cards", () => {
       backlog: [],
       ready: [],
       in_progress: [],
+      simplify_review: [],
       review: [],
       done: [],
     };

--- a/plugins/tt-agentboard/app/utils/constants.ts
+++ b/plugins/tt-agentboard/app/utils/constants.ts
@@ -1,10 +1,11 @@
-export const COLUMNS = ["backlog", "ready", "in_progress", "review", "done"] as const;
+export const COLUMNS = ["backlog", "ready", "in_progress", "simplify_review", "review", "done"] as const;
 export type Column = (typeof COLUMNS)[number];
 
 export const COLUMN_LABELS: Record<Column, string> = {
   backlog: "Backlog",
   ready: "Ready",
   in_progress: "In Progress",
+  simplify_review: "Simplify & Review",
   review: "Review",
   done: "Done",
 };
@@ -13,6 +14,7 @@ export const COLUMN_ICONS: Record<Column, string> = {
   backlog: "◇",
   ready: "◆",
   in_progress: "▶",
+  simplify_review: "⟳",
   review: "◉",
   done: "✓",
 };

--- a/plugins/tt-agentboard/app/utils/constants.ts
+++ b/plugins/tt-agentboard/app/utils/constants.ts
@@ -1,4 +1,11 @@
-export const COLUMNS = ["backlog", "ready", "in_progress", "simplify_review", "review", "done"] as const;
+export const COLUMNS = [
+  "backlog",
+  "ready",
+  "in_progress",
+  "simplify_review",
+  "review",
+  "done",
+] as const;
 export type Column = (typeof COLUMNS)[number];
 
 export const COLUMN_LABELS: Record<Column, string> = {

--- a/plugins/tt-agentboard/docs/system-flow.md
+++ b/plugins/tt-agentboard/docs/system-flow.md
@@ -45,14 +45,14 @@ stateDiagram-v2
 
 **Column/status mapping:**
 
-| Column           | Statuses               |
-| ---------------- | ---------------------- |
-| backlog          | idle, blocked          |
-| ready            | idle, queued           |
-| in_progress      | running, waiting_input |
-| simplify_review  | running, waiting_input |
-| review           | review_ready           |
-| done             | done                   |
+| Column          | Statuses               |
+| --------------- | ---------------------- |
+| backlog         | idle, blocked          |
+| ready           | idle, queued           |
+| in_progress     | running, waiting_input |
+| simplify_review | running, waiting_input |
+| review          | review_ready           |
+| done            | done                   |
 
 ## Agent Execution Flow
 

--- a/plugins/tt-agentboard/docs/system-flow.md
+++ b/plugins/tt-agentboard/docs/system-flow.md
@@ -6,7 +6,7 @@ AgentBoard is a Nuxt 4 app that manages autonomous Claude Code agents via a Kanb
 
 | Concept            | Description                                                                           |
 | ------------------ | ------------------------------------------------------------------------------------- |
-| **Board**          | Kanban board with columns: backlog, ready, in_progress, review, done                  |
+| **Board**          | Kanban board with columns: backlog, ready, in_progress, simplify_review, review, done |
 | **Card**           | A task with title, description, repo, status, optional workflow and GitHub issue link |
 | **Repository**     | A registered Git repo (org, name, default branch, GitHub URL)                         |
 | **Workspace Slot** | A directory (git worktree) tied to a repo. Each running agent needs one slot.         |
@@ -31,6 +31,11 @@ stateDiagram-v2
     in_progress_running --> waiting_input: Notification hook fires
     in_progress_running --> failed: StopFailure / timeout / error
 
+    ready_idle --> simplify_review_running: Moved to simplify_review
+    in_progress_running --> simplify_review_running: Moved to simplify_review
+    simplify_review_running --> review_ready: Simplify+review pass
+    simplify_review_running --> failed: StopFailure / timeout / error
+
     waiting_input --> in_progress_running: User responds
     waiting_input --> review_ready: Stop hook fires
 
@@ -40,13 +45,14 @@ stateDiagram-v2
 
 **Column/status mapping:**
 
-| Column      | Statuses               |
-| ----------- | ---------------------- |
-| backlog     | idle, blocked          |
-| ready       | idle, queued           |
-| in_progress | running, waiting_input |
-| review      | review_ready           |
-| done        | done                   |
+| Column           | Statuses               |
+| ---------------- | ---------------------- |
+| backlog          | idle, blocked          |
+| ready            | idle, queued           |
+| in_progress      | running, waiting_input |
+| simplify_review  | running, waiting_input |
+| review           | review_ready           |
+| done             | done                   |
 
 ## Agent Execution Flow
 

--- a/plugins/tt-agentboard/server/api/cards/[id]/move.post.ts
+++ b/plugins/tt-agentboard/server/api/cards/[id]/move.post.ts
@@ -34,6 +34,37 @@ export default defineEventHandler(async (event) => {
 
   await cardService.logEvent(id, "card_moved", `${fromColumn} → ${body.column}`);
 
+  // If moved to simplify_review, set workflow to simplify-review and trigger execution
+  if (body.column === "simplify_review") {
+    // Set the simplify-review workflow and use current branch
+    await db
+      .update(cards)
+      .set({ workflowId: "simplify-review", branchMode: "current" })
+      .where(eq(cards.id, id));
+
+    // Release any stale slots from a previous run
+    const staleSlots = await db
+      .select()
+      .from(workspaceSlots)
+      .where(eq(workspaceSlots.claimedByCardId, id));
+    for (const slot of staleSlots) {
+      await db
+        .update(workspaceSlots)
+        .set({ status: "available", claimedByCardId: null })
+        .where(eq(workspaceSlots.id, slot.id));
+      eventBus.emit("slot:released", { slotId: slot.id });
+    }
+
+    // Kill any stale tmux session
+    const sessionName = `card-${id}`;
+    tmuxManager.stopCapture(sessionName);
+    tmuxManager.killSession(sessionName);
+
+    agentExecutor.startExecution(id).catch(() => {
+      cardService.updateStatus(id, "failed");
+    });
+  }
+
   // If moved to in_progress, clean up stale resources first, then trigger agent
   if (body.column === "in_progress") {
     // Release any stale slots from a previous run

--- a/plugins/tt-agentboard/server/domains/cards/card-service.ts
+++ b/plugins/tt-agentboard/server/domains/cards/card-service.ts
@@ -63,6 +63,9 @@ export class CardService {
 
   /** Mark card complete: status=review_ready, column=review */
   async markComplete(cardId: number): Promise<void> {
+    const rows = await this.deps.db.select().from(cards).where(eq(cards.id, cardId));
+    const fromColumn = (rows[0]?.column ?? "in_progress") as Column;
+
     await this.deps.db
       .update(cards)
       .set({ status: "review_ready", column: "review", updatedAt: new Date() })
@@ -74,7 +77,7 @@ export class CardService {
     });
     this.deps.eventBus.emit("card:moved", {
       cardId,
-      fromColumn: "in_progress" as Column,
+      fromColumn,
       toColumn: "review" as Column,
     });
   }

--- a/plugins/tt-agentboard/server/domains/cards/schema.ts
+++ b/plugins/tt-agentboard/server/domains/cards/schema.ts
@@ -37,7 +37,7 @@ export const cards = sqliteTable("cards", {
   title: text("title").notNull(),
   description: text("description"),
   repoId: integer("repo_id").references(() => repositories.id, { onDelete: "set null" }),
-  column: text("column", { enum: ["backlog", "ready", "in_progress", "review", "done"] }).default(
+  column: text("column", { enum: ["backlog", "ready", "in_progress", "simplify_review", "review", "done"] }).default(
     "backlog",
   ),
   position: integer("position").notNull().default(0),

--- a/plugins/tt-agentboard/server/domains/cards/schema.ts
+++ b/plugins/tt-agentboard/server/domains/cards/schema.ts
@@ -37,9 +37,9 @@ export const cards = sqliteTable("cards", {
   title: text("title").notNull(),
   description: text("description"),
   repoId: integer("repo_id").references(() => repositories.id, { onDelete: "set null" }),
-  column: text("column", { enum: ["backlog", "ready", "in_progress", "simplify_review", "review", "done"] }).default(
-    "backlog",
-  ),
+  column: text("column", {
+    enum: ["backlog", "ready", "in_progress", "simplify_review", "review", "done"],
+  }).default("backlog"),
   position: integer("position").notNull().default(0),
   executionMode: text("execution_mode", { enum: ["headless", "interactive"] }).default("headless"),
   branchMode: text("branch_mode", { enum: ["create", "current"] }).default("create"),

--- a/plugins/tt-agentboard/server/domains/cards/types.ts
+++ b/plugins/tt-agentboard/server/domains/cards/types.ts
@@ -1,4 +1,4 @@
-export type Column = "backlog" | "ready" | "in_progress" | "review" | "done";
+export type Column = "backlog" | "ready" | "in_progress" | "simplify_review" | "review" | "done";
 export type CardStatus =
   | "idle"
   | "queued"

--- a/plugins/tt-agentboard/templates/workflows/simplify-review.yaml
+++ b/plugins/tt-agentboard/templates/workflows/simplify-review.yaml
@@ -1,0 +1,16 @@
+name: simplify-review
+description: Simplify and review only — for implementations that are close enough
+steps:
+  - id: simplify
+    prompt_template: .agentboard/prompts/simplify.md
+    artifact: .auto-claude/issue-{issue}/simplify-summary.md
+  - id: review
+    prompt_template: .agentboard/prompts/review.md
+    artifact: .auto-claude/issue-{issue}/review.md
+    pass_condition: "first_line_equals:PASS"
+    on_fail: "goto:simplify"
+    max_retries: 2
+post_steps:
+  create_pr: false
+branch_template: "current"
+artifact_dir: ".auto-claude/issue-{issue}"


### PR DESCRIPTION
## Summary

- Adds a `simplify_review` column to the AgentBoard between `in_progress` and `review` for running only simplify + review steps on existing implementations
- Creates `simplify-review.yaml` workflow template (simplify → review with retry loop, operates on current branch)
- When a card is dragged to the new column, it auto-sets the simplify-review workflow and `branchMode: current`, then triggers execution
- Fixes `markComplete` in CardService to use actual `fromColumn` instead of hardcoded `"in_progress"`

## Test plan

- [x] All 145 agentboard unit tests pass
- [x] TypeScript typecheck clean
- [x] Lint clean (only pre-existing warnings)
- [ ] Manual: drag a card to Simplify & Review column, verify it triggers simplify-review workflow
- [ ] Manual: verify card moves to Review column on completion

Closes #148

https://claude.ai/code/session_01TNc4dKAcXoyoFDhFYr1Psf