### PR TITLE
Add system prompt and resolved prompt logging to Claude CLI

### DIFF
--- a/src/lib/auto-claude/claude-cli.ts
+++ b/src/lib/auto-claude/claude-cli.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import consola from "consola";
 import pc from "picocolors";
 
-import { fileExists, readFile } from "../../utils/fs.js";
+import { readFile } from "../../utils/fs.js";
 import { getConfig } from "./config.js";
 import { sleep } from "./shell.js";
 import { spawnClaude as defaultSpawnClaude } from "./spawn-claude.js";
@@ -55,23 +55,19 @@ export async function runClaude(opts: {
 
   log.info(`${pc.dim("▶")} Calling Claude${opts.maxTurns ? ` (max ${opts.maxTurns} turns)` : ""}…`);
 
-  // Log the system prompt (CLAUDE.md auto-loaded by Claude Code)
-  const claudeMdPath = join(process.cwd(), "CLAUDE.md");
-  if (fileExists(claudeMdPath)) {
-    const systemPrompt = readFile(claudeMdPath);
+  try {
+    const systemPrompt = readFile(join(process.cwd(), "CLAUDE.md"));
     log.info(
       `\n${pc.bold(pc.cyan("── System Prompt (CLAUDE.md) ──"))}\n${pc.dim(systemPrompt.trimEnd())}\n`,
     );
-  }
+  } catch { /* CLAUDE.md not present */ }
 
-  // Log the resolved prompt being sent
-  const promptPath = join(process.cwd(), opts.promptFile);
-  if (fileExists(promptPath)) {
-    const promptContent = readFile(promptPath);
+  try {
+    const promptContent = readFile(join(process.cwd(), opts.promptFile));
     log.info(
       `\n${pc.bold(pc.cyan(`── Prompt (${opts.promptFile}) ──`))}\n${pc.dim(promptContent.trimEnd())}\n`,
     );
-  }
+  } catch { /* prompt file not present */ }
 
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= PROCESS_RETRIES; attempt++) {

--- a/src/lib/auto-claude/claude-cli.ts
+++ b/src/lib/auto-claude/claude-cli.ts
@@ -1,8 +1,10 @@
 import { createInterface } from "node:readline";
+import { join } from "node:path";
 
 import consola from "consola";
 import pc from "picocolors";
 
+import { fileExists, readFile } from "../../utils/fs.js";
 import { getConfig } from "./config.js";
 import { sleep } from "./shell.js";
 import { spawnClaude as defaultSpawnClaude } from "./spawn-claude.js";
@@ -52,6 +54,20 @@ export async function runClaude(opts: {
   ];
 
   log.info(`${pc.dim("▶")} Calling Claude${opts.maxTurns ? ` (max ${opts.maxTurns} turns)` : ""}…`);
+
+  // Log the system prompt (CLAUDE.md auto-loaded by Claude Code)
+  const claudeMdPath = join(process.cwd(), "CLAUDE.md");
+  if (fileExists(claudeMdPath)) {
+    const systemPrompt = readFile(claudeMdPath);
+    log.info(`\n${pc.bold(pc.cyan("── System Prompt (CLAUDE.md) ──"))}\n${pc.dim(systemPrompt.trimEnd())}\n`);
+  }
+
+  // Log the resolved prompt being sent
+  const promptPath = join(process.cwd(), opts.promptFile);
+  if (fileExists(promptPath)) {
+    const promptContent = readFile(promptPath);
+    log.info(`\n${pc.bold(pc.cyan(`── Prompt (${opts.promptFile}) ──`))}\n${pc.dim(promptContent.trimEnd())}\n`);
+  }
 
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= PROCESS_RETRIES; attempt++) {

--- a/src/lib/auto-claude/claude-cli.ts
+++ b/src/lib/auto-claude/claude-cli.ts
@@ -59,14 +59,18 @@ export async function runClaude(opts: {
   const claudeMdPath = join(process.cwd(), "CLAUDE.md");
   if (fileExists(claudeMdPath)) {
     const systemPrompt = readFile(claudeMdPath);
-    log.info(`\n${pc.bold(pc.cyan("── System Prompt (CLAUDE.md) ──"))}\n${pc.dim(systemPrompt.trimEnd())}\n`);
+    log.info(
+      `\n${pc.bold(pc.cyan("── System Prompt (CLAUDE.md) ──"))}\n${pc.dim(systemPrompt.trimEnd())}\n`,
+    );
   }
 
   // Log the resolved prompt being sent
   const promptPath = join(process.cwd(), opts.promptFile);
   if (fileExists(promptPath)) {
     const promptContent = readFile(promptPath);
-    log.info(`\n${pc.bold(pc.cyan(`── Prompt (${opts.promptFile}) ──`))}\n${pc.dim(promptContent.trimEnd())}\n`);
+    log.info(
+      `\n${pc.bold(pc.cyan(`── Prompt (${opts.promptFile}) ──`))}\n${pc.dim(promptContent.trimEnd())}\n`,
+    );
   }
 
   let lastError: Error | undefined;


### PR DESCRIPTION
## Summary
Enhanced the Claude CLI to display the system prompt (from `CLAUDE.md`) and the resolved prompt file content before executing Claude, improving visibility into what's being sent to the AI.

## Key Changes
- Added imports for `join` from `node:path` and file utility functions (`fileExists`, `readFile`)
- Added logging of `CLAUDE.md` system prompt if it exists in the current working directory
- Added logging of the resolved prompt file content before Claude execution
- Both prompts are displayed with formatted headers and dimmed text for better readability

## Implementation Details
- System prompt is auto-loaded from `CLAUDE.md` in the project root (matching Claude Code's behavior)
- Prompt file path is resolved relative to the current working directory using `opts.promptFile`
- Both file existence checks prevent errors if files don't exist
- Output uses `picocolors` for consistent styling with cyan headers and dimmed content
- Logging occurs after the initial "Calling Claude" message but before the retry loop

https://claude.ai/code/session_018XrjyUBiSsroFYrXdRkPsV