### PR TITLE
feat(agentboard): add remote execution mode via claude --remote

### DIFF
--- a/plugins/tt-agentboard/app/components/board/NewCardForm.vue
+++ b/plugins/tt-agentboard/app/components/board/NewCardForm.vue
@@ -18,7 +18,7 @@ const emit = defineEmits<{
 const prompt = ref(props.initialTitle ?? "");
 const repoId = ref<number | undefined>(undefined);
 const workflowId = ref<string | undefined>(undefined);
-const executionMode = ref<"headless" | "interactive">("headless");
+const executionMode = ref<"headless" | "interactive" | "remote">("headless");
 const branchMode = ref<"create" | "current">("create");
 const startColumn = ref<"ready">("ready");
 const submitting = ref(false);
@@ -35,7 +35,7 @@ interface CardTemplate {
   name: string;
   description: string;
   prompt: string;
-  executionMode: "headless" | "interactive";
+  executionMode: "headless" | "interactive" | "remote";
   branchMode: "create" | "current";
   column: "ready";
 }
@@ -318,12 +318,26 @@ async function submit() {
             >
               ⌨ Interactive
             </button>
+            <button
+              type="button"
+              class="flex-1 rounded-lg border px-3 py-2 text-xs font-medium transition-colors"
+              :class="
+                executionMode === 'remote'
+                  ? 'border-blue-500 bg-blue-500/10 text-blue-400'
+                  : 'border-zinc-700 bg-zinc-800 text-zinc-400 hover:border-zinc-600'
+              "
+              @click="executionMode = 'remote'"
+            >
+              ☁ Remote
+            </button>
           </div>
           <p class="mt-1.5 text-[11px] text-zinc-600">
             {{
               executionMode === "headless"
                 ? "Runs autonomously with --dangerously-skip-permissions."
-                : "Runs in tmux — attach to interact with the agent."
+                : executionMode === "interactive"
+                  ? "Runs in tmux — attach to interact with the agent."
+                  : "Runs on Anthropic cloud via claude --remote. No local slot needed."
             }}
           </p>
         </div>

--- a/plugins/tt-agentboard/app/stores/cards.ts
+++ b/plugins/tt-agentboard/app/stores/cards.ts
@@ -15,7 +15,7 @@ export interface Card {
   repoId: number | null;
   column: Column;
   position: number;
-  executionMode: "headless" | "interactive";
+  executionMode: "headless" | "interactive" | "remote";
   status: CardStatus;
   planId: number | null;
   dependsOn: number[];

--- a/plugins/tt-agentboard/server/api/cards/templates.get.ts
+++ b/plugins/tt-agentboard/server/api/cards/templates.get.ts
@@ -6,7 +6,7 @@ interface CardTemplate {
   name: string;
   description: string;
   prompt: string;
-  executionMode: "headless" | "interactive";
+  executionMode: "headless" | "interactive" | "remote";
   branchMode: "create" | "current";
   column: "ready";
 }

--- a/plugins/tt-agentboard/server/domains/cards/schema.ts
+++ b/plugins/tt-agentboard/server/domains/cards/schema.ts
@@ -41,7 +41,9 @@ export const cards = sqliteTable("cards", {
     enum: ["backlog", "ready", "in_progress", "simplify_review", "review", "done"],
   }).default("ready"),
   position: integer("position").notNull().default(0),
-  executionMode: text("execution_mode", { enum: ["headless", "interactive"] }).default("headless"),
+  executionMode: text("execution_mode", { enum: ["headless", "interactive", "remote"] }).default(
+    "headless",
+  ),
   branchMode: text("branch_mode", { enum: ["create", "current"] }).default("create"),
   status: text("status", {
     enum: [

--- a/plugins/tt-agentboard/server/domains/execution/agent-executor.ts
+++ b/plugins/tt-agentboard/server/domains/execution/agent-executor.ts
@@ -15,6 +15,8 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { buildAgentBranchName, buildStreamingCommand, getCardLogPath } from "./workflow-helpers";
 import { cardService as defaultCardService } from "../cards/card-service";
+import { remoteExecutor as defaultRemoteExecutor } from "./remote-executor";
+import type { RemoteExecutor } from "./remote-executor";
 import type { CardService } from "../cards/card-service";
 import type { SlotPreparer } from "./slot-preparer";
 import type { Logger, EventBus } from "./types";
@@ -44,6 +46,7 @@ export interface AgentExecutorDeps {
   mkdirSync: typeof mkdirSync;
   writeFileSync: typeof writeFileSync;
   ttydManager: Pick<TtydManager, "isAvailable" | "attach">;
+  remoteExecutor: Pick<RemoteExecutor, "startExecution">;
 }
 
 /**
@@ -73,6 +76,7 @@ export class AgentExecutor {
       mkdirSync,
       writeFileSync,
       ttydManager: defaultTtydManager,
+      remoteExecutor: defaultRemoteExecutor,
       ...deps,
     };
   }
@@ -116,6 +120,12 @@ export class AgentExecutor {
         "workflow_not_found",
         `workflow=${card.workflowId}, falling back to single-prompt`,
       );
+    }
+
+    // Remote execution — no local slot/tmux needed
+    if (card.executionMode === "remote") {
+      await this.deps.remoteExecutor.startExecution(cardId);
+      return;
     }
 
     // Single-prompt execution (no workflow)

--- a/plugins/tt-agentboard/server/domains/execution/remote-executor.ts
+++ b/plugins/tt-agentboard/server/domains/execution/remote-executor.ts
@@ -1,0 +1,106 @@
+import { execSync as defaultExecSync } from "node:child_process";
+import { db as defaultDb } from "../../shared/db";
+import { cards, workflowRuns } from "../../shared/db/schema";
+import { eq } from "drizzle-orm";
+import { eventBus as defaultEventBus } from "../../shared/event-bus";
+import { logger as defaultLogger } from "../../utils/logger";
+import { cardService as defaultCardService } from "../cards/card-service";
+import type { CardService } from "../cards/card-service";
+import type { Logger, EventBus } from "./types";
+
+export interface RemoteExecutorDeps {
+  db: typeof defaultDb;
+  eventBus: EventBus;
+  logger: Logger;
+  cardService: CardService;
+  execSync: typeof defaultExecSync;
+}
+
+const SESSION_ID_RE = /Resume with: claude --teleport (session_\w+)/;
+const SESSION_URL_RE = /View: (https:\/\/claude\.ai\/code\/\S+)/;
+
+export class RemoteExecutor {
+  private deps: RemoteExecutorDeps;
+
+  constructor(deps: Partial<RemoteExecutorDeps> = {}) {
+    this.deps = {
+      db: defaultDb,
+      eventBus: defaultEventBus,
+      logger: defaultLogger,
+      cardService: defaultCardService,
+      execSync: defaultExecSync,
+      ...deps,
+    };
+  }
+
+  async startExecution(cardId: number): Promise<void> {
+    const cardRows = await this.deps.db.select().from(cards).where(eq(cards.id, cardId));
+    if (cardRows.length === 0) {
+      this.deps.logger.error(`Card ${cardId} not found`);
+      return;
+    }
+    const card = cardRows[0]!;
+
+    if (!card.repoId) {
+      await this.deps.cardService.logEvent(cardId, "error", "No repo assigned");
+      await this.deps.cardService.updateStatus(cardId, "failed");
+      return;
+    }
+
+    await this.deps.cardService.updateStatus(cardId, "running");
+
+    const prompt = card.description ?? card.title;
+
+    let stdout: string;
+    try {
+      stdout = this.deps
+        .execSync(`claude --remote "${prompt.replace(/"/g, '\\"')}"`, {
+          encoding: "utf-8",
+          timeout: 30_000,
+        })
+        .toString();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await this.deps.cardService.logEvent(cardId, "error", `claude --remote failed: ${msg}`);
+      await this.deps.cardService.updateStatus(cardId, "failed");
+      return;
+    }
+
+    const sessionIdMatch = stdout.match(SESSION_ID_RE);
+    const sessionUrlMatch = stdout.match(SESSION_URL_RE);
+
+    if (!sessionIdMatch) {
+      await this.deps.cardService.logEvent(
+        cardId,
+        "error",
+        `Could not parse session ID from claude --remote output`,
+      );
+      await this.deps.cardService.updateStatus(cardId, "failed");
+      return;
+    }
+
+    const remoteSessionId = sessionIdMatch[1]!;
+    const remoteSessionUrl = sessionUrlMatch?.[1] ?? null;
+
+    await this.deps.db
+      .insert(workflowRuns)
+      .values({
+        cardId,
+        workflowId: "remote",
+        remoteSessionId,
+        remoteSessionUrl,
+        startedAt: new Date(),
+      })
+      .returning();
+
+    await this.deps.cardService.logEvent(
+      cardId,
+      "remote_session_created",
+      `sessionId=${remoteSessionId}${remoteSessionUrl ? `, url=${remoteSessionUrl}` : ""}`,
+    );
+
+    this.deps.logger.info(`Card ${cardId} remote session started: ${remoteSessionId}`);
+  }
+}
+
+export const remoteExecutor = new RemoteExecutor();

--- a/plugins/tt-agentboard/server/domains/execution/schema.ts
+++ b/plugins/tt-agentboard/server/domains/execution/schema.ts
@@ -24,6 +24,8 @@ export const workflowRuns = sqliteTable("workflow_runs", {
   workflowId: text("workflow_id").notNull(),
   slotId: integer("slot_id").references(() => workspaceSlots.id, { onDelete: "set null" }),
   tmuxSession: text("tmux_session"),
+  remoteSessionId: text("remote_session_id"),
+  remoteSessionUrl: text("remote_session_url"),
   branch: text("branch"),
   startedAt: integer("started_at", { mode: "timestamp" }),
   endedAt: integer("ended_at", { mode: "timestamp" }),

--- a/plugins/tt-agentboard/server/plugins/remote-poll.ts
+++ b/plugins/tt-agentboard/server/plugins/remote-poll.ts
@@ -1,0 +1,103 @@
+import { db as defaultDb } from "../shared/db";
+import { workflowRuns } from "../shared/db/schema";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { logger as defaultLogger } from "../utils/logger";
+import { execSync as defaultExecSync } from "node:child_process";
+import { cardService as defaultCardService } from "../domains/cards/card-service";
+import { eventBus as defaultEventBus } from "../shared/event-bus";
+import type { CardService } from "../domains/cards/card-service";
+
+export interface RemotePollDeps {
+  db: typeof defaultDb;
+  logger: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void };
+  cardService: CardService;
+  eventBus: { emit: (event: string, data: unknown) => void };
+  execSync: typeof defaultExecSync;
+  pollIntervalMs: number;
+}
+
+export function checkRemoteSessionStatus(
+  sessionId: string,
+  execSync: typeof defaultExecSync,
+): "running" | "completed" | "failed" | "unknown" {
+  try {
+    const output = execSync(`claude sessions list --json`, {
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    const sessions = JSON.parse(output) as Array<{ id: string; status: string }>;
+    const session = sessions.find((s) => s.id === sessionId);
+    if (!session) return "unknown";
+    if (session.status === "completed" || session.status === "done") return "completed";
+    if (session.status === "failed" || session.status === "error") return "failed";
+    return "running";
+  } catch {
+    return "unknown";
+  }
+}
+
+export async function pollRemoteSessions(deps: RemotePollDeps): Promise<void> {
+  const running = await deps.db
+    .select()
+    .from(workflowRuns)
+    .where(and(isNotNull(workflowRuns.remoteSessionId), eq(workflowRuns.status, "running")));
+
+  if (running.length === 0) return;
+
+  deps.logger.info(`Remote poll: checking ${running.length} remote session(s)`);
+
+  for (const run of running) {
+    const status = checkRemoteSessionStatus(run.remoteSessionId!, deps.execSync);
+
+    if (status === "completed") {
+      await deps.db
+        .update(workflowRuns)
+        .set({ status: "completed", endedAt: new Date() })
+        .where(eq(workflowRuns.id, run.id));
+      await deps.cardService.markComplete(run.cardId);
+      await deps.cardService.logEvent(
+        run.cardId,
+        "remote_session_completed",
+        `sessionId=${run.remoteSessionId}`,
+      );
+      deps.eventBus.emit("workflow:completed", { cardId: run.cardId, status: "completed" });
+      deps.logger.info(`Remote session ${run.remoteSessionId} completed for card ${run.cardId}`);
+    } else if (status === "failed") {
+      await deps.db
+        .update(workflowRuns)
+        .set({ status: "failed", endedAt: new Date() })
+        .where(eq(workflowRuns.id, run.id));
+      await deps.cardService.updateStatus(run.cardId, "failed");
+      await deps.cardService.logEvent(
+        run.cardId,
+        "remote_session_failed",
+        `sessionId=${run.remoteSessionId}`,
+      );
+      deps.logger.info(`Remote session ${run.remoteSessionId} failed for card ${run.cardId}`);
+    }
+    // "running" and "unknown" — no action, check again next poll
+  }
+}
+
+export default defineNitroPlugin(() => {
+  const deps: RemotePollDeps = {
+    db: defaultDb,
+    logger: defaultLogger,
+    cardService: defaultCardService,
+    eventBus: defaultEventBus,
+    execSync: defaultExecSync,
+    pollIntervalMs: 30_000,
+  };
+
+  const interval = setInterval(() => {
+    pollRemoteSessions(deps).catch((err) => {
+      defaultLogger.warn(`Remote poll error: ${err}`);
+    });
+  }, deps.pollIntervalMs);
+
+  // Nitro doesn't provide cleanup hooks natively, but the interval
+  // will be cleared when the process exits
+  if (typeof globalThis !== "undefined") {
+    (globalThis as Record<string, unknown>).__remotePollInterval = interval;
+  }
+});

--- a/plugins/tt-agentboard/test/helpers/mock-deps.ts
+++ b/plugins/tt-agentboard/test/helpers/mock-deps.ts
@@ -99,6 +99,13 @@ export function createMockCardService() {
 
 export type MockCardService = ReturnType<typeof createMockCardService>;
 
+/** Create a mock RemoteExecutor */
+export function createMockRemoteExecutor() {
+  return {
+    startExecution: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 /** Create a mock WorkflowRunner */
 export function createMockWorkflowRunner() {
   return {

--- a/plugins/tt-agentboard/test/plugins/remote-poll.test.ts
+++ b/plugins/tt-agentboard/test/plugins/remote-poll.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { pollRemoteSessions, checkRemoteSessionStatus } from "../../server/plugins/remote-poll";
+import {
+  createMockDb,
+  createMockEventBus,
+  createMockLogger,
+  createMockCardService,
+} from "../helpers/mock-deps";
+import type { MockDb } from "../helpers/mock-deps";
+import type { RemotePollDeps } from "../../server/plugins/remote-poll";
+
+function setupRunningRemoteSessions(mockDb: MockDb, sessions: unknown[]) {
+  const selectChain: Record<string, unknown> = {};
+  selectChain.from = vi.fn().mockReturnValue(selectChain);
+  selectChain.where = vi.fn().mockResolvedValue(sessions);
+  mockDb.select = vi.fn().mockReturnValue(selectChain);
+}
+
+function setupUpdate(mockDb: MockDb) {
+  const updateChain: Record<string, unknown> = {};
+  updateChain.set = vi.fn().mockReturnValue(updateChain);
+  updateChain.where = vi.fn().mockResolvedValue(undefined);
+  mockDb.update = vi.fn().mockReturnValue(updateChain);
+}
+
+describe("remote-poll", () => {
+  describe("checkRemoteSessionStatus", () => {
+    it("returns completed for finished sessions", () => {
+      const mockExecSync = vi
+        .fn()
+        .mockReturnValue(JSON.stringify([{ id: "session_abc", status: "completed" }]));
+      expect(checkRemoteSessionStatus("session_abc", mockExecSync as never)).toBe("completed");
+    });
+
+    it("returns running for active sessions", () => {
+      const mockExecSync = vi
+        .fn()
+        .mockReturnValue(JSON.stringify([{ id: "session_abc", status: "running" }]));
+      expect(checkRemoteSessionStatus("session_abc", mockExecSync as never)).toBe("running");
+    });
+
+    it("returns failed for errored sessions", () => {
+      const mockExecSync = vi
+        .fn()
+        .mockReturnValue(JSON.stringify([{ id: "session_abc", status: "failed" }]));
+      expect(checkRemoteSessionStatus("session_abc", mockExecSync as never)).toBe("failed");
+    });
+
+    it("returns unknown when session not found", () => {
+      const mockExecSync = vi.fn().mockReturnValue(JSON.stringify([]));
+      expect(checkRemoteSessionStatus("session_abc", mockExecSync as never)).toBe("unknown");
+    });
+
+    it("returns unknown when execSync throws", () => {
+      const mockExecSync = vi.fn().mockImplementation(() => {
+        throw new Error("command failed");
+      });
+      expect(checkRemoteSessionStatus("session_abc", mockExecSync as never)).toBe("unknown");
+    });
+  });
+
+  describe("pollRemoteSessions", () => {
+    function createDeps(overrides: Partial<RemotePollDeps> = {}): RemotePollDeps & {
+      mockDb: MockDb;
+      mockCardService: ReturnType<typeof createMockCardService>;
+    } {
+      const mockDb = createMockDb();
+      const mockCardService = createMockCardService();
+      return {
+        db: mockDb as never,
+        logger: createMockLogger(),
+        cardService: mockCardService as never,
+        eventBus: createMockEventBus(),
+        execSync: vi.fn() as never,
+        pollIntervalMs: 1000,
+        mockDb,
+        mockCardService,
+        ...overrides,
+      };
+    }
+
+    it("does nothing when no running remote sessions", async () => {
+      const deps = createDeps();
+      setupRunningRemoteSessions(deps.mockDb, []);
+
+      await pollRemoteSessions(deps);
+
+      expect(deps.mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("marks completed sessions", async () => {
+      const mockExecSync = vi
+        .fn()
+        .mockReturnValue(JSON.stringify([{ id: "session_abc", status: "completed" }]));
+      const deps = createDeps({ execSync: mockExecSync as never });
+      setupRunningRemoteSessions(deps.mockDb, [
+        { id: 1, cardId: 42, remoteSessionId: "session_abc", status: "running" },
+      ]);
+      setupUpdate(deps.mockDb);
+
+      await pollRemoteSessions(deps);
+
+      expect(deps.mockCardService.markComplete).toHaveBeenCalledWith(42);
+    });
+
+    it("marks failed sessions", async () => {
+      const mockExecSync = vi
+        .fn()
+        .mockReturnValue(JSON.stringify([{ id: "session_abc", status: "failed" }]));
+      const deps = createDeps({ execSync: mockExecSync as never });
+      setupRunningRemoteSessions(deps.mockDb, [
+        { id: 1, cardId: 42, remoteSessionId: "session_abc", status: "running" },
+      ]);
+      setupUpdate(deps.mockDb);
+
+      await pollRemoteSessions(deps);
+
+      expect(deps.mockCardService.updateStatus).toHaveBeenCalledWith(42, "failed");
+    });
+
+    it("skips sessions still running", async () => {
+      const mockExecSync = vi
+        .fn()
+        .mockReturnValue(JSON.stringify([{ id: "session_abc", status: "running" }]));
+      const deps = createDeps({ execSync: mockExecSync as never });
+      setupRunningRemoteSessions(deps.mockDb, [
+        { id: 1, cardId: 42, remoteSessionId: "session_abc", status: "running" },
+      ]);
+
+      await pollRemoteSessions(deps);
+
+      expect(deps.mockDb.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/plugins/tt-agentboard/test/services/agent-executor.test.ts
+++ b/plugins/tt-agentboard/test/services/agent-executor.test.ts
@@ -9,6 +9,7 @@ import {
   createMockSlotAllocator,
   createMockWorkflowLoader,
   createMockWorkflowOrchestrator,
+  createMockRemoteExecutor,
   createMockExecSync,
   createMockCardService,
   setupSelectReturning,
@@ -27,6 +28,7 @@ describe("AgentExecutor", () => {
   let mockWorkflowOrchestrator: ReturnType<typeof createMockWorkflowOrchestrator>;
   let mockWriteHooks: ReturnType<typeof vi.fn>;
   let mockCardService: ReturnType<typeof createMockCardService>;
+  let mockRemoteExecutor: ReturnType<typeof createMockRemoteExecutor>;
 
   beforeEach(() => {
     mockDb = createMockDb();
@@ -37,6 +39,7 @@ describe("AgentExecutor", () => {
     mockWorkflowOrchestrator = createMockWorkflowOrchestrator();
     mockWriteHooks = vi.fn();
     mockCardService = createMockCardService();
+    mockRemoteExecutor = createMockRemoteExecutor();
 
     executor = new AgentExecutor(4200, {
       db: mockDb as never,
@@ -52,6 +55,7 @@ describe("AgentExecutor", () => {
       existsSync: vi.fn().mockReturnValue(false) as never,
       mkdirSync: vi.fn() as never,
       writeFileSync: vi.fn() as never,
+      remoteExecutor: mockRemoteExecutor as never,
     });
     vi.clearAllMocks();
   });
@@ -86,6 +90,16 @@ describe("AgentExecutor", () => {
       await executor.startExecution(1);
 
       expect(mockWorkflowOrchestrator.run).toHaveBeenCalledWith(1);
+    });
+
+    it("delegates to remoteExecutor when executionMode is remote", async () => {
+      const card = { id: 1, repoId: 1, workflowId: null, title: "Test", executionMode: "remote" };
+      setupSelectReturning(mockDb, [card]);
+
+      await executor.startExecution(1);
+
+      expect(mockRemoteExecutor.startExecution).toHaveBeenCalledWith(1);
+      expect(mockTmuxManager.createSession).not.toHaveBeenCalled();
     });
 
     it("falls back to single prompt when workflow not found", async () => {

--- a/plugins/tt-agentboard/test/services/remote-executor.test.ts
+++ b/plugins/tt-agentboard/test/services/remote-executor.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { RemoteExecutor } from "../../server/domains/execution/remote-executor";
+import {
+  createMockDb,
+  createMockEventBus,
+  createMockLogger,
+  createMockCardService,
+  setupSelectReturning,
+  setupInsert,
+} from "../helpers/mock-deps";
+
+const CLAUDE_REMOTE_OUTPUT = `Created remote session: Test implementation and validation
+View: https://claude.ai/code/session_01CLmof84P5YY3MboTRacDLg?m=0
+Resume with: claude --teleport session_01CLmof84P5YY3MboTRacDLg
+`;
+
+describe("RemoteExecutor", () => {
+  function createExecutor(overrides: Record<string, unknown> = {}) {
+    const mockDb = createMockDb();
+    const mockCardService = createMockCardService();
+    const mockExecSync = vi.fn().mockReturnValue(CLAUDE_REMOTE_OUTPUT);
+
+    const executor = new RemoteExecutor({
+      db: mockDb as never,
+      eventBus: createMockEventBus(),
+      logger: createMockLogger(),
+      cardService: mockCardService as never,
+      execSync: mockExecSync as never,
+      ...overrides,
+    });
+
+    return { executor, mockDb, mockCardService, mockExecSync };
+  }
+
+  it("parses session ID and URL from claude --remote output", async () => {
+    const { executor, mockDb, mockCardService, mockExecSync } = createExecutor();
+    const card = { id: 1, repoId: 1, title: "Test", description: "Do stuff" };
+    setupSelectReturning(mockDb, [card]);
+    setupInsert(mockDb);
+
+    await executor.startExecution(1);
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("claude --remote"),
+      expect.objectContaining({ encoding: "utf-8" }),
+    );
+    expect(mockCardService.updateStatus).toHaveBeenCalledWith(1, "running");
+    expect(mockCardService.logEvent).toHaveBeenCalledWith(
+      1,
+      "remote_session_created",
+      expect.stringContaining("session_01CLmof84P5YY3MboTRacDLg"),
+    );
+  });
+
+  it("creates workflow run with remote session metadata", async () => {
+    const { executor, mockDb } = createExecutor();
+    const card = { id: 1, repoId: 1, title: "Test", description: "Do stuff" };
+    setupSelectReturning(mockDb, [card]);
+    setupInsert(mockDb);
+
+    await executor.startExecution(1);
+
+    expect(mockDb.insert).toHaveBeenCalled();
+  });
+
+  it("marks card failed when claude --remote throws", async () => {
+    const mockExecSync = vi.fn().mockImplementation(() => {
+      throw new Error("command not found");
+    });
+    const { executor, mockDb, mockCardService } = createExecutor({
+      execSync: mockExecSync as never,
+    });
+    const card = { id: 1, repoId: 1, title: "Test", description: "Do stuff" };
+    setupSelectReturning(mockDb, [card]);
+
+    await executor.startExecution(1);
+
+    expect(mockCardService.updateStatus).toHaveBeenCalledWith(1, "failed");
+    expect(mockCardService.logEvent).toHaveBeenCalledWith(
+      1,
+      "error",
+      expect.stringContaining("claude --remote failed"),
+    );
+  });
+
+  it("marks card failed when session ID cannot be parsed", async () => {
+    const mockExecSync = vi.fn().mockReturnValue("some unexpected output\n");
+    const { executor, mockDb, mockCardService } = createExecutor({
+      execSync: mockExecSync as never,
+    });
+    const card = { id: 1, repoId: 1, title: "Test", description: "Do stuff" };
+    setupSelectReturning(mockDb, [card]);
+
+    await executor.startExecution(1);
+
+    expect(mockCardService.updateStatus).toHaveBeenCalledWith(1, "failed");
+    expect(mockCardService.logEvent).toHaveBeenCalledWith(
+      1,
+      "error",
+      expect.stringContaining("Could not parse session ID"),
+    );
+  });
+
+  it("marks card failed when no repoId", async () => {
+    const { executor, mockDb, mockCardService } = createExecutor();
+    const card = { id: 1, repoId: null, title: "Test" };
+    setupSelectReturning(mockDb, [card]);
+
+    await executor.startExecution(1);
+
+    expect(mockCardService.updateStatus).toHaveBeenCalledWith(1, "failed");
+  });
+
+  it("uses card title when description is null", async () => {
+    const { executor, mockDb, mockExecSync } = createExecutor();
+    const card = { id: 1, repoId: 1, title: "Fix the bug", description: null };
+    setupSelectReturning(mockDb, [card]);
+    setupInsert(mockDb);
+
+    await executor.startExecution(1);
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("Fix the bug"),
+      expect.anything(),
+    );
+  });
+});

--- a/src/lib/auto-claude/claude-cli.ts
+++ b/src/lib/auto-claude/claude-cli.ts
@@ -60,14 +60,18 @@ export async function runClaude(opts: {
     log.info(
       `\n${pc.bold(pc.cyan("── System Prompt (CLAUDE.md) ──"))}\n${pc.dim(systemPrompt.trimEnd())}\n`,
     );
-  } catch { /* CLAUDE.md not present */ }
+  } catch {
+    /* CLAUDE.md not present */
+  }
 
   try {
     const promptContent = readFile(join(process.cwd(), opts.promptFile));
     log.info(
       `\n${pc.bold(pc.cyan(`── Prompt (${opts.promptFile}) ──`))}\n${pc.dim(promptContent.trimEnd())}\n`,
     );
-  } catch { /* prompt file not present */ }
+  } catch {
+    /* prompt file not present */
+  }
 
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= PROCESS_RETRIES; attempt++) {


### PR DESCRIPTION
## Summary
- Adds `"remote"` execution mode to AgentBoard that uses `claude --remote` instead of local tmux + slots
- New `RemoteExecutor` service parses session ID and URL from `claude --remote` stdout
- New `remote-poll` plugin polls running remote sessions for completion
- UI: added "Remote" button to execution mode selector in NewCardForm
- Schema: added `remoteSessionId` and `remoteSessionUrl` columns to `workflowRuns`

Closes #177

## Test plan
- [x] RemoteExecutor: parses session ID/URL, handles failures, uses title fallback (6 tests)
- [x] Remote poller: checks session status, marks completed/failed, skips running (9 tests)
- [x] AgentExecutor: delegates to remote executor for remote mode (1 test)
- [x] All 183 agentboard tests pass
- [x] All 269 main tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)