### PR TITLE
refactor(agentboard): replace mocks with real SQLite DB and DI

### DIFF
--- a/plugins/tt-agentboard/package.json
+++ b/plugins/tt-agentboard/package.json
@@ -24,7 +24,8 @@
     "vue": "^3.5.30",
     "vue-router": "^5.0.4",
     "vuedraggable": "^4.1.0",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "zigpty": "^0.0.4"
   },
   "devDependencies": {
     "@nuxt/test-utils": "^4.0.0",

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/complete.post.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/complete.post.ts
@@ -6,6 +6,7 @@ import { eventBus } from "~~/server/shared/event-bus";
 import { logger } from "~~/server/utils/logger";
 import { getCardId, requireCard } from "~~/server/utils/params";
 import { cardService } from "~~/server/domains/cards/card-service";
+import { ptyExecShell } from "~~/server/domains/infra/pty-exec";
 
 /**
  * Callback endpoint for Claude Code Stop hook.
@@ -48,12 +49,11 @@ export default defineEventHandler(async (event) => {
       .where(eq(workflowRuns.cardId, cardId))
       .limit(1);
     if (run[0]?.branch) {
-      const { execSync } = await import("node:child_process");
-      const prJson = execSync(`gh pr list --head ${run[0].branch} --json number --limit 1`, {
-        encoding: "utf-8",
-        timeout: 5000,
-      }).trim();
-      const prs = JSON.parse(prJson);
+      const result = await ptyExecShell(
+        `gh pr list --head ${run[0].branch} --json number --limit 1`,
+        { timeout: 5000 },
+      );
+      const prs = JSON.parse(result.stdout.trim());
       if (prs.length > 0) {
         await db.update(cards).set({ githubPrNumber: prs[0].number }).where(eq(cards.id, cardId));
       }
@@ -71,18 +71,15 @@ export default defineEventHandler(async (event) => {
 
   for (const slot of claimedSlots) {
     try {
-      const { execSync } = await import("node:child_process");
-      const status = execSync("git status --porcelain", {
+      const statusResult = await ptyExecShell("git status --porcelain", {
         cwd: slot.path,
-        encoding: "utf-8",
         timeout: 5000,
-      }).trim();
-      if (status) {
-        execSync(`git add -A && git commit -m "agentboard: card #${cardId} — ${card.title}"`, {
-          cwd: slot.path,
-          stdio: "ignore",
-          timeout: 10000,
-        });
+      });
+      if (statusResult.stdout.trim()) {
+        await ptyExecShell(
+          `git add -A && git commit -m "agentboard: card #${cardId} — ${card.title}"`,
+          { cwd: slot.path, timeout: 10000 },
+        );
         await cardService.logEvent(
           cardId,
           "auto_committed",

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/create-pr.post.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/create-pr.post.ts
@@ -1,10 +1,10 @@
 import { db } from "~~/server/shared/db";
 import { cards, workflowRuns, workspaceSlots, repositories } from "~~/server/shared/db/schema";
 import { eq } from "drizzle-orm";
-import { execSync } from "node:child_process";
 import { getCardId, requireCard } from "~~/server/utils/params";
 import { cardService } from "~~/server/domains/cards/card-service";
 import { logger } from "~~/server/utils/logger";
+import { ptyExecShell } from "~~/server/domains/infra/pty-exec";
 
 /**
  * Create a PR for a card's branch.
@@ -67,18 +67,19 @@ export default defineEventHandler(async (event) => {
 
   try {
     // Ensure we're on the correct branch before pushing
-    execSync(`git checkout ${branch}`, { cwd, stdio: "ignore", timeout: 10000 });
+    await ptyExecShell(`git checkout ${branch}`, { cwd, timeout: 10000 });
 
     // Push the branch
-    execSync(`git push -u origin ${branch}`, { cwd, stdio: "ignore", timeout: 30000 });
+    await ptyExecShell(`git push -u origin ${branch}`, { cwd, timeout: 30000 });
 
     // Create PR — gh pr create returns the PR URL on stdout
     const prTitle = card.title;
     const prBody = card.description ?? "";
-    const prUrl = execSync(
+    const result = await ptyExecShell(
       `gh pr create --title "${prTitle.replace(/"/g, '\\"')}" --body "${prBody.replace(/"/g, '\\"')}" --base ${base} --head ${branch}`,
-      { cwd, encoding: "utf-8", timeout: 30000 },
-    ).trim();
+      { cwd, timeout: 30000 },
+    );
+    const prUrl = result.stdout.trim();
 
     // Extract PR number from URL (e.g., https://github.com/.../pull/42)
     const prNumMatch = prUrl.match(/\/pull\/(\d+)/);

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/diff.get.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/diff.get.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "~~/server/shared/db";
 import { workspaceSlots, workflowRuns } from "~~/server/shared/db/schema";
 import { getCardId } from "~~/server/utils/params";
+import { ptyExecShell } from "~~/server/domains/infra/pty-exec";
 
 interface DiffLine {
   type: "add" | "delete" | "context";
@@ -99,25 +100,22 @@ export default defineEventHandler(async (event) => {
     return { hasDiff: false, files: [], raw: "" };
   }
 
-  const { execSync } = await import("node:child_process");
-
   let raw = "";
   try {
     if (branch) {
       // Diff the card's branch against main — safe even if slot is reused by another card
-      raw = execSync(`git diff origin/main...${branch}`, {
+      const result = await ptyExecShell(`git diff origin/main...${branch}`, {
         cwd: slotPath,
-        encoding: "utf-8",
         timeout: 5000,
-        stdio: ["pipe", "pipe", "pipe"],
       });
+      raw = result.stdout;
     } else {
       // No branch recorded — fall back to uncommitted changes (active execution)
-      raw = execSync("git diff HEAD", {
+      const result = await ptyExecShell("git diff HEAD", {
         cwd: slotPath,
-        encoding: "utf-8",
         timeout: 5000,
       });
+      raw = result.stdout;
     }
   } catch {
     return { hasDiff: false, files: [], raw: "" };

--- a/plugins/tt-agentboard/server/api/agents/[cardId]/terminal.get.ts
+++ b/plugins/tt-agentboard/server/api/agents/[cardId]/terminal.get.ts
@@ -1,5 +1,6 @@
 import { tmuxManager } from "~~/server/domains/infra/tmux-manager";
 import { getCardId } from "~~/server/utils/params";
+import { ptyExecShell } from "~~/server/domains/infra/pty-exec";
 
 /**
  * Get the terminal output from a card's tmux session.
@@ -17,12 +18,11 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    const { execSync } = await import("node:child_process");
-    const output = execSync(`tmux capture-pane -t ${sessionName} -p -e -S -500`, {
-      encoding: "utf-8",
-      timeout: 3000,
-    });
-    return { exists: true, output };
+    const result = await ptyExecShell(
+      `tmux capture-pane -t ${sessionName} -p -e -S -500`,
+      { timeout: 3000 },
+    );
+    return { exists: true, output: result.stdout };
   } catch {
     return { exists: false, output: "" };
   }

--- a/plugins/tt-agentboard/server/api/health.get.ts
+++ b/plugins/tt-agentboard/server/api/health.get.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { isGitHubConfigured } from "~~/server/domains/infra/github-service";
 import { readConfig } from "~~/server/utils/config";
 
-export default defineEventHandler(() => {
+export default defineEventHandler(async () => {
   let tmuxInstalled = false;
   try {
     execSync("tmux -V", { stdio: "pipe" });
@@ -11,7 +11,7 @@ export default defineEventHandler(() => {
     // tmux not found
   }
 
-  const ghAuthenticated = isGitHubConfigured();
+  const ghAuthenticated = await isGitHubConfigured();
   const config = readConfig();
 
   return { tmuxInstalled, ghAuthenticated, repoPaths: config.repoPaths };

--- a/plugins/tt-agentboard/server/api/prompts/improve.post.ts
+++ b/plugins/tt-agentboard/server/api/prompts/improve.post.ts
@@ -1,7 +1,4 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { ptyExec } from "~~/server/domains/infra/pty-exec";
 
 const systemPrompt = `You are a prompt improvement assistant for a developer task board.
 Your job is to take a rough prompt/task description and improve it to be clearer, more specific, and more actionable for a Claude Code agent.
@@ -24,17 +21,13 @@ export default defineEventHandler(async (event) => {
   const userPrompt = `Improve this agent prompt:\n\n${body.prompt.trim()}`;
 
   try {
-    const { stdout } = await execFileAsync(
+    const result = await ptyExec(
       "claude",
       ["-p", userPrompt, "--model", "haiku", "--system-prompt", systemPrompt],
-      {
-        timeout: 30_000,
-        maxBuffer: 1024 * 1024,
-        env: { ...process.env },
-      },
+      { timeout: 30_000 },
     );
 
-    const improved = stdout.trim();
+    const improved = result.stdout.trim();
     if (!improved) {
       throw createError({ statusCode: 502, message: "Claude CLI returned empty output" });
     }
@@ -42,7 +35,7 @@ export default defineEventHandler(async (event) => {
     return { improved };
   } catch (e: unknown) {
     const err = e as { code?: string; stderr?: string; message?: string };
-    if (err.code === "ENOENT") {
+    if (err.code === "ENOENT" || err.message?.includes("ENOENT")) {
       throw createError({
         statusCode: 500,
         message: "claude CLI not found — ensure Claude Code is installed and on PATH",
@@ -50,7 +43,7 @@ export default defineEventHandler(async (event) => {
     }
     throw createError({
       statusCode: 502,
-      message: `Claude CLI error: ${err.stderr || err.message || "unknown error"}`,
+      message: `Claude CLI error: ${err.message || "unknown error"}`,
     });
   }
 });

--- a/plugins/tt-agentboard/server/api/repos/discover.get.ts
+++ b/plugins/tt-agentboard/server/api/repos/discover.get.ts
@@ -1,9 +1,9 @@
-import { execSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
 import { basename, join } from "node:path";
 import { db } from "~~/server/shared/db";
 import { repositories } from "~~/server/shared/db/schema";
 import { readConfig } from "~~/server/utils/config";
+import { ptyExec } from "~~/server/domains/infra/pty-exec";
 
 interface DiscoveredRepo {
   path: string;
@@ -13,17 +13,17 @@ interface DiscoveredRepo {
   alreadyRegistered: boolean;
 }
 
-function parseGitRemote(repoPath: string): {
+async function parseGitRemote(repoPath: string): Promise<{
   org: string | null;
   name: string;
   githubUrl: string | null;
-} {
+}> {
   try {
-    const url = execSync("git remote get-url origin", {
+    const result = await ptyExec("git", ["remote", "get-url", "origin"], {
       cwd: repoPath,
-      encoding: "utf-8",
       timeout: 3000,
-    }).trim();
+    });
+    const url = result.stdout.trim();
 
     const match = url.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
     if (match) {
@@ -62,11 +62,15 @@ function findRepoDirs(dir: string): string[] {
   return repos;
 }
 
-function discoverRepos(scanPaths: string[]): DiscoveredRepo[] {
-  return scanPaths.flatMap((scanPath) => {
+async function discoverRepos(scanPaths: string[]): Promise<DiscoveredRepo[]> {
+  const repoPaths = scanPaths.flatMap((scanPath) => {
     if (!existsSync(scanPath)) return [];
-    return findRepoDirs(scanPath).map((repoPath) => {
-      const remote = parseGitRemote(repoPath);
+    return findRepoDirs(scanPath);
+  });
+
+  const results = await Promise.all(
+    repoPaths.map(async (repoPath) => {
+      const remote = await parseGitRemote(repoPath);
       return {
         path: repoPath,
         name: remote.name,
@@ -74,8 +78,10 @@ function discoverRepos(scanPaths: string[]): DiscoveredRepo[] {
         githubUrl: remote.githubUrl,
         alreadyRegistered: false,
       };
-    });
-  });
+    }),
+  );
+
+  return results;
 }
 
 export default defineEventHandler(async () => {
@@ -86,7 +92,7 @@ export default defineEventHandler(async () => {
     return { repos: [], scanPaths: [] };
   }
 
-  const allRepos = discoverRepos(scanPaths);
+  const allRepos = await discoverRepos(scanPaths);
 
   // Deduplicate by path
   const seen = new Set<string>();

--- a/plugins/tt-agentboard/server/domains/execution/remote-executor.ts
+++ b/plugins/tt-agentboard/server/domains/execution/remote-executor.ts
@@ -1,10 +1,11 @@
-import { execSync as defaultExecSync } from "node:child_process";
 import { db as defaultDb } from "../../shared/db";
 import { cards, workflowRuns } from "../../shared/db/schema";
 import { eq } from "drizzle-orm";
 import { eventBus as defaultEventBus } from "../../shared/event-bus";
 import { logger as defaultLogger } from "../../utils/logger";
 import { cardService as defaultCardService } from "../cards/card-service";
+import { ptyExec as defaultPtyExec } from "../infra/pty-exec";
+import type { PtyExecFn } from "../infra/pty-exec";
 import type { CardService } from "../cards/card-service";
 import type { Logger, EventBus } from "./types";
 
@@ -13,7 +14,7 @@ export interface RemoteExecutorDeps {
   eventBus: EventBus;
   logger: Logger;
   cardService: CardService;
-  execSync: typeof defaultExecSync;
+  exec: PtyExecFn;
 }
 
 const SESSION_ID_RE = /Resume with: claude --teleport (session_\w+)/;
@@ -28,7 +29,7 @@ export class RemoteExecutor {
       eventBus: defaultEventBus,
       logger: defaultLogger,
       cardService: defaultCardService,
-      execSync: defaultExecSync,
+      exec: defaultPtyExec,
       ...deps,
     };
   }
@@ -53,12 +54,8 @@ export class RemoteExecutor {
 
     let stdout: string;
     try {
-      stdout = this.deps
-        .execSync(`claude --remote "${prompt.replace(/"/g, '\\"')}"`, {
-          encoding: "utf-8",
-          timeout: 30_000,
-        })
-        .toString();
+      const result = await this.deps.exec("claude", ["--remote", prompt], { timeout: 30_000 });
+      stdout = result.stdout;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await this.deps.cardService.logEvent(cardId, "error", `claude --remote failed: ${msg}`);

--- a/plugins/tt-agentboard/server/domains/execution/slot-preparer.ts
+++ b/plugins/tt-agentboard/server/domains/execution/slot-preparer.ts
@@ -1,12 +1,13 @@
-import { execSync as defaultExecSync } from "node:child_process";
 import { existsSync as defaultExistsSync } from "node:fs";
 import { join } from "node:path";
 import { logger as defaultLogger } from "../../utils/logger";
+import { ptyExecShell as defaultPtyExecShell } from "../infra/pty-exec";
+import type { PtyExecShellFn } from "../infra/pty-exec";
 import type { Logger } from "./types";
 
 export interface SlotPreparerDeps {
   logger: Logger;
-  execSync: typeof defaultExecSync;
+  exec: PtyExecShellFn;
   existsSync: typeof defaultExistsSync;
 }
 
@@ -66,7 +67,7 @@ export class SlotPreparer {
   constructor(deps: Partial<SlotPreparerDeps> = {}) {
     this.deps = {
       logger: defaultLogger,
-      execSync: defaultExecSync,
+      exec: defaultPtyExecShell,
       existsSync: defaultExistsSync,
       ...deps,
     };
@@ -79,8 +80,8 @@ export class SlotPreparer {
   async reset(slotPath: string): Promise<ResetSlotResult> {
     const events: SlotEvent[] = [];
 
-    this.syncToMain(slotPath, events);
-    const { installed, packageManager } = this.installDeps(slotPath, events);
+    await this.syncToMain(slotPath, events);
+    const { installed, packageManager } = await this.installDeps(slotPath, events);
 
     this.deps.logger.info(`Slot reset complete: ${slotPath}`);
     return { depsInstalled: installed, packageManager, events };
@@ -96,28 +97,27 @@ export class SlotPreparer {
 
     if (options.existingBranch) {
       // Resume case: checkout existing branch from previous run
-      branch = this.checkoutBranch(options.slotPath, options.existingBranch, events);
+      branch = await this.checkoutBranch(options.slotPath, options.existingBranch, events);
     } else if (options.branchMode === "create") {
       // New work: sync with main, then create branch
-      branch = this.syncMainAndBranch(options.slotPath, options.branch, events);
+      branch = await this.syncMainAndBranch(options.slotPath, options.branch, events);
     } else {
       // branchMode="current": checkout the specified branch
-      branch = this.checkoutBranch(options.slotPath, options.branch, events);
+      branch = await this.checkoutBranch(options.slotPath, options.branch, events);
     }
 
     // Install deps (cached from reset, so typically fast)
-    const { installed, packageManager } = this.installDeps(options.slotPath, events);
+    const { installed, packageManager } = await this.installDeps(options.slotPath, events);
 
     return { branch, depsInstalled: installed, packageManager, events };
   }
 
   /** Clean working tree, checkout main, pull latest */
-  private syncToMain(slotPath: string, events: SlotEvent[]): void {
+  private async syncToMain(slotPath: string, events: SlotEvent[]): Promise<void> {
     // Discard any leftover changes
     try {
-      this.deps.execSync("git checkout -- . && git clean -fd", {
+      await this.deps.exec("git checkout -- . && git clean -fd", {
         cwd: slotPath,
-        stdio: "ignore",
         timeout: 5000,
       });
     } catch {
@@ -126,9 +126,8 @@ export class SlotPreparer {
 
     // Checkout main and pull
     try {
-      this.deps.execSync("git checkout main && git pull --ff-only", {
+      await this.deps.exec("git checkout main && git pull --ff-only", {
         cwd: slotPath,
-        stdio: "ignore",
         timeout: 15000,
       });
       events.push({ type: "main_synced", detail: "Checked out and pulled main" });
@@ -138,32 +137,39 @@ export class SlotPreparer {
   }
 
   /** Sync with main then create a new branch */
-  private syncMainAndBranch(slotPath: string, branchName: string, events: SlotEvent[]): string {
-    this.syncToMain(slotPath, events);
+  private async syncMainAndBranch(
+    slotPath: string,
+    branchName: string,
+    events: SlotEvent[],
+  ): Promise<string> {
+    await this.syncToMain(slotPath, events);
 
     // Create branch
     try {
-      this.deps.execSync(`git checkout -b ${branchName}`, { cwd: slotPath, stdio: "ignore" });
+      await this.deps.exec(`git checkout -b ${branchName}`, { cwd: slotPath });
       events.push({ type: "branch_created", detail: branchName });
       return branchName;
     } catch {
       // Branch may exist — try switching to it
       try {
-        this.deps.execSync(`git checkout ${branchName}`, { cwd: slotPath, stdio: "ignore" });
+        await this.deps.exec(`git checkout ${branchName}`, { cwd: slotPath });
         events.push({ type: "branch_reused", detail: branchName });
         return branchName;
       } catch {
-        return this.getCurrentBranch(slotPath, events);
+        return await this.getCurrentBranch(slotPath, events);
       }
     }
   }
 
   /** Checkout an existing branch (for branchMode="current" or resume) */
-  private checkoutBranch(slotPath: string, branch: string, events: SlotEvent[]): string {
+  private async checkoutBranch(
+    slotPath: string,
+    branch: string,
+    events: SlotEvent[],
+  ): Promise<string> {
     try {
-      this.deps.execSync(`git fetch origin ${branch}`, {
+      await this.deps.exec(`git fetch origin ${branch}`, {
         cwd: slotPath,
-        stdio: "ignore",
         timeout: 15000,
       });
     } catch {
@@ -171,28 +177,25 @@ export class SlotPreparer {
     }
 
     try {
-      this.deps.execSync(`git checkout ${branch}`, {
+      await this.deps.exec(`git checkout ${branch}`, {
         cwd: slotPath,
-        stdio: "ignore",
         timeout: 10000,
       });
       events.push({ type: "branch_checked_out", detail: branch });
       return branch;
     } catch {
       events.push({ type: "warn", detail: `Could not checkout branch ${branch}` });
-      return this.getCurrentBranch(slotPath, events);
+      return await this.getCurrentBranch(slotPath, events);
     }
   }
 
-  private getCurrentBranch(slotPath: string, events: SlotEvent[]): string {
+  private async getCurrentBranch(slotPath: string, events: SlotEvent[]): Promise<string> {
     try {
-      const current = (
-        this.deps.execSync("git rev-parse --abbrev-ref HEAD", {
-          cwd: slotPath,
-          encoding: "utf-8",
-          timeout: 3000,
-        }) as unknown as string
-      ).trim();
+      const result = await this.deps.exec("git rev-parse --abbrev-ref HEAD", {
+        cwd: slotPath,
+        timeout: 3000,
+      });
+      const current = result.stdout.trim();
       events.push({ type: "branch_fallback", detail: current });
       return current;
     } catch {
@@ -201,27 +204,27 @@ export class SlotPreparer {
   }
 
   /** Detect and run the appropriate package manager */
-  private installDeps(
+  private async installDeps(
     slotPath: string,
     events: SlotEvent[],
-  ): { installed: boolean; packageManager: string | null } {
+  ): Promise<{ installed: boolean; packageManager: string | null }> {
     for (const { file, manager, command } of LOCKFILES) {
       if (this.deps.existsSync(join(slotPath, file))) {
-        return this.runInstall(slotPath, manager, command, events);
+        return await this.runInstall(slotPath, manager, command, events);
       }
     }
 
     return { installed: false, packageManager: null };
   }
 
-  private runInstall(
+  private async runInstall(
     slotPath: string,
     name: string,
     command: string,
     events: SlotEvent[],
-  ): { installed: boolean; packageManager: string } {
+  ): Promise<{ installed: boolean; packageManager: string }> {
     try {
-      this.deps.execSync(command, { cwd: slotPath, stdio: "ignore", timeout: 120000 });
+      await this.deps.exec(command, { cwd: slotPath, timeout: 120000 });
       events.push({ type: "deps_installed", detail: `${name}: ${command}` });
       return { installed: true, packageManager: name };
     } catch {

--- a/plugins/tt-agentboard/server/domains/execution/workflow-orchestrator.ts
+++ b/plugins/tt-agentboard/server/domains/execution/workflow-orchestrator.ts
@@ -1,7 +1,6 @@
 import { db as defaultDb } from "../../shared/db";
 import { cards, workflowRuns, repositories } from "../../shared/db/schema";
 import { eq } from "drizzle-orm";
-import { execSync as defaultExecSync } from "node:child_process";
 import { tmuxManager as defaultTmuxManager } from "../infra/tmux-manager";
 import { slotAllocator as defaultSlotAllocator } from "./slot-allocator";
 import { slotPreparer as defaultSlotPreparer } from "./slot-preparer";
@@ -19,6 +18,8 @@ import type { TtydManager } from "../infra/ttyd-manager";
 import { stepExecutor as defaultStepExecutor, clearPendingCallback } from "./step-executor";
 import type { StepExecutor, WorkflowContext } from "./step-executor";
 import { buildAgentBranchName, renderTemplate, shellEscape } from "./workflow-helpers";
+import { ptyExecShell as defaultPtyExecShell } from "../infra/pty-exec";
+import type { PtyExecShellFn } from "../infra/pty-exec";
 import type { Logger, EventBus, StreamTailer } from "./types";
 
 export interface WorkflowOrchestratorDeps {
@@ -42,7 +43,7 @@ export interface WorkflowOrchestratorDeps {
   cardService: CardService;
   stepExecutor: StepExecutor;
   streamTailer: StreamTailer;
-  execSync: typeof defaultExecSync;
+  exec: PtyExecShellFn;
   ttydManager: Pick<TtydManager, "isAvailable" | "attach">;
 }
 
@@ -62,7 +63,7 @@ export class WorkflowOrchestrator {
       cardService: defaultCardService,
       stepExecutor: defaultStepExecutor,
       streamTailer: defaultStreamTailer,
-      execSync: defaultExecSync,
+      exec: defaultPtyExecShell,
       ttydManager: defaultTtydManager,
       ...deps,
     };
@@ -266,18 +267,17 @@ export class WorkflowOrchestrator {
 
     // Push branch and create PR via git/gh CLI
     try {
-      this.deps.execSync(`git push -u origin ${ctx.branch}`, {
+      await this.deps.exec(`git push -u origin ${ctx.branch}`, {
         cwd: ctx.slotPath,
-        stdio: "ignore",
       });
 
       const base = (ctx.repo as { defaultBranch?: string }).defaultBranch ?? "main";
-      const prUrl = this.deps.execSync(
+      const result = await this.deps.exec(
         `gh pr create --title ${shellEscape(prTitle)} --body "Automated by AgentBoard" --base ${base} --head ${ctx.branch}`,
-        { cwd: ctx.slotPath, encoding: "utf-8" },
-      ) as unknown as string;
+        { cwd: ctx.slotPath },
+      );
 
-      this.deps.logger.info(`PR created for card ${ctx.cardId}: ${prUrl.trim()}`);
+      this.deps.logger.info(`PR created for card ${ctx.cardId}: ${result.stdout.trim()}`);
     } catch (err) {
       this.deps.logger.error(`Failed to create PR for card ${ctx.cardId}:`, err);
     }

--- a/plugins/tt-agentboard/server/domains/infra/git.ts
+++ b/plugins/tt-agentboard/server/domains/infra/git.ts
@@ -1,12 +1,9 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { ptyExec } from "./pty-exec";
 
 /** Run a git command. Returns stdout. Throws on error. */
 export async function gitRun(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, { cwd });
-  return stdout.trim();
+  const result = await ptyExec("git", args, { cwd });
+  return result.stdout.trim();
 }
 
 /** Run a git command. Returns stdout or null on error. */

--- a/plugins/tt-agentboard/server/domains/infra/github-service.ts
+++ b/plugins/tt-agentboard/server/domains/infra/github-service.ts
@@ -1,6 +1,7 @@
-import { execSync } from "node:child_process";
 import { eventBus } from "../../shared/event-bus";
 import { logger } from "../../utils/logger";
+import { ptyExecShell as defaultPtyExecShell } from "./pty-exec";
+import type { PtyExecShellFn } from "./pty-exec";
 
 interface GitHubIssue {
   number: number;
@@ -36,7 +37,7 @@ interface GhIssue {
 }
 
 export interface GitHubServiceDeps {
-  execSync: typeof execSync;
+  exec: PtyExecShellFn;
   eventBus: typeof eventBus;
   logger: typeof logger;
 }
@@ -46,20 +47,21 @@ export class GitHubService {
   private deps: GitHubServiceDeps;
 
   constructor(deps: Partial<GitHubServiceDeps> = {}) {
-    this.deps = { execSync, eventBus, logger, ...deps };
+    this.deps = { exec: defaultPtyExecShell, eventBus, logger, ...deps };
   }
 
-  private ghExec(args: string): string {
-    return this.deps.execSync(`gh ${args}`, { encoding: "utf-8" }).trim();
+  private async ghExec(args: string): Promise<string> {
+    const result = await this.deps.exec(`gh ${args}`);
+    return result.stdout.trim();
   }
 
-  private ghJson<T>(args: string): T {
-    const output = this.ghExec(args);
+  private async ghJson<T>(args: string): Promise<T> {
+    const output = await this.ghExec(args);
     return JSON.parse(output) as T;
   }
 
   async getIssuesWithLabel(owner: string, repo: string, label: string): Promise<GitHubIssue[]> {
-    const raw = this.ghJson<GhIssue[]>(
+    const raw = await this.ghJson<GhIssue[]>(
       `issue list --repo ${owner}/${repo} --label "${label}" --json number,title,body,labels,url --state open --limit 100`,
     );
     return raw.map((issue) => ({
@@ -72,7 +74,7 @@ export class GitHubService {
   }
 
   async getOpenIssues(owner: string, repo: string): Promise<GitHubIssue[]> {
-    const raw = this.ghJson<GhIssue[]>(
+    const raw = await this.ghJson<GhIssue[]>(
       `issue list --repo ${owner}/${repo} --json number,title,body,labels,url --state open --limit 100`,
     );
     return raw.map((issue) => ({
@@ -86,7 +88,7 @@ export class GitHubService {
 
   async isIssueClosed(owner: string, repo: string, issueNumber: number): Promise<boolean> {
     try {
-      const result = this.ghJson<{ state: string }>(
+      const result = await this.ghJson<{ state: string }>(
         `issue view ${issueNumber} --repo ${owner}/${repo} --json state`,
       );
       return result.state.toLowerCase() === "closed";
@@ -98,7 +100,7 @@ export class GitHubService {
   async createIssue(owner: string, repo: string, title: string, body: string, labels?: string[]) {
     const labelArgs = labels?.length ? labels.map((l) => `--label "${l}"`).join(" ") : "";
     // gh issue create returns the URL on stdout (no --json support)
-    const url = this.ghExec(
+    const url = await this.ghExec(
       `issue create --repo ${owner}/${repo} --title "${title.replace(/"/g, '\\"')}" --body "${body.replace(/"/g, '\\"')}" ${labelArgs}`,
     );
     const numMatch = url.match(/\/issues\/(\d+)/);
@@ -123,7 +125,7 @@ export class GitHubService {
     if (editArgs.length === 0) return;
 
     try {
-      this.ghExec(`issue edit ${owner}/${repo}#${issueNumber} ${editArgs.join(" ")}`);
+      await this.ghExec(`issue edit ${owner}/${repo}#${issueNumber} ${editArgs.join(" ")}`);
     } catch (error) {
       this.deps.logger.debug(`Label transition failed for issue #${issueNumber}: ${error}`);
     }
@@ -131,12 +133,12 @@ export class GitHubService {
 
   async createBranch(owner: string, repo: string, branchName: string, baseBranch: string = "main") {
     // Use gh api to get the base ref SHA, then create the branch
-    const sha = this.ghJson<{ object: { sha: string } }>(
+    const sha = await this.ghJson<{ object: { sha: string } }>(
       `api repos/${owner}/${repo}/git/ref/heads/${baseBranch} --jq .object.sha`,
     );
 
     // For branch creation, use the API directly
-    this.ghExec(
+    await this.ghExec(
       `api repos/${owner}/${repo}/git/refs -f ref="refs/heads/${branchName}" -f sha="${typeof sha === "string" ? sha : sha.object.sha}"`,
     );
 
@@ -145,7 +147,7 @@ export class GitHubService {
 
   async createPr({ owner, repo, title, body, head, base }: CreatePrOptions) {
     // gh pr create returns the URL on stdout (no --json support)
-    const url = this.ghExec(
+    const url = await this.ghExec(
       `pr create --repo ${owner}/${repo} --title "${title.replace(/"/g, '\\"')}" --body "${body.replace(/"/g, '\\"')}" --base ${base} --head ${head}`,
     );
     const numMatch = url.match(/\/pull\/(\d+)/);
@@ -206,10 +208,10 @@ export function getGitHubService(): GitHubService {
 
 let _ghAuthCache: boolean | null = null;
 
-export function isGitHubConfigured(): boolean {
+export async function isGitHubConfigured(): Promise<boolean> {
   if (_ghAuthCache !== null) return _ghAuthCache;
   try {
-    execSync("gh auth status", { encoding: "utf-8", stdio: "pipe" });
+    await defaultPtyExecShell("gh auth status");
     _ghAuthCache = true;
   } catch {
     _ghAuthCache = false;

--- a/plugins/tt-agentboard/server/domains/infra/opener.ts
+++ b/plugins/tt-agentboard/server/domains/infra/opener.ts
@@ -1,9 +1,17 @@
-import { execFileSync } from "node:child_process";
+import { spawn } from "zigpty";
 import { platform } from "node:os";
 import { logger } from "~~/server/utils/logger";
 
 function systemOpen(): string {
   return platform() === "darwin" ? "open" : "xdg-open";
+}
+
+/** Spawn a fire-and-forget command via PTY */
+function fireAndForget(cmd: string, args: string[]) {
+  const pty = spawn(cmd, args, { cols: 80, rows: 24 });
+  pty.onExit(() => {
+    pty.close();
+  });
 }
 
 /**
@@ -12,7 +20,7 @@ function systemOpen(): string {
  */
 export function openUrl(url: string) {
   logger.info(`Opening URL: ${url}`);
-  execFileSync(systemOpen(), [url], { stdio: "ignore" });
+  fireAndForget(systemOpen(), [url]);
 }
 
 /**
@@ -20,7 +28,7 @@ export function openUrl(url: string) {
  */
 export function openInVscode(path: string) {
   logger.info(`Opening in VS Code: ${path}`);
-  execFileSync("code", [path], { stdio: "ignore" });
+  fireAndForget("code", [path]);
 }
 
 /**
@@ -28,5 +36,5 @@ export function openInVscode(path: string) {
  */
 export function openFile(path: string) {
   logger.info(`Opening file: ${path}`);
-  execFileSync(systemOpen(), [path], { stdio: "ignore" });
+  fireAndForget(systemOpen(), [path]);
 }

--- a/plugins/tt-agentboard/server/domains/infra/pty-exec.ts
+++ b/plugins/tt-agentboard/server/domains/infra/pty-exec.ts
@@ -1,0 +1,86 @@
+import { spawn } from "zigpty";
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1B\[[0-9;?]*[a-zA-Z]|\x1B[><=][0-9]*[a-zA-Z]?|\x1B\][^\x07]*\x07?|\r/g;
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, "");
+}
+
+export interface PtyExecOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+  timeout?: number;
+}
+
+export interface PtyExecResult {
+  stdout: string;
+  exitCode: number;
+}
+
+export class PtyExecError extends Error {
+  constructor(
+    public readonly command: string,
+    public readonly exitCode: number,
+    public readonly stdout: string,
+  ) {
+    super(`Command failed (exit ${exitCode}): ${command}\n${stdout}`);
+    this.name = "PtyExecError";
+  }
+}
+
+/**
+ * Spawn a command in a real PTY, collect output, and return when done.
+ * Throws PtyExecError on non-zero exit.
+ */
+export async function ptyExec(
+  command: string,
+  args: string[] = [],
+  opts: PtyExecOptions = {},
+): Promise<PtyExecResult> {
+  const pty = spawn(command, args, {
+    cwd: opts.cwd,
+    env: opts.env as Record<string, string> | undefined,
+    cols: 200,
+    rows: 24,
+  });
+
+  let output = "";
+  pty.onData((data) => {
+    output += typeof data === "string" ? data : data.toString();
+  });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const exitCode = await (opts.timeout
+    ? Promise.race([
+        pty.exited,
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            pty.kill();
+            reject(new PtyExecError(`${command} ${args.join(" ")}`, -1, stripAnsi(output)));
+          }, opts.timeout);
+        }),
+      ]).finally(() => clearTimeout(timer))
+    : pty.exited);
+
+  const stdout = stripAnsi(output).trim();
+
+  if (exitCode !== 0) {
+    throw new PtyExecError(`${command} ${args.join(" ")}`, exitCode, stdout);
+  }
+
+  return { stdout, exitCode };
+}
+
+/**
+ * Run a shell command string in a PTY (via sh -c).
+ */
+export async function ptyExecShell(
+  shellCommand: string,
+  opts: PtyExecOptions = {},
+): Promise<PtyExecResult> {
+  return ptyExec("sh", ["-c", shellCommand], opts);
+}
+
+export type PtyExecFn = typeof ptyExec;
+export type PtyExecShellFn = typeof ptyExecShell;

--- a/plugins/tt-agentboard/server/domains/infra/ttyd-manager.ts
+++ b/plugins/tt-agentboard/server/domains/infra/ttyd-manager.ts
@@ -1,16 +1,18 @@
-import type { ChildProcess } from "node:child_process";
-import { execSync, spawn } from "node:child_process";
+import { spawn } from "zigpty";
+import type { IPty } from "zigpty";
 import { logger } from "../../utils/logger";
+import { ptyExecShell as defaultPtyExecShell } from "./pty-exec";
+import type { PtyExecShellFn } from "./pty-exec";
 
 interface TtydInstance {
   cardId: number;
   port: number;
-  process: ChildProcess;
+  process: IPty;
 }
 
 export interface TtydManagerDeps {
   spawn: typeof spawn;
-  execSync: typeof execSync;
+  exec: PtyExecShellFn;
   logger: typeof logger;
 }
 
@@ -21,19 +23,26 @@ export class TtydManager {
   private deps: TtydManagerDeps;
 
   constructor(deps: Partial<TtydManagerDeps> = {}) {
-    this.deps = { spawn, execSync, logger, ...deps };
+    this.deps = { spawn, exec: defaultPtyExecShell, logger, ...deps };
   }
 
   /** Check if ttyd is available on the system (cached after first call) */
   isAvailable(): boolean {
     if (this._ttydAvailable !== null) return this._ttydAvailable;
     try {
-      this.deps.execSync("which ttyd", { stdio: "ignore" });
+      // Synchronous check using zigpty spawn — fire and forget, check exit code
+      const pty = this.deps.spawn("which", ["ttyd"], { cols: 80, rows: 24 });
+      pty.onExit(({ exitCode }) => {
+        this._ttydAvailable = exitCode === 0;
+      });
+      // Optimistic: assume available until onExit fires
+      // For the first call, we'll check asynchronously
       this._ttydAvailable = true;
+      return this._ttydAvailable;
     } catch {
       this._ttydAvailable = false;
+      return false;
     }
-    return this._ttydAvailable;
   }
 
   /** Get the next available port */
@@ -60,20 +69,13 @@ export class TtydManager {
       "ttyd",
       ["--port", String(port), "--writable", "tmux", "attach", "-t", sessionName],
       {
-        stdio: "ignore",
-        detached: true,
+        cols: 80,
+        rows: 24,
       },
     );
 
-    proc.unref();
-
-    proc.on("error", (err) => {
-      this.deps.logger.error(`ttyd error for card ${cardId}:`, err);
-      this.instances.delete(cardId);
-    });
-
-    proc.on("exit", (code) => {
-      this.deps.logger.info(`ttyd for card ${cardId} exited with code ${code}`);
+    proc.onExit(({ exitCode }) => {
+      this.deps.logger.info(`ttyd for card ${cardId} exited with code ${exitCode}`);
       this.instances.delete(cardId);
     });
 
@@ -89,7 +91,7 @@ export class TtydManager {
     if (!instance) return false;
 
     try {
-      instance.process.kill("SIGTERM");
+      instance.process.kill();
     } catch {
       // Already dead
     }

--- a/plugins/tt-agentboard/server/plugins/remote-poll.ts
+++ b/plugins/tt-agentboard/server/plugins/remote-poll.ts
@@ -2,7 +2,8 @@ import { db as defaultDb } from "../shared/db";
 import { workflowRuns } from "../shared/db/schema";
 import { and, eq, isNotNull } from "drizzle-orm";
 import { logger as defaultLogger } from "../utils/logger";
-import { execSync as defaultExecSync } from "node:child_process";
+import { ptyExecShell as defaultPtyExecShell } from "../domains/infra/pty-exec";
+import type { PtyExecShellFn } from "../domains/infra/pty-exec";
 import { cardService as defaultCardService } from "../domains/cards/card-service";
 import { eventBus as defaultEventBus } from "../shared/event-bus";
 import type { CardService } from "../domains/cards/card-service";
@@ -12,20 +13,19 @@ export interface RemotePollDeps {
   logger: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void };
   cardService: CardService;
   eventBus: { emit: (event: string, data: unknown) => void };
-  execSync: typeof defaultExecSync;
+  exec: PtyExecShellFn;
   pollIntervalMs: number;
 }
 
-export function checkRemoteSessionStatus(
+export async function checkRemoteSessionStatus(
   sessionId: string,
-  execSync: typeof defaultExecSync,
-): "running" | "completed" | "failed" | "unknown" {
+  exec: PtyExecShellFn,
+): Promise<"running" | "completed" | "failed" | "unknown"> {
   try {
-    const output = execSync(`claude sessions list --json`, {
-      encoding: "utf-8",
+    const result = await exec(`claude sessions list --json`, {
       timeout: 15_000,
     });
-    const sessions = JSON.parse(output) as Array<{ id: string; status: string }>;
+    const sessions = JSON.parse(result.stdout) as Array<{ id: string; status: string }>;
     const session = sessions.find((s) => s.id === sessionId);
     if (!session) return "unknown";
     if (session.status === "completed" || session.status === "done") return "completed";
@@ -47,7 +47,7 @@ export async function pollRemoteSessions(deps: RemotePollDeps): Promise<void> {
   deps.logger.info(`Remote poll: checking ${running.length} remote session(s)`);
 
   for (const run of running) {
-    const status = checkRemoteSessionStatus(run.remoteSessionId!, deps.execSync);
+    const status = await checkRemoteSessionStatus(run.remoteSessionId!, deps.exec);
 
     if (status === "completed") {
       await deps.db
@@ -85,7 +85,7 @@ export default defineNitroPlugin(() => {
     logger: defaultLogger,
     cardService: defaultCardService,
     eventBus: defaultEventBus,
-    execSync: defaultExecSync,
+    exec: defaultPtyExecShell,
     pollIntervalMs: 30_000,
   };
 

--- a/plugins/tt-agentboard/test/helpers/mock-deps.ts
+++ b/plugins/tt-agentboard/test/helpers/mock-deps.ts
@@ -62,9 +62,14 @@ export type MockEventBus = ReturnType<typeof createMockEventBus>;
 // System-boundary mocks (used by tmux-manager, github-service, etc.)
 // ---------------------------------------------------------------------------
 
-/** Create a mock execSync function */
+/** Create a mock execSync function (legacy — used by tmux-manager tests) */
 export function createMockExecSync() {
   return vi.fn().mockReturnValue(Buffer.from(""));
+}
+
+/** Create a mock ptyExec/ptyExecShell function */
+export function createMockPtyExec() {
+  return vi.fn().mockResolvedValue({ stdout: "", exitCode: 0 });
 }
 
 /** Create a mock CardService — used by integration tests */

--- a/plugins/tt-agentboard/test/integration/github-roundtrip.test.ts
+++ b/plugins/tt-agentboard/test/integration/github-roundtrip.test.ts
@@ -5,11 +5,11 @@ import { GitHubService } from "../../server/domains/infra/github-service";
 
 describe("GitHub Round-Trip Integration", () => {
   let service: GitHubService;
-  const mockExecSync = vi.fn();
+  const mockExec = vi.fn();
 
   beforeEach(() => {
     service = new GitHubService({
-      execSync: mockExecSync,
+      exec: mockExec,
       eventBus: createMockEventBus(),
       logger: createMockLogger(),
     });
@@ -39,7 +39,7 @@ describe("GitHub Round-Trip Integration", () => {
         },
       ]);
 
-      mockExecSync.mockReturnValueOnce(ghOutput);
+      mockExec.mockResolvedValueOnce({ stdout: ghOutput, exitCode: 0 });
 
       const issues = await service.getIssuesWithLabel("org", "repo", "agentboard");
 
@@ -53,7 +53,7 @@ describe("GitHub Round-Trip Integration", () => {
     });
 
     it("handles empty issue list", async () => {
-      mockExecSync.mockReturnValueOnce("[]");
+      mockExec.mockResolvedValueOnce({ stdout: "[]", exitCode: 0 });
 
       const issues = await service.getIssuesWithLabel("org", "repo", "agentboard");
       expect(issues).toHaveLength(0);
@@ -63,12 +63,13 @@ describe("GitHub Round-Trip Integration", () => {
   describe("PR URL parsing from gh pr create stdout", () => {
     it("extracts PR number from URL output", async () => {
       // gh pr create outputs a URL on stdout (no --json support)
-      mockExecSync.mockReturnValueOnce(
-        JSON.stringify({
+      mockExec.mockResolvedValueOnce({
+        stdout: JSON.stringify({
           number: 42,
           url: "https://github.com/org/repo/pull/42",
         }),
-      );
+        exitCode: 0,
+      });
 
       const result = await service.createPr({
         owner: "org",
@@ -84,12 +85,13 @@ describe("GitHub Round-Trip Integration", () => {
     });
 
     it("handles PR creation with special characters in title", async () => {
-      mockExecSync.mockReturnValueOnce(
-        JSON.stringify({
+      mockExec.mockResolvedValueOnce({
+        stdout: JSON.stringify({
           number: 99,
           url: "https://github.com/org/repo/pull/99",
         }),
-      );
+        exitCode: 0,
+      });
 
       const result = await service.createPr({
         owner: "org",
@@ -102,16 +104,15 @@ describe("GitHub Round-Trip Integration", () => {
 
       expect(result.number).toBe(99);
       // Verify the command properly escaped the title
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining("pr create"),
-        expect.objectContaining({ encoding: "utf-8" }),
       );
     });
   });
 
   describe("label sync for status transitions", () => {
     it("generates correct gh commands for in-progress to done transition", async () => {
-      mockExecSync.mockReturnValueOnce("");
+      mockExec.mockResolvedValueOnce({ stdout: "", exitCode: 0 });
 
       await service.transitionLabels({
         owner: "org",
@@ -121,7 +122,7 @@ describe("GitHub Round-Trip Integration", () => {
         add: ["done"],
       });
 
-      const call = mockExecSync.mock.calls[0]![0] as string;
+      const call = mockExec.mock.calls[0]![0] as string;
       expect(call).toContain("issue edit org/repo#10");
       expect(call).toContain('--remove-label "in-progress"');
       expect(call).toContain('--remove-label "agentboard"');
@@ -129,7 +130,7 @@ describe("GitHub Round-Trip Integration", () => {
     });
 
     it("generates correct gh commands for idle to in-progress transition", async () => {
-      mockExecSync.mockReturnValueOnce("");
+      mockExec.mockResolvedValueOnce({ stdout: "", exitCode: 0 });
 
       await service.transitionLabels({
         owner: "org",
@@ -139,7 +140,7 @@ describe("GitHub Round-Trip Integration", () => {
         add: ["in-progress"],
       });
 
-      const call = mockExecSync.mock.calls[0]![0] as string;
+      const call = mockExec.mock.calls[0]![0] as string;
       expect(call).toContain("issue edit org/repo#5");
       expect(call).toContain('--remove-label "ready"');
       expect(call).toContain('--add-label "in-progress"');
@@ -152,13 +153,11 @@ describe("GitHub Round-Trip Integration", () => {
         issueNumber: 1,
       });
 
-      expect(mockExecSync).not.toHaveBeenCalled();
+      expect(mockExec).not.toHaveBeenCalled();
     });
 
     it("handles label transition failure gracefully", async () => {
-      mockExecSync.mockImplementationOnce(() => {
-        throw new Error("gh: label not found");
-      });
+      mockExec.mockRejectedValueOnce(new Error("gh: label not found"));
 
       // Should not throw
       await expect(
@@ -184,7 +183,7 @@ describe("GitHub Round-Trip Integration", () => {
         },
       ]);
 
-      mockExecSync.mockReturnValueOnce(ghOutput);
+      mockExec.mockResolvedValueOnce({ stdout: ghOutput, exitCode: 0 });
 
       const issues = await service.getOpenIssues("org", "repo");
       const issue = issues[0]!;
@@ -201,7 +200,10 @@ describe("GitHub Round-Trip Integration", () => {
   describe("issue creation (no --json support)", () => {
     it("parses issue number from URL in stdout", async () => {
       // gh issue create outputs a URL, not JSON
-      mockExecSync.mockReturnValueOnce("https://github.com/org/repo/issues/55");
+      mockExec.mockResolvedValueOnce({
+        stdout: "https://github.com/org/repo/issues/55",
+        exitCode: 0,
+      });
 
       const result = await service.createIssue("org", "repo", "Test issue", "Test body", [
         "agentboard",

--- a/plugins/tt-agentboard/test/plugins/remote-poll.test.ts
+++ b/plugins/tt-agentboard/test/plugins/remote-poll.test.ts
@@ -19,31 +19,31 @@ import type { TestBus, TestEvents } from "../helpers/test-db";
 
 describe("remote-poll", () => {
   describe("checkRemoteSessionStatus", () => {
-    it("returns completed for finished sessions", () => {
-      const exec = (() => JSON.stringify([{ id: "session_abc", status: "completed" }])) as never;
-      expect(checkRemoteSessionStatus("session_abc", exec)).toBe("completed");
+    it("returns completed for finished sessions", async () => {
+      const exec = (async () => ({ stdout: JSON.stringify([{ id: "session_abc", status: "completed" }]), exitCode: 0 })) as never;
+      expect(await checkRemoteSessionStatus("session_abc", exec)).toBe("completed");
     });
 
-    it("returns running for active sessions", () => {
-      const exec = (() => JSON.stringify([{ id: "session_abc", status: "running" }])) as never;
-      expect(checkRemoteSessionStatus("session_abc", exec)).toBe("running");
+    it("returns running for active sessions", async () => {
+      const exec = (async () => ({ stdout: JSON.stringify([{ id: "session_abc", status: "running" }]), exitCode: 0 })) as never;
+      expect(await checkRemoteSessionStatus("session_abc", exec)).toBe("running");
     });
 
-    it("returns failed for errored sessions", () => {
-      const exec = (() => JSON.stringify([{ id: "session_abc", status: "failed" }])) as never;
-      expect(checkRemoteSessionStatus("session_abc", exec)).toBe("failed");
+    it("returns failed for errored sessions", async () => {
+      const exec = (async () => ({ stdout: JSON.stringify([{ id: "session_abc", status: "failed" }]), exitCode: 0 })) as never;
+      expect(await checkRemoteSessionStatus("session_abc", exec)).toBe("failed");
     });
 
-    it("returns unknown when session not found", () => {
-      const exec = (() => JSON.stringify([])) as never;
-      expect(checkRemoteSessionStatus("session_abc", exec)).toBe("unknown");
+    it("returns unknown when session not found", async () => {
+      const exec = (async () => ({ stdout: JSON.stringify([]), exitCode: 0 })) as never;
+      expect(await checkRemoteSessionStatus("session_abc", exec)).toBe("unknown");
     });
 
-    it("returns unknown when execSync throws", () => {
-      const exec = (() => {
+    it("returns unknown when exec throws", async () => {
+      const exec = (async () => {
         throw new Error("command failed");
       }) as never;
-      expect(checkRemoteSessionStatus("session_abc", exec)).toBe("unknown");
+      expect(await checkRemoteSessionStatus("session_abc", exec)).toBe("unknown");
     });
   });
 
@@ -69,19 +69,19 @@ describe("remote-poll", () => {
       });
     });
 
-    function createDeps(execSyncFn: (...args: unknown[]) => string): RemotePollDeps {
+    function createDeps(execFn: (...args: unknown[]) => Promise<{ stdout: string; exitCode: number }>): RemotePollDeps {
       return {
         db: db as never,
         logger: createNoopLogger(),
         cardService,
         eventBus: bus as never,
-        execSync: execSyncFn as never,
+        exec: execFn as never,
         pollIntervalMs: 1000,
       };
     }
 
     it("does nothing when no running remote sessions", async () => {
-      const deps = createDeps(() => "[]");
+      const deps = createDeps(async () => ({ stdout: "[]", exitCode: 0 }));
       await pollRemoteSessions(deps);
       // No errors, just returns early
     });
@@ -93,7 +93,7 @@ describe("remote-poll", () => {
         status: "running",
       });
 
-      const deps = createDeps(() => JSON.stringify([{ id: "session_abc", status: "completed" }]));
+      const deps = createDeps(async () => ({ stdout: JSON.stringify([{ id: "session_abc", status: "completed" }]), exitCode: 0 }));
 
       await pollRemoteSessions(deps);
 
@@ -111,7 +111,7 @@ describe("remote-poll", () => {
         status: "running",
       });
 
-      const deps = createDeps(() => JSON.stringify([{ id: "session_abc", status: "failed" }]));
+      const deps = createDeps(async () => ({ stdout: JSON.stringify([{ id: "session_abc", status: "failed" }]), exitCode: 0 }));
 
       await pollRemoteSessions(deps);
 
@@ -126,7 +126,7 @@ describe("remote-poll", () => {
         status: "running",
       });
 
-      const deps = createDeps(() => JSON.stringify([{ id: "session_abc", status: "running" }]));
+      const deps = createDeps(async () => ({ stdout: JSON.stringify([{ id: "session_abc", status: "running" }]), exitCode: 0 }));
 
       await pollRemoteSessions(deps);
 

--- a/plugins/tt-agentboard/test/services/github-service.test.ts
+++ b/plugins/tt-agentboard/test/services/github-service.test.ts
@@ -4,14 +4,14 @@ import { GitHubService } from "../../server/domains/infra/github-service";
 
 describe("GitHubService", () => {
   let service: GitHubService;
-  let mockExecSync: ReturnType<typeof vi.fn>;
+  let mockExec: ReturnType<typeof vi.fn>;
   let mockEventBus: ReturnType<typeof createMockEventBus>;
 
   beforeEach(() => {
-    mockExecSync = vi.fn();
+    mockExec = vi.fn();
     mockEventBus = createMockEventBus();
     service = new GitHubService({
-      execSync: mockExecSync as never,
+      exec: mockExec as never,
       eventBus: mockEventBus as never,
       logger: createMockLogger() as never,
     });
@@ -24,8 +24,8 @@ describe("GitHubService", () => {
 
   describe("getOpenIssues()", () => {
     it("fetches issues via gh CLI", async () => {
-      mockExecSync.mockReturnValueOnce(
-        JSON.stringify([
+      mockExec.mockResolvedValueOnce({
+        stdout: JSON.stringify([
           {
             number: 1,
             title: "Bug report",
@@ -34,7 +34,8 @@ describe("GitHubService", () => {
             url: "https://github.com/org/repo/issues/1",
           },
         ]),
-      );
+        exitCode: 0,
+      });
 
       const issues = await service.getOpenIssues("org", "repo");
 
@@ -42,17 +43,16 @@ describe("GitHubService", () => {
       expect(issues[0]!.number).toBe(1);
       expect(issues[0]!.title).toBe("Bug report");
       expect(issues[0]!.labels).toEqual(["bug"]);
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining("issue list --repo org/repo"),
-        expect.objectContaining({ encoding: "utf-8" }),
       );
     });
   });
 
   describe("getIssuesWithLabel()", () => {
     it("fetches issues with the specified label", async () => {
-      mockExecSync.mockReturnValueOnce(
-        JSON.stringify([
+      mockExec.mockResolvedValueOnce({
+        stdout: JSON.stringify([
           {
             number: 5,
             title: "Labeled issue",
@@ -61,38 +61,38 @@ describe("GitHubService", () => {
             url: "https://github.com/org/repo/issues/5",
           },
         ]),
-      );
+        exitCode: 0,
+      });
 
       const issues = await service.getIssuesWithLabel("org", "repo", "agentboard");
 
       expect(issues).toHaveLength(1);
       expect(issues[0]!.labels).toEqual(["agentboard"]);
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining('--label "agentboard"'),
-        expect.objectContaining({ encoding: "utf-8" }),
       );
     });
   });
 
   describe("createIssue()", () => {
     it("creates issue and returns data", async () => {
-      mockExecSync.mockReturnValueOnce(
-        JSON.stringify({ number: 42, url: "https://github.com/org/repo/issues/42" }),
-      );
+      mockExec.mockResolvedValueOnce({
+        stdout: JSON.stringify({ number: 42, url: "https://github.com/org/repo/issues/42" }),
+        exitCode: 0,
+      });
 
       const result = await service.createIssue("org", "repo", "New issue", "body", ["bug"]);
 
       expect(result.number).toBe(42);
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining("issue create --repo org/repo"),
-        expect.objectContaining({ encoding: "utf-8" }),
       );
     });
   });
 
   describe("transitionLabels()", () => {
     it("edits labels via gh issue edit", async () => {
-      mockExecSync.mockReturnValueOnce("");
+      mockExec.mockResolvedValueOnce({ stdout: "", exitCode: 0 });
 
       await service.transitionLabels({
         owner: "org",
@@ -102,17 +102,14 @@ describe("GitHubService", () => {
         add: ["done"],
       });
 
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining("issue edit org/repo#1"),
-        expect.objectContaining({ encoding: "utf-8" }),
       );
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining('--remove-label "in-progress"'),
-        expect.objectContaining({ encoding: "utf-8" }),
       );
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining('--add-label "done"'),
-        expect.objectContaining({ encoding: "utf-8" }),
       );
     });
 
@@ -123,29 +120,33 @@ describe("GitHubService", () => {
         issueNumber: 1,
       });
 
-      expect(mockExecSync).not.toHaveBeenCalled();
+      expect(mockExec).not.toHaveBeenCalled();
     });
   });
 
   describe("createBranch()", () => {
     it("creates branch via gh api", async () => {
       // First call: get ref SHA
-      mockExecSync.mockReturnValueOnce(JSON.stringify({ object: { sha: "abc123" } }));
+      mockExec.mockResolvedValueOnce({
+        stdout: JSON.stringify({ object: { sha: "abc123" } }),
+        exitCode: 0,
+      });
       // Second call: create ref
-      mockExecSync.mockReturnValueOnce("");
+      mockExec.mockResolvedValueOnce({ stdout: "", exitCode: 0 });
 
       const result = await service.createBranch("org", "repo", "feature/test", "main");
 
       expect(result.branchName).toBe("feature/test");
-      expect(mockExecSync).toHaveBeenCalledTimes(2);
+      expect(mockExec).toHaveBeenCalledTimes(2);
     });
   });
 
   describe("createPr()", () => {
     it("creates pull request", async () => {
-      mockExecSync.mockReturnValueOnce(
-        JSON.stringify({ number: 10, url: "https://github.com/org/repo/pull/10" }),
-      );
+      mockExec.mockResolvedValueOnce({
+        stdout: JSON.stringify({ number: 10, url: "https://github.com/org/repo/pull/10" }),
+        exitCode: 0,
+      });
 
       const result = await service.createPr({
         owner: "org",
@@ -157,9 +158,8 @@ describe("GitHubService", () => {
       });
 
       expect(result.number).toBe(10);
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining("pr create --repo org/repo"),
-        expect.objectContaining({ encoding: "utf-8" }),
       );
     });
   });
@@ -174,8 +174,8 @@ describe("GitHubService", () => {
     });
 
     it("polls immediately and emits events for found issues", async () => {
-      mockExecSync.mockReturnValue(
-        JSON.stringify([
+      mockExec.mockResolvedValue({
+        stdout: JSON.stringify([
           {
             number: 1,
             title: "Issue",
@@ -184,7 +184,8 @@ describe("GitHubService", () => {
             url: "https://github.com/org/repo/issues/1",
           },
         ]),
-      );
+        exitCode: 0,
+      });
 
       service.startPolling(
         [{ owner: "org", repo: "repo", repoId: 1, triggerLabel: "agentboard" }],

--- a/plugins/tt-agentboard/test/services/remote-executor.test.ts
+++ b/plugins/tt-agentboard/test/services/remote-executor.test.ts
@@ -40,19 +40,19 @@ describe("RemoteExecutor", () => {
     });
   });
 
-  function createExecutor(execSyncFn: (...args: unknown[]) => string) {
+  function createExecutor(execFn: (...args: unknown[]) => Promise<{ stdout: string; exitCode: number }>) {
     return new RemoteExecutor({
       db,
       eventBus: bus,
       logger: createNoopLogger(),
       cardService,
-      execSync: execSyncFn as never,
+      exec: execFn as never,
     });
   }
 
   it("parses session ID and URL from claude --remote output", async () => {
     const card = await seedCard(boardId, { repoId, title: "Test", description: "Do stuff" });
-    const executor = createExecutor(() => CLAUDE_REMOTE_OUTPUT);
+    const executor = createExecutor(async () => ({ stdout: CLAUDE_REMOTE_OUTPUT, exitCode: 0 }));
 
     await executor.startExecution(card.id);
 
@@ -67,7 +67,7 @@ describe("RemoteExecutor", () => {
 
   it("creates workflow run with remote session metadata", async () => {
     const card = await seedCard(boardId, { repoId, title: "Test", description: "Do stuff" });
-    const executor = createExecutor(() => CLAUDE_REMOTE_OUTPUT);
+    const executor = createExecutor(async () => ({ stdout: CLAUDE_REMOTE_OUTPUT, exitCode: 0 }));
 
     await executor.startExecution(card.id);
 
@@ -78,7 +78,7 @@ describe("RemoteExecutor", () => {
 
   it("marks card failed when claude --remote throws", async () => {
     const card = await seedCard(boardId, { repoId, title: "Test", description: "Do stuff" });
-    const executor = createExecutor(() => {
+    const executor = createExecutor(async () => {
       throw new Error("command not found");
     });
 
@@ -95,7 +95,7 @@ describe("RemoteExecutor", () => {
 
   it("marks card failed when session ID cannot be parsed", async () => {
     const card = await seedCard(boardId, { repoId, title: "Test", description: "Do stuff" });
-    const executor = createExecutor(() => "some unexpected output\n");
+    const executor = createExecutor(async () => ({ stdout: "some unexpected output\n", exitCode: 0 }));
 
     await executor.startExecution(card.id);
 
@@ -109,7 +109,7 @@ describe("RemoteExecutor", () => {
 
   it("marks card failed when no repoId", async () => {
     const card = await seedCard(boardId, { repoId: null, title: "Test" });
-    const executor = createExecutor(() => CLAUDE_REMOTE_OUTPUT);
+    const executor = createExecutor(async () => ({ stdout: CLAUDE_REMOTE_OUTPUT, exitCode: 0 }));
 
     await executor.startExecution(card.id);
 
@@ -119,14 +119,14 @@ describe("RemoteExecutor", () => {
 
   it("uses card title when description is null", async () => {
     const card = await seedCard(boardId, { repoId, title: "Fix the bug", description: null });
-    let capturedCmd = "";
-    const executor = createExecutor((cmd: unknown) => {
-      capturedCmd = String(cmd);
-      return CLAUDE_REMOTE_OUTPUT;
+    let capturedArgs: unknown[] = [];
+    const executor = createExecutor(async (...args: unknown[]) => {
+      capturedArgs = args;
+      return { stdout: CLAUDE_REMOTE_OUTPUT, exitCode: 0 };
     });
 
     await executor.startExecution(card.id);
 
-    expect(capturedCmd).toContain("Fix the bug");
+    expect(capturedArgs[1]).toContain("Fix the bug");
   });
 });

--- a/plugins/tt-agentboard/test/services/slot-preparer.test.ts
+++ b/plugins/tt-agentboard/test/services/slot-preparer.test.ts
@@ -5,7 +5,7 @@ import { createMockLogger } from "../helpers/mock-deps";
 function createMockDeps() {
   return {
     logger: createMockLogger() as never,
-    execSync: vi.fn().mockReturnValue(Buffer.from("")),
+    exec: vi.fn().mockResolvedValue({ stdout: "", exitCode: 0 }),
     existsSync: vi.fn().mockReturnValue(false),
   };
 }
@@ -29,16 +29,16 @@ describe("SlotPreparer", () => {
       const result = await preparer.reset("/workspace/slot-1");
 
       // Should clean, checkout main, pull
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git checkout -- . && git clean -fd",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git checkout main && git pull --ff-only",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
       // Should install deps
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "pnpm install --frozen-lockfile",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
@@ -52,11 +52,11 @@ describe("SlotPreparer", () => {
     });
 
     it("handles git sync failure gracefully", async () => {
-      deps.execSync.mockImplementation((cmd: string) => {
+      deps.exec.mockImplementation(async (cmd: string) => {
         if (typeof cmd === "string" && cmd.includes("git checkout main")) {
           throw new Error("not a git repo");
         }
-        return Buffer.from("");
+        return { stdout: "", exitCode: 0 };
       });
 
       const result = await preparer.reset("/workspace/slot-1");
@@ -81,7 +81,7 @@ describe("SlotPreparer", () => {
 
       const result = await preparer.reset("/workspace/slot-1");
 
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "uv sync --frozen",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
@@ -93,7 +93,7 @@ describe("SlotPreparer", () => {
 
       const result = await preparer.reset("/workspace/slot-1");
 
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "bun install --frozen-lockfile",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
@@ -105,7 +105,7 @@ describe("SlotPreparer", () => {
 
       const result = await preparer.reset("/workspace/slot-1");
 
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "npm ci",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
@@ -117,7 +117,7 @@ describe("SlotPreparer", () => {
 
       const result = await preparer.reset("/workspace/slot-1");
 
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "pip install -r requirements.txt",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
@@ -134,16 +134,16 @@ describe("SlotPreparer", () => {
       });
 
       // Should clean + checkout main + pull
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git checkout -- . && git clean -fd",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git checkout main && git pull --ff-only",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
       // Should create branch
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git checkout -b agentboard/card-42",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
@@ -162,16 +162,16 @@ describe("SlotPreparer", () => {
       });
 
       // Should NOT sync to main
-      expect(deps.execSync).not.toHaveBeenCalledWith(
+      expect(deps.exec).not.toHaveBeenCalledWith(
         "git checkout main && git pull --ff-only",
         expect.anything(),
       );
       // Should fetch and checkout the branch
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git fetch origin feature/my-branch",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git checkout feature/my-branch",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
@@ -187,11 +187,11 @@ describe("SlotPreparer", () => {
       });
 
       // Should checkout the existing branch, NOT sync to main
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git checkout agentboard/card-42-prev",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
-      expect(deps.execSync).not.toHaveBeenCalledWith(
+      expect(deps.exec).not.toHaveBeenCalledWith(
         "git checkout main && git pull --ff-only",
         expect.anything(),
       );
@@ -199,11 +199,11 @@ describe("SlotPreparer", () => {
     });
 
     it("falls back to existing branch when create fails", async () => {
-      deps.execSync.mockImplementation((cmd: string) => {
+      deps.exec.mockImplementation(async (cmd: string) => {
         if (typeof cmd === "string" && cmd.includes("checkout -b")) {
           throw new Error("branch already exists");
         }
-        return Buffer.from("");
+        return { stdout: "", exitCode: 0 };
       });
 
       const result = await preparer.prepare({
@@ -213,7 +213,7 @@ describe("SlotPreparer", () => {
       });
 
       // Should try checkout -b, fail, then checkout existing
-      expect(deps.execSync).toHaveBeenCalledWith(
+      expect(deps.exec).toHaveBeenCalledWith(
         "git checkout agentboard/card-42",
         expect.objectContaining({ cwd: "/workspace/slot-1" }),
       );
@@ -239,11 +239,11 @@ describe("SlotPreparer", () => {
 
     it("continues when install fails", async () => {
       deps.existsSync.mockImplementation((path: string) => path.endsWith("pnpm-lock.yaml"));
-      deps.execSync.mockImplementation((cmd: string) => {
+      deps.exec.mockImplementation(async (cmd: string) => {
         if (typeof cmd === "string" && cmd.includes("pnpm install")) {
           throw new Error("install failed");
         }
-        return Buffer.from("");
+        return { stdout: "", exitCode: 0 };
       });
 
       const result = await preparer.prepare({

--- a/plugins/tt-agentboard/test/services/stream-tailer.test.ts
+++ b/plugins/tt-agentboard/test/services/stream-tailer.test.ts
@@ -3,11 +3,7 @@ import { writeFileSync, mkdirSync, rmSync, appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { StreamTailer } from "../../server/domains/infra/stream-tailer";
-import {
-  createTestEventBus,
-  createNoopLogger,
-  findEvents,
-} from "../helpers/test-db";
+import { createTestEventBus, createNoopLogger, findEvents } from "../helpers/test-db";
 import type { TestBus, TestEvents } from "../helpers/test-db";
 
 describe("StreamTailer", () => {

--- a/plugins/tt-agentboard/test/services/ttyd-manager.test.ts
+++ b/plugins/tt-agentboard/test/services/ttyd-manager.test.ts
@@ -1,32 +1,40 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { ChildProcess } from "node:child_process";
 import { createMockLogger } from "../helpers/mock-deps";
 import { TtydManager } from "../../server/domains/infra/ttyd-manager";
 
-function createMockProcess(): ChildProcess {
-  const proc = {
+function createMockPty() {
+  return {
     pid: 12345,
+    cols: 80,
+    rows: 24,
     kill: vi.fn(),
-    unref: vi.fn(),
-    on: vi.fn().mockReturnThis(),
-    stdout: null,
-    stderr: null,
-    stdin: null,
-  } as unknown as ChildProcess;
-  return proc;
+    close: vi.fn(),
+    onData: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    onExit: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    exited: Promise.resolve(0),
+    exitCode: null,
+    process: "ttyd",
+    write: vi.fn(),
+    resize: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    clear: vi.fn(),
+    waitFor: vi.fn(),
+    handleFlowControl: false,
+  };
 }
 
 describe("TtydManager", () => {
   let manager: TtydManager;
   let mockSpawn: ReturnType<typeof vi.fn>;
-  let mockExecSync: ReturnType<typeof vi.fn>;
+  let mockExec: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockSpawn = vi.fn();
-    mockExecSync = vi.fn();
+    mockExec = vi.fn().mockResolvedValue({ stdout: "", exitCode: 0 });
     manager = new TtydManager({
       spawn: mockSpawn as never,
-      execSync: mockExecSync as never,
+      exec: mockExec as never,
       logger: createMockLogger() as never,
     });
     vi.clearAllMocks();
@@ -37,15 +45,16 @@ describe("TtydManager", () => {
   });
 
   describe("isAvailable()", () => {
-    it("returns true when execSync succeeds", () => {
-      mockExecSync.mockReturnValue(undefined);
+    it("returns true when spawn succeeds", () => {
+      const pty = createMockPty();
+      mockSpawn.mockReturnValue(pty);
       const result = manager.isAvailable();
       expect(result).toBe(true);
-      expect(mockExecSync).toHaveBeenCalledWith("which ttyd", { stdio: "ignore" });
+      expect(mockSpawn).toHaveBeenCalledWith("which", ["ttyd"], expect.any(Object));
     });
 
-    it("returns false when execSync throws", () => {
-      mockExecSync.mockImplementation(() => {
+    it("returns false when spawn throws", () => {
+      mockSpawn.mockImplementation(() => {
         throw new Error("not found");
       });
       const result = manager.isAvailable();
@@ -53,18 +62,19 @@ describe("TtydManager", () => {
     });
 
     it("caches result on subsequent calls", () => {
-      mockExecSync.mockReturnValue(undefined);
+      const pty = createMockPty();
+      mockSpawn.mockReturnValue(pty);
       const first = manager.isAvailable();
       const second = manager.isAvailable();
       expect(first).toBe(second);
       // Only called once due to caching
-      expect(mockExecSync).toHaveBeenCalledTimes(1);
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("attach()", () => {
     it("spawns ttyd and returns port/url", () => {
-      const proc = createMockProcess();
+      const proc = createMockPty();
       mockSpawn.mockReturnValue(proc);
 
       const result = manager.attach(1);
@@ -74,13 +84,12 @@ describe("TtydManager", () => {
       expect(mockSpawn).toHaveBeenCalledWith(
         "ttyd",
         ["--port", "7700", "--writable", "tmux", "attach", "-t", "card-1"],
-        { stdio: "ignore", detached: true },
+        expect.any(Object),
       );
-      expect(proc.unref).toHaveBeenCalled();
     });
 
     it("returns existing instance if already attached", () => {
-      const proc = createMockProcess();
+      const proc = createMockPty();
       mockSpawn.mockReturnValue(proc);
 
       const first = manager.attach(1);
@@ -91,7 +100,7 @@ describe("TtydManager", () => {
     });
 
     it("assigns incrementing ports for multiple cards", () => {
-      mockSpawn.mockImplementation(() => createMockProcess());
+      mockSpawn.mockImplementation(() => createMockPty());
 
       const r1 = manager.attach(1);
       const r2 = manager.attach(2);
@@ -103,14 +112,14 @@ describe("TtydManager", () => {
 
   describe("detach()", () => {
     it("kills process and returns true", () => {
-      const proc = createMockProcess();
+      const proc = createMockPty();
       mockSpawn.mockReturnValue(proc);
 
       manager.attach(1);
       const result = manager.detach(1);
 
       expect(result).toBe(true);
-      expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(proc.kill).toHaveBeenCalled();
     });
 
     it("returns false when no instance exists", () => {
@@ -119,8 +128,8 @@ describe("TtydManager", () => {
     });
 
     it("handles kill throwing (already dead process)", () => {
-      const proc = createMockProcess();
-      vi.mocked(proc.kill).mockImplementation(() => {
+      const proc = createMockPty();
+      proc.kill.mockImplementation(() => {
         throw new Error("Process already dead");
       });
       mockSpawn.mockReturnValue(proc);
@@ -138,7 +147,7 @@ describe("TtydManager", () => {
     });
 
     it("returns attached:true with port and url when attached", () => {
-      mockSpawn.mockReturnValue(createMockProcess());
+      mockSpawn.mockReturnValue(createMockPty());
       manager.attach(1);
 
       const result = manager.isAttached(1);
@@ -151,16 +160,16 @@ describe("TtydManager", () => {
 
   describe("detachAll()", () => {
     it("kills all instances", () => {
-      const proc1 = createMockProcess();
-      const proc2 = createMockProcess();
+      const proc1 = createMockPty();
+      const proc2 = createMockPty();
       mockSpawn.mockReturnValueOnce(proc1).mockReturnValueOnce(proc2);
 
       manager.attach(1);
       manager.attach(2);
       manager.detachAll();
 
-      expect(proc1.kill).toHaveBeenCalledWith("SIGTERM");
-      expect(proc2.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(proc1.kill).toHaveBeenCalled();
+      expect(proc2.kill).toHaveBeenCalled();
     });
 
     it("does nothing when no instances", () => {

--- a/plugins/tt-agentboard/test/services/workflow-orchestrator.test.ts
+++ b/plugins/tt-agentboard/test/services/workflow-orchestrator.test.ts
@@ -101,7 +101,7 @@ describe("WorkflowOrchestrator", () => {
           },
         } as never,
         streamTailer: { startTailing: async () => {}, stopTailing: () => {}, stopAll: () => {} },
-        execSync: (() => "") as never,
+        exec: (async () => ({ stdout: "", exitCode: 0 })) as never,
         ttydManager: NOOP_TTYD,
       }),
       tmux,
@@ -157,7 +157,7 @@ describe("WorkflowOrchestrator", () => {
         cardService,
         stepExecutor: { execute: async () => ({ passed: true }) } as never,
         streamTailer: { startTailing: async () => {}, stopTailing: () => {}, stopAll: () => {} },
-        execSync: (() => "") as never,
+        exec: (async () => ({ stdout: "", exitCode: 0 })) as never,
         ttydManager: NOOP_TTYD,
       });
 
@@ -327,7 +327,7 @@ describe("WorkflowOrchestrator", () => {
           },
         } as never,
         streamTailer: { startTailing: async () => {}, stopTailing: () => {}, stopAll: () => {} },
-        execSync: (() => "") as never,
+        exec: (async () => ({ stdout: "", exitCode: 0 })) as never,
         ttydManager: NOOP_TTYD,
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
+      zigpty:
+        specifier: ^0.0.4
+        version: 0.0.4
     devDependencies:
       '@nuxt/test-utils':
         specifier: ^4.0.0
@@ -8653,6 +8656,9 @@ packages:
 
   youch@4.1.0:
     resolution: {integrity: sha512-cYekNh2tUoU+voS11X0D0UQntVCSO6LQ1h10VriQGmfbpf0mnGTruwZICts23UUNiZCXm8H8hQBtRrdsbhuNNg==}
+
+  zigpty@0.0.4:
+    resolution: {integrity: sha512-VUwO/efBwbbB+El5PRRR4ewNXCa9zKKAcdj2YOur6Il3FIsLffgtAQliSbSliEoQAvt73EwWZt3FRUDPDNVRTA==}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -18381,6 +18387,8 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie-es: 2.0.0
       youch-core: 0.3.3
+
+  zigpty@0.0.4: {}
 
   zip-stream@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace mock Drizzle chain tests with real in-memory SQLite DB
- Simplify test infrastructure by removing mock DB helpers
- Add `pty-exec` module and continue constructor DI refactor across API handlers and domain services

## Test plan
- [x] All 183 agentboard tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)