### PR TITLE
feat(agentboard2): add tmux sidebar TUI plugin

### DIFF
--- a/plugins/tt-agentboard2/README.md
+++ b/plugins/tt-agentboard2/README.md
@@ -1,0 +1,125 @@
+# AgentBoard2
+
+Tmux sidebar TUI for monitoring sessions and AI agents. Based on [opensessions](https://github.com/nicholasgasior/opensessions).
+
+## Why
+
+AgentBoard v1 was a Nuxt web UI with embedded terminal rendering in the browser, built around a Kanban board workflow — create tickets, watch them move across columns as agents work. In practice, most tasks only need one or two touches before they're done, so constantly tracking which state a card is in added friction instead of removing it. The real unit of work is just a tmux session — when it's ready, merge it.
+
+On top of that, fighting the gap between a web page and the real terminal meant losing Claude Code's native TUI goodness — keybindings, scrollback, copy/paste, all the little things that just work in a real terminal. Less is more. A tmux sidebar that lives right next to your sessions keeps everything terminal-native, no translation layer needed.
+
+## Quick Start
+
+```bash
+# Install into tmux (one-time)
+tt agentboard2 setup
+
+# Reload tmux, then toggle the sidebar:
+# prefix a t
+```
+
+## Keybindings
+
+### Tmux (prefix defaults to `C-a`)
+
+| Key            | Action                   |
+| -------------- | ------------------------ |
+| `prefix a t`   | Toggle sidebar           |
+| `prefix a s`   | Focus sidebar            |
+| `prefix a 1-9` | Jump to session by index |
+
+### In Sidebar
+
+| Key                       | Action                      |
+| ------------------------- | --------------------------- |
+| `Tab` / `Shift+Tab`       | Cycle sessions              |
+| `j` / `k` / `Up` / `Down` | Move focus                  |
+| `Enter`                   | Switch to session           |
+| `1-9`                     | Jump to session             |
+| `d`                       | Hide session                |
+| `x`                       | Kill session (with confirm) |
+| `t`                       | Theme picker                |
+| `r`                       | Refresh                     |
+| `u`                       | Show all sessions           |
+| `n` / `c`                 | New session                 |
+| `q`                       | Quit                        |
+
+### Agent Detail Panel
+
+| Key                     | Action                 |
+| ----------------------- | ---------------------- |
+| `Right` / `l`           | Switch to agents panel |
+| `Left` / `h` / `Escape` | Back to sessions       |
+| `Enter`                 | Focus agent pane       |
+| `d`                     | Dismiss agent          |
+| `x`                     | Kill agent pane        |
+| `Alt+Up/Down`           | Reorder sessions       |
+
+## Architecture
+
+```
+plugins/tt-agentboard2/
+  apps/
+    server/        WebSocket server (port 7392)
+    tui/           OpenTUI + Solid.js terminal UI
+  packages/
+    runtime/       Shared types, themes, agent watchers
+    mux-tmux/      Tmux provider (session/pane management)
+  scripts/         Tmux keybinding scripts
+  agentboard2.tmux Tmux plugin entry
+```
+
+### Server
+
+WebSocket server on `127.0.0.1:4201`. Auto-started by the TUI or tmux scripts.
+
+- Scans tmux sessions, git info, listening ports
+- Tracks agent status (Claude Code, Amp, Codex, OpenCode)
+- Broadcasts state to connected TUI clients
+- HTTP endpoints for tmux hooks (`/focus`, `/toggle`, `/ensure-sidebar`, etc.)
+
+### TUI
+
+Solid.js app rendered via OpenTUI. Connects to server over WebSocket.
+
+- Session cards with accent bars, status icons, branch info
+- Resizable detail panel with agent list + metadata
+- 19 builtin themes (Catppuccin, Tokyo Night, Gruvbox, Nord, Dracula, etc.)
+- Mouse support (click, drag to resize)
+
+## Configuration
+
+Config file: `~/.config/towles-tool/agentboard2/config.json`
+
+```json
+{
+  "theme": "catppuccin-mocha",
+  "sidebarWidth": 26,
+  "sidebarPosition": "left"
+}
+```
+
+## CLI Commands
+
+```bash
+tt agentboard2 setup      # Install tmux plugin
+tt agentboard2 uninstall  # Remove from tmux
+tt agentboard2 server     # Start server manually
+tt agentboard2 tui        # Start TUI manually
+tt agentboard2 keys       # Show keybindings
+```
+
+## Agent Watchers
+
+Detects and tracks AI coding agents running in tmux sessions:
+
+- **Claude Code** - reads `~/.claude/sessions/` and project journals
+- **Amp** - detects from pane titles
+- **Codex** - reads `~/.codex/logs_1.sqlite`
+- **OpenCode** - reads log files via `lsof`
+
+## Themes
+
+Press `t` in the sidebar to open the theme picker. Available themes:
+
+catppuccin-mocha, catppuccin-latte, catppuccin-frappe, catppuccin-macchiato, tokyo-night, gruvbox-dark, nord, dracula, github-dark, one-dark, kanagawa, everforest, material, cobalt2, flexoki, ayu, aura, matrix, transparent

--- a/plugins/tt-agentboard2/agentboard2.tmux
+++ b/plugins/tt-agentboard2/agentboard2.tmux
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$CURRENT_DIR/scripts"
+BUN_PATH="${BUN_PATH:-$(command -v bun 2>/dev/null || echo "$HOME/.bun/bin/bun")}"
+
+# Read tmux options with defaults
+key=$(tmux show-option -gqv @agentboard2-key)
+key=${key:-a}
+
+# Export to tmux environment so scripts can read them
+tmux set-environment -g AGENTBOARD2_DIR "$CURRENT_DIR"
+tmux set-environment -g AGENTBOARD2_PORT "${AGENTBOARD2_PORT:-4201}"
+tmux set-environment -g AGENTBOARD2_HOST "${AGENTBOARD2_HOST:-127.0.0.1}"
+
+AB2_PORT="${AGENTBOARD2_PORT:-4201}"
+AB2_HOST="${AGENTBOARD2_HOST:-127.0.0.1}"
+
+# Bootstrap: install deps if missing
+if [ ! -d "$CURRENT_DIR/apps/tui/node_modules" ]; then
+  (cd "$CURRENT_DIR" && pnpm install >> /tmp/agentboard2-install.log 2>&1 &)
+fi
+
+# Bind keybindings via command table "agentboard2"
+tmux bind-key -T prefix "$key" switch-client -T agentboard2
+tmux bind-key -T agentboard2 t run-shell "$BUN_PATH run $SCRIPTS_DIR/toggle.ts"
+tmux bind-key -T agentboard2 s run-shell "$BUN_PATH run $SCRIPTS_DIR/focus.ts"
+
+# Number keys 1-9 switch to session by index
+# #{q:...} shell-escapes tmux variables to prevent injection from session names
+for i in $(seq 1 9); do
+  tmux bind-key -T agentboard2 "$i" run-shell "curl -s -X POST 'http://${AB2_HOST}:${AB2_PORT}/switch-index?index=$i' -d \"\$(tmux display-message -p '#{q:client_tty}|#{q:session_name}|#{q:window_id}')\" >/dev/null 2>&1 || true"
+done
+
+# Hooks: server manages hooks via provider.setupHooks() at runtime.
+# These are fallback hooks for when the server isn't running yet (e.g. first load).
+# #{q:...} shell-escapes tmux variables to prevent injection from session names.
+tmux set-hook -g client-session-changed "run-shell -b \"curl -s -X POST http://${AB2_HOST}:${AB2_PORT}/focus -d \\\"\$(tmux display-message -p '#{q:client_tty}|#{q:session_name}|#{q:window_id}')\\\" >/dev/null 2>&1 || true\""
+tmux set-hook -g after-select-window "run-shell -b \"curl -s -X POST http://${AB2_HOST}:${AB2_PORT}/ensure-sidebar -d \\\"\$(tmux display-message -p '#{q:client_tty}|#{q:session_name}|#{q:window_id}')\\\" >/dev/null 2>&1 || true\""
+
+# Hook: on pane resize, sync sidebar width
+tmux set-hook -g after-resize-pane "run-shell -b \"curl -s -X POST http://${AB2_HOST}:${AB2_PORT}/resize-sidebars -d \\\"\$(tmux display-message -p '#{q:pane_id}|#{q:session_name}|#{q:window_id}|#{q:pane_width}|#{q:window_width}')\\\" >/dev/null 2>&1 || true\""

--- a/plugins/tt-agentboard2/apps/server/package.json
+++ b/plugins/tt-agentboard2/apps/server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tt-agentboard2/server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/main.ts",
+  "types": "src/main.ts",
+  "scripts": {
+    "start": "bun run src/main.ts",
+    "dev": "bun --watch run src/main.ts"
+  },
+  "dependencies": {
+    "@tt-agentboard2/mux-tmux": "workspace:*",
+    "@tt-agentboard2/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/plugins/tt-agentboard2/apps/server/src/main.ts
+++ b/plugins/tt-agentboard2/apps/server/src/main.ts
@@ -1,0 +1,60 @@
+import {
+  AmpAgentWatcher,
+  ClaudeCodeAgentWatcher,
+  CodexAgentWatcher,
+  OpenCodeAgentWatcher,
+  PluginLoader,
+  loadConfig,
+  startServer,
+} from "@tt-agentboard2/runtime";
+import { TmuxProvider } from "@tt-agentboard2/mux-tmux";
+import { join } from "node:path";
+
+const config = loadConfig();
+const loader = new PluginLoader();
+
+// Register tmux provider (tmux only)
+try {
+  const provider = new TmuxProvider();
+  loader.registerMux(provider);
+} catch (err) {
+  console.error("Failed to initialize tmux provider:", err);
+}
+
+const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+const pluginDir = join(home, ".config", "towles-tool", "agentboard2", "plugins");
+const localPlugins = loader.loadDir(pluginDir);
+if (localPlugins.length > 0) {
+  console.log(`Loaded local plugins: ${localPlugins.join(", ")}`);
+}
+
+if (config.plugins.length > 0) {
+  const npmPlugins = loader.loadPackages(config.plugins);
+  if (npmPlugins.length > 0) {
+    console.log(`Loaded npm plugins: ${npmPlugins.join(", ")}`);
+  }
+}
+
+const mux = loader.resolve(config.mux);
+if (!mux) {
+  console.error(
+    "No terminal multiplexer detected.\n" +
+      `Registered providers: ${loader.registry.list().join(", ") || "(none)"}\n` +
+      "$TMUX environment variable is not set — are you running inside a tmux session?\n" +
+      "Set 'mux' in ~/.config/towles-tool/agentboard2/config.json to override.",
+  );
+  process.exit(1);
+}
+
+loader.registerWatcher(new AmpAgentWatcher());
+loader.registerWatcher(new ClaudeCodeAgentWatcher());
+loader.registerWatcher(new CodexAgentWatcher());
+loader.registerWatcher(new OpenCodeAgentWatcher());
+
+const watchers = loader.getWatchers();
+if (watchers.length > 0) {
+  console.log(`Agent watchers: ${watchers.map((watcher) => watcher.name).join(", ")}`);
+}
+
+console.log(`Primary mux provider: ${mux.name}`);
+startServer(mux, [], watchers);

--- a/plugins/tt-agentboard2/apps/tui/build.ts
+++ b/plugins/tt-agentboard2/apps/tui/build.ts
@@ -1,0 +1,11 @@
+import solidPlugin from "@opentui/solid/bun-plugin";
+
+await Bun.build({
+  entrypoints: ["./src/index.tsx"],
+  outdir: "./dist",
+  target: "bun",
+  minify: true,
+  plugins: [solidPlugin],
+});
+
+console.log("Build complete!");

--- a/plugins/tt-agentboard2/apps/tui/bunfig.toml
+++ b/plugins/tt-agentboard2/apps/tui/bunfig.toml
@@ -1,0 +1,1 @@
+preload = ["@opentui/solid/preload"]

--- a/plugins/tt-agentboard2/apps/tui/package.json
+++ b/plugins/tt-agentboard2/apps/tui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tt-agentboard2/tui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.tsx",
+  "scripts": {
+    "start": "bun run src/index.tsx",
+    "dev": "bun --watch run src/index.tsx",
+    "build": "bun run build.ts"
+  },
+  "dependencies": {
+    "@opentui/core": "^0.1.88",
+    "@opentui/solid": "^0.1.88",
+    "@tt-agentboard2/mux-tmux": "workspace:*",
+    "@tt-agentboard2/runtime": "workspace:*",
+    "solid-js": "^1.9.11"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/plugins/tt-agentboard2/apps/tui/scripts/sessionizer.sh
+++ b/plugins/tt-agentboard2/apps/tui/scripts/sessionizer.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# agentboard2 sessionizer — fuzzy directory picker for new tmux sessions
+# Requires: fzf, find
+
+SEARCH_DIR="${SESSIONIZER_DIR:-$HOME/code}"
+
+if ! command -v fzf &>/dev/null; then
+  echo "fzf is required for the sessionizer. Install it: https://github.com/junegunn/fzf"
+  exit 1
+fi
+
+if [ ! -d "$SEARCH_DIR" ]; then
+  echo "Directory not found: $SEARCH_DIR"
+  exit 1
+fi
+
+selected=$(find "$SEARCH_DIR" -mindepth 1 -maxdepth 3 -type d 2>/dev/null | fzf \
+  --reverse \
+  --header="Pick a directory for new session" \
+  --preview=':' \
+  --preview-window=hidden \
+  --bind='ctrl-c:abort')
+
+[ -z "$selected" ] && exit 0
+
+# Derive session name from directory basename, replacing dots with underscores
+session_name=$(basename "$selected" | tr '.' '_')
+
+# If session already exists, just switch to it
+if tmux has-session -t "=$session_name" 2>/dev/null; then
+  tmux switch-client -t "$session_name"
+  exit 0
+fi
+
+tmux new-session -d -s "$session_name" -c "$selected"
+tmux switch-client -t "$session_name"

--- a/plugins/tt-agentboard2/apps/tui/scripts/start.sh
+++ b/plugins/tt-agentboard2/apps/tui/scripts/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Start the agentboard2 TUI (tmux only).
+
+if [ -n "${TMUX:-}" ]; then
+    AGENTBOARD2_DIR="$(tmux show-environment -g AGENTBOARD2_DIR 2>/dev/null | cut -d= -f2)"
+fi
+AGENTBOARD2_DIR="${AGENTBOARD2_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+TUI_DIR="$AGENTBOARD2_DIR/apps/tui"
+
+BUN_PATH="${BUN_PATH:-$(command -v bun 2>/dev/null || echo "$HOME/.bun/bin/bun")}"
+
+cd "$TUI_DIR"
+export REFOCUS_WINDOW
+export AGENTBOARD2_DIR
+exec "$BUN_PATH" run src/index.tsx 2>/tmp/agentboard2-err.log

--- a/plugins/tt-agentboard2/apps/tui/src/components/DetailPanel.tsx
+++ b/plugins/tt-agentboard2/apps/tui/src/components/DetailPanel.tsx
@@ -1,0 +1,350 @@
+import { createSignal, For, Show } from "solid-js";
+import type { Accessor } from "solid-js";
+import type { MouseEvent } from "@opentui/core";
+import type { SessionData, Theme } from "@tt-agentboard2/runtime";
+import { TUI_AGENT_CLICK_LOG } from "@tt-agentboard2/runtime";
+import { appendFileSync } from "node:fs";
+import {
+  SPINNERS,
+  UNSEEN_ICON,
+  BOLD,
+  DIM,
+  SPARK_BLOCKS,
+  TONE_ICONS,
+  toneColor,
+  logResizeDebug,
+} from "../constants";
+
+// --- Sparkline ---
+
+export function buildSparkline(
+  timestamps: number[],
+  width: number,
+  windowMs: number = 30 * 60 * 1000,
+): string {
+  if (timestamps.length === 0 || width <= 0) return "";
+  const now = Date.now();
+  const start = now - windowMs;
+  const bucketSize = windowMs / width;
+  const buckets = Array.from({ length: width }, () => 0);
+
+  for (const ts of timestamps) {
+    if (ts < start) continue;
+    const idx = Math.min(width - 1, Math.floor((ts - start) / bucketSize));
+    buckets[idx]++;
+  }
+
+  const max = Math.max(...buckets, 1);
+  return buckets
+    .map((count: number) => {
+      const level = Math.round((count / max) * (SPARK_BLOCKS.length - 1));
+      return SPARK_BLOCKS[level];
+    })
+    .join("");
+}
+
+// --- Detail Panel ---
+
+export interface DetailPanelProps {
+  session: SessionData;
+  theme: Accessor<Theme>;
+  statusColors: Accessor<Theme["status"]>;
+  spinIdx: Accessor<number>;
+  focusedAgentIdx: number;
+  onDismissAgent: (agent: SessionData["agents"][number]) => void;
+  onFocusAgentPane: (agent: SessionData["agents"][number]) => void;
+  isResizeHover: boolean;
+  isResizing: boolean;
+  onResizeStart: (event: MouseEvent) => void;
+  onResizeDrag: (event: MouseEvent) => void;
+  onResizeEnd: (event?: MouseEvent) => void;
+  onResizeHoverChange: (hovered: boolean) => void;
+}
+
+export function DetailPanel(props: DetailPanelProps) {
+  const P = () => props.theme().palette;
+
+  const agents = () => props.session.agents ?? [];
+  const hasAgents = () => agents().length > 0;
+  const meta = () => props.session.metadata;
+  const hasMeta = () => !!meta();
+  const visibleLogs = () => {
+    const m = meta();
+    if (!m || m.logs.length === 0) return [];
+    return m.logs.slice(-8);
+  };
+
+  const truncDir = () => {
+    const d = props.session.dir;
+    if (!d) return "";
+    const home = process.env.HOME ?? "";
+    const short = home && d.startsWith(home) ? "~" + d.slice(home.length) : d;
+    return short.length > 24 ? "…" + short.slice(short.length - 23) : short;
+  };
+
+  return (
+    <box flexDirection="column" flexShrink={0} paddingLeft={1}>
+      <box height={1}>
+        <text
+          selectable={false}
+          onMouseDown={(event) => {
+            logResizeDebug("separator:onMouseDown", {
+              x: event.x,
+              y: event.y,
+              button: event.button,
+              session: props.session.name,
+            });
+            event.preventDefault();
+            props.onResizeStart(event);
+          }}
+          onMouseDrag={(event) => {
+            logResizeDebug("separator:onMouseDrag", {
+              x: event.x,
+              y: event.y,
+              button: event.button,
+              session: props.session.name,
+            });
+            event.preventDefault();
+            props.onResizeDrag(event);
+          }}
+          onMouseDragEnd={(event) => {
+            logResizeDebug("separator:onMouseDragEnd", {
+              x: event.x,
+              y: event.y,
+              button: event.button,
+              session: props.session.name,
+            });
+            event.preventDefault();
+            props.onResizeEnd(event);
+          }}
+          onMouseUp={(event) => {
+            logResizeDebug("separator:onMouseUp", {
+              x: event.x,
+              y: event.y,
+              button: event.button,
+              session: props.session.name,
+            });
+            event.preventDefault();
+            props.onResizeEnd(event);
+          }}
+          onMouseOver={() => props.onResizeHoverChange(true)}
+          onMouseOut={() => {
+            if (!props.isResizing) props.onResizeHoverChange(false);
+          }}
+          style={{
+            fg: props.isResizing ? P().blue : props.isResizeHover ? P().overlay1 : P().surface2,
+          }}
+        >
+          {"─".repeat(200)}
+        </text>
+      </box>
+
+      {/* Directory */}
+      <text truncate>
+        <span style={{ fg: P().overlay0, attributes: DIM }}>{truncDir()}</span>
+      </text>
+
+      {/* Agent instances */}
+      <Show when={hasAgents()}>
+        <For each={agents()}>
+          {(agent, i) => (
+            <AgentListItem
+              agent={agent}
+              palette={P}
+              statusColors={props.statusColors}
+              spinIdx={props.spinIdx}
+              isKeyboardFocused={i() === props.focusedAgentIdx}
+              onDismiss={() => props.onDismissAgent(agent)}
+              onFocusPane={() => props.onFocusAgentPane(agent)}
+            />
+          )}
+        </For>
+      </Show>
+
+      {/* Metadata: status, progress, logs */}
+      <Show when={hasMeta()}>
+        {(_) => {
+          const m = meta()!;
+          const progressText = () => {
+            const p = m.progress;
+            if (!p) return "";
+            if (p.current != null && p.total != null) return `${p.current}/${p.total}`;
+            if (p.percent != null) return `${Math.round(p.percent * 100)}%`;
+            return "";
+          };
+          return (
+            <box flexDirection="column">
+              <box height={1} />
+
+              {/* Status + progress on one line */}
+              <Show when={m.status || m.progress}>
+                <box flexDirection="row" paddingRight={1}>
+                  <Show when={m.status}>
+                    <text truncate flexGrow={1}>
+                      <span style={{ fg: toneColor(m.status!.tone, P()) }}>
+                        {TONE_ICONS[m.status!.tone ?? "neutral"]} {m.status!.text}
+                      </span>
+                    </text>
+                  </Show>
+                  <Show when={m.progress}>
+                    <text flexShrink={0}>
+                      <span style={{ fg: P().sky }}>
+                        {m.status ? " · " : ""}
+                        {progressText()}
+                        {m.progress!.label ? ` ${m.progress!.label}` : ""}
+                      </span>
+                    </text>
+                  </Show>
+                </box>
+              </Show>
+
+              {/* Log entries */}
+              <Show when={visibleLogs().length > 0}>
+                <For each={visibleLogs()}>
+                  {(entry) => (
+                    <text truncate>
+                      <span style={{ fg: toneColor(entry.tone, P()), attributes: DIM }}>
+                        {TONE_ICONS[entry.tone ?? "neutral"]}
+                      </span>
+                      <Show when={entry.source}>
+                        <span
+                          style={{ fg: P().surface2, attributes: DIM }}
+                        >{` [${entry.source}]`}</span>
+                      </Show>
+                      <span style={{ fg: P().overlay0 }}> {entry.message}</span>
+                    </text>
+                  )}
+                </For>
+              </Show>
+            </box>
+          );
+        }}
+      </Show>
+    </box>
+  );
+}
+
+// --- Agent List Item ---
+
+interface AgentListItemProps {
+  agent: SessionData["agents"][number];
+  palette: Accessor<Theme["palette"]>;
+  statusColors: Accessor<Theme["status"]>;
+  spinIdx: Accessor<number>;
+  isKeyboardFocused: boolean;
+  onDismiss: () => void;
+  onFocusPane: () => void;
+}
+
+function AgentListItem(props: AgentListItemProps) {
+  const P = () => props.palette();
+  const SC = () => props.statusColors();
+  const [isDismissHover, setIsDismissHover] = createSignal(false);
+  const [isFlash, setIsFlash] = createSignal(false);
+
+  const isTerminal = () => ["done", "error", "interrupted"].includes(props.agent.status);
+  const isUnseen = () => isTerminal() && props.agent.unseen === true;
+
+  const icon = () => {
+    if (isUnseen()) return UNSEEN_ICON;
+    if (isTerminal())
+      return props.agent.status === "done" ? "✓" : props.agent.status === "error" ? "✗" : "⚠";
+    if (props.agent.status === "running") return SPINNERS[props.spinIdx() % SPINNERS.length]!;
+    if (props.agent.status === "waiting") return "◉";
+    return "○";
+  };
+
+  const color = () => {
+    if (isTerminal()) {
+      if (props.agent.status === "error") return P().red;
+      if (props.agent.status === "interrupted") return P().peach;
+      return isUnseen() ? P().teal : P().green;
+    }
+    return SC()[props.agent.status];
+  };
+
+  const statusText = () => {
+    if (props.agent.status === "running") return "running";
+    if (props.agent.status === "done") return "done";
+    if (props.agent.status === "error") return "error";
+    if (props.agent.status === "interrupted") return "stopped";
+    if (props.agent.status === "waiting") return "waiting";
+    return "";
+  };
+
+  const triggerFlash = () => {
+    setIsFlash(true);
+    setTimeout(() => setIsFlash(false), 150);
+  };
+
+  const bgColor = () => {
+    if (isFlash()) return P().surface1;
+    if (props.isKeyboardFocused) return P().surface0;
+    return "transparent";
+  };
+
+  return (
+    <box
+      flexDirection="column"
+      flexShrink={0}
+      onMouseDown={(event) => {
+        // Don't trigger focus if clicking the dismiss button
+        if ((event.target as any)?.id === "dismiss") return;
+        appendFileSync(
+          TUI_AGENT_CLICK_LOG,
+          `[${new Date().toISOString()}] clicked agent=${props.agent.agent} thread=${props.agent.threadName ?? "?"}\n`,
+        );
+        triggerFlash();
+        props.onFocusPane();
+      }}
+    >
+      <box height={1} />
+      <box flexDirection="row" backgroundColor={bgColor()} paddingLeft={1}>
+        {/* Content column — name row + thread name row */}
+        <box flexDirection="column" flexGrow={1} paddingRight={1}>
+          {/* Row 1: icon + agent name + status + dismiss */}
+          <box flexDirection="row">
+            <text flexGrow={1} truncate>
+              <span style={{ fg: color() }}>{icon()}</span>
+              <span
+                style={{
+                  fg: props.isKeyboardFocused ? P().text : P().subtext1,
+                  attributes: props.isKeyboardFocused ? BOLD : undefined,
+                }}
+              >
+                {" "}
+                {props.agent.agent}
+              </span>
+            </text>
+            <Show when={!isTerminal() || !isUnseen()}>
+              <text flexShrink={0}>
+                <span style={{ fg: color(), attributes: DIM }}>{statusText()}</span>
+              </text>
+            </Show>
+            <text
+              flexShrink={0}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                props.onDismiss();
+              }}
+              onMouseOver={() => setIsDismissHover(true)}
+              onMouseOut={() => setIsDismissHover(false)}
+            >
+              <span style={{ fg: isDismissHover() ? P().red : P().overlay0 }}>{" ✕"}</span>
+            </text>
+          </box>
+
+          {/* Row 2: thread name */}
+          <Show when={props.agent.threadName}>
+            <text truncate>
+              <span style={{ fg: isUnseen() ? color() : P().overlay0 }}>
+                {props.agent.threadName}
+              </span>
+            </text>
+          </Show>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/plugins/tt-agentboard2/apps/tui/src/components/SessionCard.tsx
+++ b/plugins/tt-agentboard2/apps/tui/src/components/SessionCard.tsx
@@ -1,0 +1,181 @@
+import { Show } from "solid-js";
+import type { Accessor } from "solid-js";
+import type { SessionData, Theme } from "@tt-agentboard2/runtime";
+import { SPINNERS, UNSEEN_ICON, BOLD, DIM, toneColor } from "../constants";
+
+export interface SessionCardProps {
+  session: SessionData;
+  index: number;
+  isFocused: boolean;
+  isCurrent: boolean;
+  spinIdx: Accessor<number>;
+  theme: Accessor<Theme>;
+  statusColors: Accessor<Theme["status"]>;
+  onSelect: () => void;
+}
+
+export function SessionCard(props: SessionCardProps) {
+  const P = () => props.theme().palette;
+  const SC = () => props.statusColors();
+
+  const status = () => props.session.agentState?.status ?? "idle";
+  const unseen = () => props.session.unseen;
+
+  const isUnseenTerminal = () => unseen() && ["done", "error", "interrupted"].includes(status());
+
+  const accentColor = () => {
+    if (props.isCurrent) return P().green;
+    if (isUnseenTerminal()) return unseenAccentColor();
+    const s = status();
+    if (s === "error") return P().red;
+    if (s === "interrupted") return P().peach;
+    if (s === "running") return P().yellow;
+    if (props.isFocused) return P().lavender;
+    return "transparent";
+  };
+
+  const unseenAccentColor = () => {
+    const s = status();
+    if (s === "error") return P().red;
+    if (s === "interrupted") return P().peach;
+    return P().teal;
+  };
+
+  const statusIcon = () => {
+    const s = status();
+    if (s === "running") return SPINNERS[props.spinIdx() % SPINNERS.length]!;
+    if (isUnseenTerminal()) return UNSEEN_ICON;
+    return "";
+  };
+
+  const statusColor = () => {
+    if (isUnseenTerminal()) return unseenAccentColor();
+    return SC()[status()];
+  };
+
+  const nameColor = () => {
+    if (props.isFocused) return P().text;
+    if (props.isCurrent) return P().subtext1;
+    return P().subtext0;
+  };
+
+  const indexColor = () => {
+    if (props.isFocused) return P().subtext0;
+    return P().surface2;
+  };
+
+  const truncName = () => {
+    const n = props.session.name;
+    return n.length > 18 ? n.slice(0, 17) + "…" : n;
+  };
+
+  const truncBranch = () => {
+    const b = props.session.branch;
+    if (!b) return "";
+    return b.length > 30 ? b.slice(0, 29) + "…" : b;
+  };
+
+  const portHint = () => {
+    const ports = props.session.ports ?? [];
+    if (ports.length === 0) return "";
+    if (ports.length === 1) return `⌁${ports[0]}`;
+    return `⌁${ports[0]}+${ports.length - 1}`;
+  };
+
+  const metaSummary = () => {
+    const meta = props.session.metadata;
+    if (!meta) return "";
+    const parts: string[] = [];
+    if (meta.status) parts.push(meta.status.text);
+    if (meta.progress) {
+      if (meta.progress.current != null && meta.progress.total != null) {
+        parts.push(`${meta.progress.current}/${meta.progress.total}`);
+      } else if (meta.progress.percent != null) {
+        parts.push(`${Math.round(meta.progress.percent * 100)}%`);
+      }
+      if (meta.progress.label) parts.push(meta.progress.label);
+    }
+    return parts.join(" · ");
+  };
+
+  const metaTone = () => props.session.metadata?.status?.tone;
+
+  const bgColor = () => {
+    if (props.isFocused) return P().surface1;
+    return "transparent";
+  };
+
+  return (
+    <box flexDirection="column" flexShrink={0}>
+      <box
+        flexDirection="row"
+        backgroundColor={bgColor()}
+        onMouseDown={props.onSelect}
+        paddingLeft={1}
+      >
+        {/* Left accent — space-preserving, only colored for meaningful states */}
+        <text style={{ fg: accentColor() }}>{accentColor() === "transparent" ? " " : "▌"}</text>
+
+        {/* Index */}
+        <box width={3} flexShrink={0}>
+          <text style={{ fg: indexColor() }}>{String(props.index).padStart(2)}</text>
+        </box>
+
+        {/* Content */}
+        <box flexDirection="column" flexGrow={1} paddingRight={1}>
+          {/* Row 1: name + status */}
+          <box flexDirection="row">
+            <text truncate flexGrow={1}>
+              <span
+                style={{
+                  fg: nameColor(),
+                  attributes: props.isFocused || props.isCurrent ? BOLD : undefined,
+                }}
+              >
+                {truncName()}
+              </span>
+            </text>
+            <Show when={statusIcon()}>
+              <text flexShrink={0}>
+                <span style={{ fg: statusColor() }}> {statusIcon()}</span>
+              </text>
+            </Show>
+          </box>
+
+          {/* Row 2: branch plus a compact local-port hint when available */}
+          <Show when={props.session.branch || portHint()}>
+            <box flexDirection="row">
+              <Show when={props.session.branch}>
+                <text truncate flexGrow={1}>
+                  <span style={{ fg: props.isFocused ? P().pink : P().overlay0 }}>
+                    {truncBranch()}
+                  </span>
+                </text>
+              </Show>
+              <Show when={portHint()}>
+                <text flexShrink={0}>
+                  <span style={{ fg: props.isFocused ? P().sky : P().overlay0 }}>
+                    {props.session.branch ? " " : ""}
+                    {portHint()}
+                  </span>
+                </text>
+              </Show>
+            </box>
+          </Show>
+
+          {/* Row 3: metadata summary (status + progress) */}
+          <Show when={metaSummary()}>
+            <text truncate>
+              <span style={{ fg: toneColor(metaTone(), P()), attributes: DIM }}>
+                {metaSummary()}
+              </span>
+            </text>
+          </Show>
+        </box>
+      </box>
+
+      {/* Breathing room — 1 empty line between cards */}
+      <box height={1} />
+    </box>
+  );
+}

--- a/plugins/tt-agentboard2/apps/tui/src/components/ThemePicker.tsx
+++ b/plugins/tt-agentboard2/apps/tui/src/components/ThemePicker.tsx
@@ -1,0 +1,165 @@
+import { createSignal, createMemo, For, Show } from "solid-js";
+import type { Accessor } from "solid-js";
+import type { InputRenderable, KeyEvent } from "@opentui/core";
+import type { Theme } from "@tt-agentboard2/runtime";
+import { THEME_NAMES, BOLD, DIM } from "../constants";
+
+export interface ThemePickerProps {
+  palette: Accessor<Theme["palette"]>;
+  onSelect: (name: string) => void;
+  onPreview: (name: string) => void;
+  onClose: () => void;
+}
+
+export function ThemePicker(props: ThemePickerProps) {
+  let inputRef: InputRenderable;
+
+  const [query, setQuery] = createSignal("");
+  const [selected, setSelected] = createSignal(0);
+
+  const filtered = createMemo(() => {
+    const q = query().toLowerCase();
+    if (!q) return THEME_NAMES;
+    return THEME_NAMES.filter((name) => name.toLowerCase().includes(q));
+  });
+
+  function move(direction: -1 | 1) {
+    const list = filtered();
+    if (!list.length) return;
+    let next = selected() + direction;
+    if (next < 0) next = list.length - 1;
+    if (next >= list.length) next = 0;
+    setSelected(next);
+    const name = list[next];
+    if (name) props.onPreview(name);
+  }
+
+  function confirm() {
+    const name = filtered()[selected()];
+    if (name) props.onSelect(name);
+  }
+
+  function handleKeyDown(e: KeyEvent) {
+    if (e.name === "up") {
+      e.preventDefault();
+      move(-1);
+    } else if (e.name === "down") {
+      e.preventDefault();
+      move(1);
+    } else if (e.name === "return") {
+      e.preventDefault();
+      confirm();
+    } else if (e.name === "escape") {
+      e.preventDefault();
+      props.onClose();
+    }
+  }
+
+  function handleInput(value: string) {
+    setQuery(value);
+    setSelected(0);
+  }
+
+  const MAX_VISIBLE = 12;
+
+  const scrollOffset = createMemo(() => {
+    const sel = selected();
+    if (sel < MAX_VISIBLE) return 0;
+    return sel - MAX_VISIBLE + 1;
+  });
+
+  const visibleItems = createMemo(() => {
+    const list = filtered();
+    return list.slice(scrollOffset(), scrollOffset() + MAX_VISIBLE);
+  });
+
+  return (
+    <box
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      justifyContent="center"
+      alignItems="center"
+      backgroundColor="transparent"
+    >
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={props.palette().blue}
+        backgroundColor={props.palette().mantle}
+        padding={1}
+        flexDirection="column"
+        width={30}
+      >
+        <text>
+          <span style={{ fg: props.palette().blue, attributes: BOLD }}>Select Theme</span>
+        </text>
+        <box height={1}>
+          <text style={{ fg: props.palette().surface2 }}>{"─".repeat(200)}</text>
+        </box>
+        <box border borderColor={props.palette().surface1} marginBottom={1}>
+          <input
+            ref={(r: InputRenderable) => {
+              inputRef = r;
+              inputRef.focus();
+            }}
+            value={query()}
+            onInput={handleInput}
+            onKeyDown={handleKeyDown}
+            placeholder="Search themes…"
+            backgroundColor={props.palette().surface0}
+            focusedBackgroundColor={props.palette().surface0}
+            textColor={props.palette().text}
+            cursorColor={props.palette().blue}
+            placeholderColor={props.palette().overlay0}
+          />
+        </box>
+        <Show
+          when={filtered().length > 0}
+          fallback={
+            <box paddingLeft={1}>
+              <text style={{ fg: props.palette().overlay0 }}>No matches</text>
+            </box>
+          }
+        >
+          <For each={visibleItems()}>
+            {(name) => {
+              const idx = createMemo(() => filtered().indexOf(name));
+              const isSel = createMemo(() => idx() === selected());
+              return (
+                <box
+                  paddingLeft={1}
+                  paddingRight={1}
+                  backgroundColor={isSel() ? props.palette().surface0 : undefined}
+                >
+                  <text style={{ fg: isSel() ? props.palette().text : props.palette().subtext0 }}>
+                    {isSel() ? "▸ " : "  "}
+                    {name}
+                  </text>
+                </box>
+              );
+            }}
+          </For>
+          <Show when={filtered().length > MAX_VISIBLE}>
+            <text style={{ fg: props.palette().overlay0, attributes: DIM }}>
+              {"  "}↕ {filtered().length - MAX_VISIBLE} more
+            </text>
+          </Show>
+        </Show>
+        <box height={1}>
+          <text style={{ fg: props.palette().surface2 }}>{"─".repeat(200)}</text>
+        </box>
+        <text style={{ fg: props.palette().overlay0 }}>
+          <span style={{ attributes: DIM }}>↑↓</span>
+          {" browse  "}
+          <span style={{ attributes: DIM }}>⏎</span>
+          {" select  "}
+          <span style={{ attributes: DIM }}>esc</span>
+          {" close"}
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/plugins/tt-agentboard2/apps/tui/src/constants.ts
+++ b/plugins/tt-agentboard2/apps/tui/src/constants.ts
@@ -1,0 +1,46 @@
+import { TextAttributes } from "@opentui/core";
+import { BUILTIN_THEMES, TUI_RESIZE_LOG } from "@tt-agentboard2/runtime";
+import type { Theme, MetadataTone } from "@tt-agentboard2/runtime";
+import { appendFileSync } from "node:fs";
+
+export const SPINNERS = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+export const UNSEEN_ICON = "●";
+export const BOLD = TextAttributes.BOLD;
+export const DIM = TextAttributes.DIM;
+export const SPARK_BLOCKS = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+export const THEME_NAMES = Object.keys(BUILTIN_THEMES);
+export const DEFAULT_DETAIL_PANEL_HEIGHT = 10;
+export const MIN_DETAIL_PANEL_HEIGHT = 4;
+export { TUI_RESIZE_LOG };
+
+export const TONE_ICONS: Record<MetadataTone, string> = {
+  neutral: "·",
+  info: "ℹ",
+  success: "✓",
+  warn: "⚠",
+  error: "✗",
+};
+
+export function toneColor(tone: MetadataTone | undefined, palette: Theme["palette"]): string {
+  switch (tone) {
+    case "success":
+      return palette.green;
+    case "error":
+      return palette.red;
+    case "warn":
+      return palette.yellow;
+    case "info":
+      return palette.blue;
+    default:
+      return palette.overlay0;
+  }
+}
+
+export function logResizeDebug(message: string, data?: Record<string, unknown>): void {
+  const ts = new Date().toISOString();
+  const extra = data ? ` ${JSON.stringify(data)}` : "";
+  try {
+    appendFileSync(TUI_RESIZE_LOG, `[${ts}] [pid:${process.pid}] ${message}${extra}\n`);
+  } catch {}
+}

--- a/plugins/tt-agentboard2/apps/tui/src/detail-panel-height.ts
+++ b/plugins/tt-agentboard2/apps/tui/src/detail-panel-height.ts
@@ -1,0 +1,21 @@
+import { loadConfig, saveConfig } from "@tt-agentboard2/runtime";
+import { MIN_DETAIL_PANEL_HEIGHT, DEFAULT_DETAIL_PANEL_HEIGHT } from "./constants";
+
+export function clampDetailPanelHeight(height: number): number {
+  return Math.max(MIN_DETAIL_PANEL_HEIGHT, Math.round(height));
+}
+
+export function getStoredDetailPanelHeight(sessionName: string): number {
+  const stored = loadConfig().detailPanelHeights?.[sessionName];
+  return typeof stored === "number" ? clampDetailPanelHeight(stored) : DEFAULT_DETAIL_PANEL_HEIGHT;
+}
+
+export function persistDetailPanelHeight(sessionName: string, height: number): void {
+  const config = loadConfig();
+  saveConfig({
+    detailPanelHeights: {
+      ...(config.detailPanelHeights ?? {}),
+      [sessionName]: clampDetailPanelHeight(height),
+    },
+  });
+}

--- a/plugins/tt-agentboard2/apps/tui/src/index.tsx
+++ b/plugins/tt-agentboard2/apps/tui/src/index.tsx
@@ -1,0 +1,1619 @@
+import { render, useKeyboard, useRenderer } from "@opentui/solid";
+import { appendFileSync } from "node:fs";
+import {
+  createSignal,
+  createEffect,
+  onCleanup,
+  onMount,
+  batch,
+  For,
+  Show,
+  createMemo,
+  createSelector,
+} from "solid-js";
+import type { Accessor } from "solid-js";
+import { createStore, reconcile } from "solid-js/store";
+import { TextAttributes } from "@opentui/core";
+import type { MouseEvent, InputRenderable, KeyEvent } from "@opentui/core";
+
+import {
+  ensureServer,
+  SERVER_PORT,
+  SERVER_HOST,
+  BUILTIN_THEMES,
+  loadConfig,
+  resolveTheme,
+  saveConfig,
+} from "@tt-agentboard2/runtime";
+import type {
+  ServerMessage,
+  SessionData,
+  ClientCommand,
+  Theme,
+  MetadataTone,
+} from "@tt-agentboard2/runtime";
+import { TmuxClient } from "@tt-agentboard2/mux-tmux";
+
+// Detect tmux context (tmux only)
+type MuxContext = { type: "tmux"; sdk: TmuxClient; paneId: string } | { type: "none" };
+
+function detectMuxContext(): MuxContext {
+  if (process.env.TMUX_PANE && process.env.TMUX) {
+    return { type: "tmux", sdk: new TmuxClient(), paneId: process.env.TMUX_PANE };
+  }
+  return { type: "none" };
+}
+
+const muxCtx = detectMuxContext();
+
+const SPINNERS = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const UNSEEN_ICON = "●";
+const BOLD = TextAttributes.BOLD;
+const DIM = TextAttributes.DIM;
+const THEME_NAMES = Object.keys(BUILTIN_THEMES);
+const DEFAULT_DETAIL_PANEL_HEIGHT = 10;
+const MIN_DETAIL_PANEL_HEIGHT = 4;
+const DIVIDER = "─".repeat(200);
+const RESIZE_DEBUG_LOG = "/tmp/agentboard2-tui-resize.log";
+
+const TONE_ICONS: Record<MetadataTone, string> = {
+  neutral: "·",
+  info: "ℹ",
+  success: "✓",
+  warn: "⚠",
+  error: "✗",
+};
+
+function toneColor(
+  tone: MetadataTone | undefined,
+  palette: ReturnType<() => Theme["palette"]>,
+): string {
+  switch (tone) {
+    case "success":
+      return palette.green;
+    case "error":
+      return palette.red;
+    case "warn":
+      return palette.yellow;
+    case "info":
+      return palette.blue;
+    default:
+      return palette.overlay0;
+  }
+}
+
+const TUI_DEBUG = !!process.env.AGENTBOARD2_DEBUG;
+
+function logResizeDebug(message: string, data?: Record<string, unknown>): void {
+  if (!TUI_DEBUG) return;
+  const ts = new Date().toISOString();
+  const extra = data ? ` ${JSON.stringify(data)}` : "";
+  try {
+    appendFileSync(RESIZE_DEBUG_LOG, `[${ts}] [pid:${process.pid}] ${message}${extra}\n`);
+  } catch {}
+}
+
+function clampDetailPanelHeight(height: number): number {
+  return Math.max(MIN_DETAIL_PANEL_HEIGHT, Math.round(height));
+}
+
+function getStoredDetailPanelHeight(sessionName: string): number {
+  const stored = loadConfig().detailPanelHeights?.[sessionName];
+  return typeof stored === "number" ? clampDetailPanelHeight(stored) : DEFAULT_DETAIL_PANEL_HEIGHT;
+}
+
+function persistDetailPanelHeight(sessionName: string, height: number): void {
+  const config = loadConfig();
+  saveConfig({
+    detailPanelHeights: {
+      ...(config.detailPanelHeights ?? {}),
+      [sessionName]: clampDetailPanelHeight(height),
+    },
+  });
+}
+
+/** Refocus the main (non-sidebar) pane after TUI capability detection finishes.
+ *  This must happen from the TUI process — doing it from start.sh races with
+ *  capability query responses and leaks escape sequences to the main pane. */
+function refocusMainPane() {
+  if (muxCtx.type === "tmux") {
+    try {
+      // Use the TUI's own pane ID to find its current window (handles stash restore
+      // where the pane may have moved to a different window than the original).
+      const windowId =
+        process.env.REFOCUS_WINDOW ||
+        Bun.spawnSync(["tmux", "display-message", "-t", muxCtx.paneId, "-p", "#{window_id}"], {
+          stdout: "pipe",
+          stderr: "pipe",
+        })
+          .stdout.toString()
+          .trim();
+      if (!windowId) return;
+      const r = Bun.spawnSync(
+        ["tmux", "list-panes", "-t", windowId, "-F", "#{pane_id} #{pane_title}"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const lines = r.stdout.toString().trim().split("\n");
+      const main = lines.find((l) => !l.includes("agentboard2-sidebar"));
+      if (main) {
+        const paneId = main.split(" ")[0];
+        Bun.spawnSync(["tmux", "select-pane", "-t", paneId], { stdout: "pipe", stderr: "pipe" });
+      }
+    } catch {}
+  }
+}
+
+function getClientTty(): string {
+  if (muxCtx.type === "tmux") {
+    const { sdk, paneId } = muxCtx;
+    const sessName = sdk.display("#{session_name}", { target: paneId });
+    if (sessName) {
+      const clients = sdk.listClients();
+      const client = clients.find((c) => c.sessionName === sessName);
+      if (client) return client.tty;
+    }
+    return sdk.getClientTty();
+  }
+  return "";
+}
+
+function getLocalSessionName(): string | null {
+  if (muxCtx.type === "tmux") {
+    const sessionName = muxCtx.sdk.display("#{session_name}", { target: muxCtx.paneId });
+    return sessionName || null;
+  }
+  return null;
+}
+
+function App() {
+  const renderer = useRenderer();
+
+  // --- Theme state (driven by server) ---
+  const [theme, setTheme] = createSignal<Theme>(resolveTheme(undefined));
+  const P = () => theme().palette;
+  const S = () => theme().status;
+
+  const [sessions, setSessions] = createStore<SessionData[]>([]);
+  const [focusedSession, setFocusedSession] = createSignal<string | null>(null);
+  const [currentSession, setCurrentSession] = createSignal<string | null>(null);
+  const [mySession, setMySession] = createSignal<string | null>(null);
+  const [connected, setConnected] = createSignal(false);
+  const [spinIdx, setSpinIdx] = createSignal(0);
+  const [detailPanelHeight, setDetailPanelHeight] = createSignal(DEFAULT_DETAIL_PANEL_HEIGHT);
+  const [isDetailResizeHover, setIsDetailResizeHover] = createSignal(false);
+  const [isDetailResizing, setIsDetailResizing] = createSignal(false);
+  const detailPanelSessionName = createMemo(() => focusedSession() ?? mySession());
+
+  // --- Panel focus: sessions list vs agent detail ---
+  type PanelFocus = "sessions" | "agents";
+  const [panelFocus, setPanelFocus] = createSignal<PanelFocus>("sessions");
+  const [focusedAgentIdx, setFocusedAgentIdx] = createSignal(0);
+
+  // --- Modal state ---
+  const [modal, setModal] = createSignal<"none" | "theme-picker" | "confirm-kill">("none");
+  const [killTarget, setKillTarget] = createSignal<string | null>(null);
+  let themeBeforePreview: Theme | null = null;
+
+  const [clientTty, setClientTty] = createSignal(getClientTty());
+  let ws: WebSocket | null = null;
+  let startupFocusSynced = false;
+  let detailResizeStartY = 0;
+  let detailResizeStartHeight = DEFAULT_DETAIL_PANEL_HEIGHT;
+  const startupSessionName = getLocalSessionName();
+
+  const focusedData = createMemo(() => sessions.find((s) => s.name === focusedSession()) ?? null);
+
+  function send(cmd: ClientCommand) {
+    if (connected() && ws) ws.send(JSON.stringify(cmd));
+  }
+
+  function switchToSession(name: string) {
+    // Optimistic local update — makes rapid Tab repeat instant by removing
+    // the server/hook round-trip from the next-Tab decision.
+    // The server's focus/state broadcast will reconcile if needed.
+    setCurrentSession(name);
+    setFocusedSession(name);
+    setPanelFocus("sessions");
+    setFocusedAgentIdx(0);
+    send({ type: "switch-session", name });
+  }
+
+  function reIdentify() {
+    const sessionName = getLocalSessionName();
+    if (!sessionName) return;
+
+    if (muxCtx.type === "tmux") {
+      send({ type: "identify-pane", paneId: muxCtx.paneId, sessionName });
+    }
+  }
+
+  function moveLocalFocus(delta: -1 | 1) {
+    const list = sessions;
+    if (list.length === 0) return;
+
+    const current = focusedSession();
+    const currentIdx = Math.max(
+      0,
+      list.findIndex((s) => s.name === current),
+    );
+    const nextIdx = Math.max(0, Math.min(list.length - 1, currentIdx + delta));
+    const next = list[nextIdx]?.name ?? null;
+
+    if (!next || next === current) return;
+
+    setFocusedSession(next);
+    send({ type: "focus-session", name: next });
+  }
+
+  function moveAgentFocus(delta: -1 | 1) {
+    const data = focusedData();
+    const agents = data?.agents ?? [];
+    if (agents.length === 0) return;
+    const idx = focusedAgentIdx();
+    const next = Math.max(0, Math.min(agents.length - 1, idx + delta));
+    setFocusedAgentIdx(next);
+  }
+
+  function activateFocusedAgent() {
+    const data = focusedData();
+    const agents = data?.agents ?? [];
+    const agent = agents[focusedAgentIdx()];
+    if (!agent || !data) return;
+    if (TUI_DEBUG)
+      appendFileSync(
+        "/tmp/agentboard2-tui-agent-click.log",
+        `[${new Date().toISOString()}] keyboard focus-agent-pane session=${data.name} agent=${agent.agent} threadId=${agent.threadId} threadName=${agent.threadName}\n`,
+      );
+    send({
+      type: "focus-agent-pane",
+      session: data.name,
+      agent: agent.agent,
+      threadId: agent.threadId,
+      threadName: agent.threadName,
+    });
+  }
+
+  function dismissFocusedAgent() {
+    const data = focusedData();
+    const agents = data?.agents ?? [];
+    const agent = agents[focusedAgentIdx()];
+    if (!agent || !data) return;
+    send({
+      type: "dismiss-agent",
+      session: data.name,
+      agent: agent.agent,
+      threadId: agent.threadId,
+    });
+    // Adjust index if we dismissed the last item
+    if (focusedAgentIdx() >= agents.length - 1 && agents.length > 1) {
+      setFocusedAgentIdx(agents.length - 2);
+    }
+    // If no agents left, go back to sessions
+    if (agents.length <= 1) setPanelFocus("sessions");
+  }
+
+  function killFocusedAgentPane() {
+    const data = focusedData();
+    const agents = data?.agents ?? [];
+    const agent = agents[focusedAgentIdx()];
+    if (!agent || !data) return;
+    send({
+      type: "kill-agent-pane",
+      session: data.name,
+      agent: agent.agent,
+      threadId: agent.threadId,
+      threadName: agent.threadName,
+    });
+  }
+
+  function applyTheme(themeName: string) {
+    send({ type: "set-theme", theme: themeName });
+  }
+
+  function previewTheme(themeName: string) {
+    setTheme(resolveTheme(themeName));
+  }
+
+  function resizeDetailPanel(delta: -1 | 1) {
+    const nextHeight = clampDetailPanelHeight(detailPanelHeight() + delta);
+    if (nextHeight === detailPanelHeight()) return;
+
+    setDetailPanelHeight(nextHeight);
+
+    const sessionName = detailPanelSessionName();
+    if (sessionName) {
+      persistDetailPanelHeight(sessionName, nextHeight);
+    }
+  }
+
+  function beginDetailResize(event: MouseEvent) {
+    logResizeDebug("beginDetailResize", {
+      button: event.button,
+      x: event.x,
+      y: event.y,
+      currentHeight: detailPanelHeight(),
+      session: detailPanelSessionName(),
+      target: event.target?.id ?? null,
+    });
+    if (event.button !== 0) return;
+    (renderer as any).setCapturedRenderable?.(event.target ?? undefined);
+    detailResizeStartY = event.y;
+    detailResizeStartHeight = detailPanelHeight();
+    setIsDetailResizing(true);
+    event.stopPropagation();
+  }
+
+  function handleDetailResizeDrag(event: MouseEvent) {
+    logResizeDebug("handleDetailResizeDrag", {
+      x: event.x,
+      y: event.y,
+      isResizing: isDetailResizing(),
+      startY: detailResizeStartY,
+      startHeight: detailResizeStartHeight,
+      currentHeight: detailPanelHeight(),
+      session: detailPanelSessionName(),
+    });
+    if (!isDetailResizing()) return;
+    const delta = detailResizeStartY - event.y;
+    const nextHeight = clampDetailPanelHeight(detailResizeStartHeight + delta);
+    setDetailPanelHeight(nextHeight);
+    logResizeDebug("handleDetailResizeDrag:applied", {
+      delta,
+      nextHeight,
+      session: detailPanelSessionName(),
+    });
+    event.stopPropagation();
+  }
+
+  function endDetailResize(event?: MouseEvent) {
+    logResizeDebug("endDetailResize", {
+      x: event?.x,
+      y: event?.y,
+      isResizing: isDetailResizing(),
+      currentHeight: detailPanelHeight(),
+      session: detailPanelSessionName(),
+      target: event?.target?.id ?? null,
+    });
+    if (!isDetailResizing()) return;
+    (renderer as any).setCapturedRenderable?.(undefined);
+    setIsDetailResizing(false);
+    setIsDetailResizeHover(false);
+
+    const sessionName = detailPanelSessionName();
+    if (sessionName) {
+      persistDetailPanelHeight(sessionName, detailPanelHeight());
+      logResizeDebug("endDetailResize:persisted", {
+        session: sessionName,
+        height: detailPanelHeight(),
+      });
+    }
+
+    event?.stopPropagation();
+  }
+
+  function createNewSession() {
+    if (muxCtx.type !== "tmux") {
+      send({ type: "new-session" });
+      return;
+    }
+    const scriptPath = new URL("../scripts/sessionizer.sh", import.meta.url).pathname;
+    muxCtx.sdk.displayPopup({
+      command: `bash "${scriptPath}"`,
+      title: " new session ",
+      width: "60%",
+      height: "60%",
+      closeOnExit: true,
+    });
+  }
+
+  onMount(() => {
+    logResizeDebug("mount", {
+      startupSessionName,
+      localSessionName: getLocalSessionName(),
+      muxType: muxCtx.type,
+      tmuxPane: process.env.TMUX_PANE ?? null,
+    });
+    // Refocus the main pane once terminal capability detection finishes.
+    // This avoids the race where start.sh refocuses too early and capability
+    // responses leak as garbage text into the main pane.
+    let startupRefocused = false;
+    const doStartupRefocus = () => {
+      if (startupRefocused) return;
+      startupRefocused = true;
+      refocusMainPane();
+    };
+    renderer.on("capabilities", doStartupRefocus);
+    // Fallback: if no capability response arrives within 2s, refocus anyway
+    const refocusTimeout = setTimeout(doStartupRefocus, 2000);
+
+    onCleanup(() => {
+      clearTimeout(refocusTimeout);
+      renderer.removeListener("capabilities", doStartupRefocus);
+    });
+
+    const socket = new WebSocket(`ws://${SERVER_HOST}:${SERVER_PORT}`);
+    ws = socket;
+
+    socket.onopen = () => {
+      setConnected(true);
+      const tty = clientTty();
+      if (tty) send({ type: "identify", clientTty: tty });
+      reIdentify();
+    };
+
+    socket.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string) as ServerMessage;
+        let startupFocusToPublish: string | null = null;
+        batch(() => {
+          if (msg.type === "state") {
+            const startupFocus =
+              !startupFocusSynced &&
+              startupSessionName &&
+              msg.sessions.some((session) => session.name === startupSessionName)
+                ? startupSessionName
+                : msg.focusedSession;
+
+            if (startupFocus === startupSessionName) {
+              startupFocusSynced = true;
+              if (msg.focusedSession !== startupSessionName) {
+                startupFocusToPublish = startupSessionName;
+              }
+            }
+
+            setSessions(reconcile(msg.sessions, { key: "name" }));
+            setFocusedSession(startupFocus);
+            setCurrentSession(msg.currentSession);
+            setTheme(resolveTheme(msg.theme));
+          } else if (msg.type === "focus") {
+            setFocusedSession(msg.focusedSession);
+            setCurrentSession(msg.currentSession);
+          } else if (msg.type === "your-session") {
+            setMySession(msg.name);
+            if (msg.clientTty) setClientTty(msg.clientTty);
+
+            if (!startupFocusSynced && sessions.some((session) => session.name === msg.name)) {
+              startupFocusSynced = true;
+              setFocusedSession(msg.name);
+              if (focusedSession() !== msg.name) {
+                startupFocusToPublish = msg.name;
+              }
+            }
+          } else if (msg.type === "re-identify") {
+            reIdentify();
+          }
+        });
+
+        if (startupFocusToPublish) {
+          send({ type: "focus-session", name: startupFocusToPublish });
+        }
+      } catch {}
+    };
+
+    socket.onclose = () => {
+      setConnected(false);
+      renderer.destroy();
+    };
+
+    onCleanup(() => socket.close());
+
+    // Listen for quit messages from server
+    socket.addEventListener("message", (event) => {
+      try {
+        const msg = JSON.parse(event.data as string);
+        if (msg.type === "quit") {
+          if (ws) ws.close();
+          renderer.destroy();
+        }
+      } catch {}
+    });
+  });
+
+  const hasRunning = createMemo(() => sessions.some((s) => s.agentState?.status === "running"));
+
+  createEffect(() => {
+    if (!hasRunning()) return;
+    const interval = setInterval(() => {
+      setSpinIdx((i) => (i + 1) % SPINNERS.length);
+    }, 120);
+    onCleanup(() => clearInterval(interval));
+  });
+
+  createEffect(() => {
+    const sessionName = detailPanelSessionName();
+    if (!sessionName) return;
+    const storedHeight = getStoredDetailPanelHeight(sessionName);
+    logResizeDebug("loadStoredDetailPanelHeight", {
+      session: sessionName,
+      storedHeight,
+    });
+    setDetailPanelHeight(storedHeight);
+  });
+
+  createEffect(() => {
+    logResizeDebug("detailPanelHeight:changed", {
+      height: detailPanelHeight(),
+      session: detailPanelSessionName(),
+      isResizing: isDetailResizing(),
+    });
+  });
+
+  useKeyboard((key) => {
+    const currentModal = modal();
+
+    // --- Theme picker modal: input handles all keys via onKeyDown ---
+    if (currentModal === "theme-picker") {
+      return;
+    }
+
+    // --- Confirm kill modal ---
+    if (currentModal === "confirm-kill") {
+      if (key.name === "y") {
+        const target = killTarget();
+        if (target) send({ type: "kill-session", name: target });
+        setKillTarget(null);
+        setModal("none");
+      } else {
+        setKillTarget(null);
+        setModal("none");
+      }
+      return;
+    }
+
+    // --- Normal mode keybindings ---
+    // Alt+Up / Alt+Down → reorder session
+    if ((key.meta || key.option) && (key.name === "up" || key.name === "down")) {
+      const focused = focusedSession();
+      if (focused) {
+        const delta: -1 | 1 = key.name === "up" ? -1 : 1;
+        send({ type: "reorder-session", name: focused, delta });
+      }
+      return;
+    }
+
+    switch (key.name) {
+      case "q":
+        send({ type: "quit" });
+        break;
+      case "escape":
+        if (panelFocus() === "agents") {
+          setPanelFocus("sessions");
+        }
+        break;
+      case "up":
+      case "k":
+        if (panelFocus() === "agents") {
+          moveAgentFocus(-1);
+        } else {
+          moveLocalFocus(-1);
+        }
+        break;
+      case "down":
+      case "j":
+        if (panelFocus() === "agents") {
+          moveAgentFocus(1);
+        } else {
+          moveLocalFocus(1);
+        }
+        break;
+      case "left":
+      case "h":
+        if (panelFocus() === "agents") {
+          setPanelFocus("sessions");
+        } else {
+          resizeDetailPanel(-1);
+        }
+        break;
+      case "right":
+      case "l":
+        if (panelFocus() === "sessions") {
+          const data = focusedData();
+          const agents = data?.agents ?? [];
+          if (agents.length > 0) {
+            setPanelFocus("agents");
+            setFocusedAgentIdx((idx) => Math.min(idx, agents.length - 1));
+          } else {
+            resizeDetailPanel(1);
+          }
+        }
+        break;
+      case "return": {
+        if (panelFocus() === "agents") {
+          activateFocusedAgent();
+        } else {
+          const focused = focusedSession();
+          if (focused) switchToSession(focused);
+        }
+        break;
+      }
+      case "tab": {
+        const list = sessions;
+        if (list.length === 0) break;
+        const cur = currentSession();
+        const idx = list.findIndex((s) => s.name === cur);
+        const next = list[(idx + (key.shift ? list.length - 1 : 1)) % list.length];
+        if (next) switchToSession(next.name);
+        break;
+      }
+      case "r":
+        send({ type: "refresh" });
+        break;
+      case "t":
+        themeBeforePreview = theme();
+        setModal("theme-picker");
+        break;
+      case "u":
+        send({ type: "show-all-sessions" });
+        break;
+      case "d": {
+        if (panelFocus() === "agents") {
+          dismissFocusedAgent();
+        } else {
+          const focused = focusedSession();
+          if (focused) send({ type: "hide-session", name: focused });
+        }
+        break;
+      }
+      case "x": {
+        if (panelFocus() === "agents") {
+          killFocusedAgentPane();
+        } else {
+          const focused = focusedSession();
+          if (focused) {
+            setKillTarget(focused);
+            setModal("confirm-kill");
+          }
+        }
+        break;
+      }
+      case "n":
+      case "c":
+        createNewSession();
+        break;
+      default: {
+        if (key.number) {
+          const idx = Number.parseInt(key.name, 10) - 1;
+          const target = sessions[idx];
+          if (target) switchToSession(target.name);
+        }
+        break;
+      }
+    }
+  });
+
+  const runningCount = createMemo(
+    () => sessions.filter((s) => s.agentState?.status === "running").length,
+  );
+
+  const errorCount = createMemo(
+    () => sessions.filter((s) => s.agentState?.status === "error").length,
+  );
+
+  const unseenCount = createMemo(() => sessions.filter((s) => s.unseen).length);
+
+  const isFocused = createSelector(focusedSession);
+
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={P().crust}>
+      {/* Header */}
+      <box flexDirection="column" paddingLeft={1} paddingTop={1} paddingBottom={0} flexShrink={0}>
+        <text>
+          <span style={{ fg: P().mauve, attributes: BOLD }}>{"  AgentBoard"}</span>
+        </text>
+        <text>
+          <span style={{ fg: P().overlay1 }}>{"  "}</span>
+          <span style={{ fg: P().subtext0, attributes: BOLD }}>Sessions</span>
+          <span style={{ fg: P().overlay0 }}> {String(sessions.length)}</span>
+          {runningCount() > 0 ? (
+            <span style={{ fg: P().yellow }}>
+              {" "}
+              {"⚡"}
+              {runningCount()}
+            </span>
+          ) : (
+            ""
+          )}
+          {errorCount() > 0 ? (
+            <span style={{ fg: P().red }}>
+              {" "}
+              {"✗"}
+              {errorCount()}
+            </span>
+          ) : (
+            ""
+          )}
+          {unseenCount() > 0 ? (
+            <span style={{ fg: P().teal }}>
+              {" "}
+              {"●"} {unseenCount()}
+            </span>
+          ) : (
+            ""
+          )}
+        </text>
+      </box>
+
+      {/* Session list */}
+      <scrollbox flexGrow={1} flexShrink={1} paddingTop={1}>
+        <For each={sessions}>
+          {(session, i) => (
+            <SessionCard
+              session={session}
+              index={i() + 1}
+              isFocused={isFocused(session.name)}
+              isCurrent={session.name === currentSession()}
+              spinIdx={spinIdx}
+              theme={theme}
+              statusColors={S}
+              onSelect={() => {
+                setFocusedSession(session.name);
+                send({ type: "focus-session", name: session.name });
+                switchToSession(session.name);
+              }}
+            />
+          )}
+        </For>
+      </scrollbox>
+
+      {/* Listening ports for focused session — above detail panel */}
+      <Show when={focusedData()?.ports?.length}>
+        {(_) => {
+          const portRows = () => {
+            const ports = focusedData()?.ports ?? [];
+            const maxPerRow = 3;
+            const rows: number[][] = [];
+            for (let i = 0; i < ports.length; i += maxPerRow) {
+              rows.push(ports.slice(i, i + maxPerRow));
+            }
+            return rows;
+          };
+          return (
+            <box flexDirection="column" flexShrink={0} paddingLeft={2}>
+              <For each={portRows()}>
+                {(ports, rowIndex) => (
+                  <box flexDirection="row" paddingRight={1}>
+                    <text flexShrink={0}>
+                      <span
+                        style={{
+                          fg: rowIndex() === 0 ? P().overlay0 : P().surface2,
+                          attributes: DIM,
+                        }}
+                      >
+                        {rowIndex() === 0 ? "local " : "      "}
+                      </span>
+                    </text>
+                    <For each={ports}>
+                      {(port, portIndex) => (
+                        <box flexDirection="row" flexShrink={0}>
+                          <text
+                            onMouseDown={() => {
+                              Bun.spawn(
+                                [
+                                  process.platform === "darwin" ? "open" : "xdg-open",
+                                  `http://localhost:${port}`,
+                                ],
+                                { stdout: "ignore", stderr: "ignore" },
+                              );
+                            }}
+                          >
+                            <span style={{ fg: P().sky, attributes: BOLD }}>{String(port)}</span>
+                          </text>
+                          <Show when={portIndex() < ports.length - 1}>
+                            <text>
+                              <span style={{ fg: P().surface2 }}>{" · "}</span>
+                            </text>
+                          </Show>
+                        </box>
+                      )}
+                    </For>
+                  </box>
+                )}
+              </For>
+            </box>
+          );
+        }}
+      </Show>
+
+      {/* Detail panel — focused session info, draggable height */}
+      <Show when={focusedData()}>
+        {(data) => (
+          <scrollbox height={detailPanelHeight()} maxHeight={detailPanelHeight()} flexShrink={0}>
+            <DetailPanel
+              session={data()}
+              theme={theme}
+              statusColors={S}
+              spinIdx={spinIdx}
+              focusedAgentIdx={panelFocus() === "agents" ? focusedAgentIdx() : -1}
+              onDismissAgent={(agent) => {
+                send({
+                  type: "dismiss-agent",
+                  session: data().name,
+                  agent: agent.agent,
+                  threadId: agent.threadId,
+                });
+              }}
+              onFocusAgentPane={(agent) => {
+                if (TUI_DEBUG)
+                  appendFileSync(
+                    "/tmp/agentboard2-tui-agent-click.log",
+                    `[${new Date().toISOString()}] sending focus-agent-pane session=${data().name} agent=${agent.agent} threadId=${agent.threadId} threadName=${agent.threadName}\n`,
+                  );
+                send({
+                  type: "focus-agent-pane",
+                  session: data().name,
+                  agent: agent.agent,
+                  threadId: agent.threadId,
+                  threadName: agent.threadName,
+                });
+              }}
+              isResizeHover={isDetailResizeHover()}
+              isResizing={isDetailResizing()}
+              onResizeStart={beginDetailResize}
+              onResizeDrag={handleDetailResizeDrag}
+              onResizeEnd={endDetailResize}
+              onResizeHoverChange={setIsDetailResizeHover}
+            />
+          </scrollbox>
+        )}
+      </Show>
+
+      {/* Footer */}
+      <box flexDirection="column" paddingLeft={1} paddingBottom={1} paddingTop={0} flexShrink={0}>
+        <box height={1}>
+          <text style={{ fg: P().surface2 }}>{DIVIDER}</text>
+        </box>
+        <Show
+          when={panelFocus() === "sessions"}
+          fallback={
+            <text>
+              <span style={{ fg: P().overlay0 }}>{"←"}</span>
+              <span style={{ fg: P().overlay1 }}>{" back  "}</span>
+              <span style={{ fg: P().overlay0 }}>{"⏎"}</span>
+              <span style={{ fg: P().overlay1 }}>{" focus  "}</span>
+              <span style={{ fg: P().overlay0 }}>{"d"}</span>
+              <span style={{ fg: P().overlay1 }}>{" dismiss  "}</span>
+              <span style={{ fg: P().overlay0 }}>{"x"}</span>
+              <span style={{ fg: P().overlay1 }}>{" kill"}</span>
+            </text>
+          }
+        >
+          <text>
+            <span style={{ fg: P().overlay0 }}>{"⇥"}</span>
+            <span style={{ fg: P().overlay1 }}>{" cycle  "}</span>
+            <span style={{ fg: P().overlay0 }}>{"⏎"}</span>
+            <span style={{ fg: P().overlay1 }}>{" go  "}</span>
+            <span style={{ fg: P().overlay0 }}>{"→"}</span>
+            <span style={{ fg: P().overlay1 }}>{" agents  "}</span>
+            <span style={{ fg: P().overlay0 }}>{"d"}</span>
+            <span style={{ fg: P().overlay1 }}>{" hide  "}</span>
+            <span style={{ fg: P().overlay0 }}>{"x"}</span>
+            <span style={{ fg: P().overlay1 }}>{" kill"}</span>
+          </text>
+        </Show>
+      </box>
+
+      {/* Theme picker overlay */}
+      <Show when={modal() === "theme-picker"}>
+        <ThemePicker
+          palette={P}
+          onSelect={(name) => {
+            themeBeforePreview = null;
+            applyTheme(name);
+            setModal("none");
+          }}
+          onPreview={(name) => {
+            previewTheme(name);
+          }}
+          onClose={() => {
+            if (themeBeforePreview) {
+              setTheme(themeBeforePreview);
+              themeBeforePreview = null;
+            }
+            setModal("none");
+          }}
+        />
+      </Show>
+
+      {/* Kill confirmation overlay */}
+      <Show when={modal() === "confirm-kill"}>
+        <box
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          justifyContent="center"
+          alignItems="center"
+          backgroundColor="transparent"
+        >
+          <box
+            border
+            borderStyle="rounded"
+            borderColor={P().red}
+            backgroundColor={P().mantle}
+            padding={1}
+            paddingX={2}
+            flexDirection="column"
+            alignItems="center"
+          >
+            <text>
+              <span style={{ fg: P().red, attributes: BOLD }}>Kill session?</span>
+            </text>
+            <text>
+              <span style={{ fg: P().text }}>{killTarget() ?? ""}</span>
+            </text>
+            <text>
+              <span style={{ fg: P().overlay0 }}>y</span>
+              <span style={{ fg: P().overlay1 }}>/</span>
+              <span style={{ fg: P().overlay0 }}>n</span>
+            </text>
+          </box>
+        </box>
+      </Show>
+    </box>
+  );
+}
+
+// --- Theme Picker ---
+
+interface ThemePickerProps {
+  palette: Accessor<Theme["palette"]>;
+  onSelect: (name: string) => void;
+  onPreview: (name: string) => void;
+  onClose: () => void;
+}
+
+function ThemePicker(props: ThemePickerProps) {
+  let inputRef: InputRenderable;
+
+  const [query, setQuery] = createSignal("");
+  const [selected, setSelected] = createSignal(0);
+
+  const filtered = createMemo(() => {
+    const q = query().toLowerCase();
+    if (!q) return THEME_NAMES;
+    return THEME_NAMES.filter((name) => name.toLowerCase().includes(q));
+  });
+
+  function move(direction: -1 | 1) {
+    const list = filtered();
+    if (!list.length) return;
+    let next = selected() + direction;
+    if (next < 0) next = list.length - 1;
+    if (next >= list.length) next = 0;
+    setSelected(next);
+    const name = list[next];
+    if (name) props.onPreview(name);
+  }
+
+  function confirm() {
+    const name = filtered()[selected()];
+    if (name) props.onSelect(name);
+  }
+
+  function handleKeyDown(e: KeyEvent) {
+    if (e.name === "up") {
+      e.preventDefault();
+      move(-1);
+    } else if (e.name === "down") {
+      e.preventDefault();
+      move(1);
+    } else if (e.name === "return") {
+      e.preventDefault();
+      confirm();
+    } else if (e.name === "escape") {
+      e.preventDefault();
+      props.onClose();
+    }
+  }
+
+  function handleInput(value: string) {
+    setQuery(value);
+    setSelected(0);
+  }
+
+  const MAX_VISIBLE = 12;
+
+  const scrollOffset = createMemo(() => {
+    const sel = selected();
+    if (sel < MAX_VISIBLE) return 0;
+    return sel - MAX_VISIBLE + 1;
+  });
+
+  const visibleItems = createMemo(() => {
+    const list = filtered();
+    return list.slice(scrollOffset(), scrollOffset() + MAX_VISIBLE);
+  });
+
+  return (
+    <box
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      justifyContent="center"
+      alignItems="center"
+      backgroundColor="transparent"
+    >
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={props.palette().blue}
+        backgroundColor={props.palette().mantle}
+        padding={1}
+        flexDirection="column"
+        width={30}
+      >
+        <text>
+          <span style={{ fg: props.palette().blue, attributes: BOLD }}>Select Theme</span>
+        </text>
+        <box height={1}>
+          <text style={{ fg: props.palette().surface2 }}>{DIVIDER}</text>
+        </box>
+        <box border borderColor={props.palette().surface1} marginBottom={1}>
+          <input
+            ref={(r: InputRenderable) => {
+              inputRef = r;
+              inputRef.focus();
+            }}
+            value={query()}
+            onInput={handleInput}
+            onKeyDown={handleKeyDown}
+            placeholder="Search themes…"
+            backgroundColor={props.palette().surface0}
+            focusedBackgroundColor={props.palette().surface0}
+            textColor={props.palette().text}
+            cursorColor={props.palette().blue}
+            placeholderColor={props.palette().overlay0}
+          />
+        </box>
+        <Show
+          when={filtered().length > 0}
+          fallback={
+            <box paddingLeft={1}>
+              <text style={{ fg: props.palette().overlay0 }}>No matches</text>
+            </box>
+          }
+        >
+          <For each={visibleItems()}>
+            {(name) => {
+              const idx = createMemo(() => filtered().indexOf(name));
+              const isSel = createMemo(() => idx() === selected());
+              return (
+                <box
+                  paddingLeft={1}
+                  paddingRight={1}
+                  backgroundColor={isSel() ? props.palette().surface0 : undefined}
+                >
+                  <text style={{ fg: isSel() ? props.palette().text : props.palette().subtext0 }}>
+                    {isSel() ? "▸ " : "  "}
+                    {name}
+                  </text>
+                </box>
+              );
+            }}
+          </For>
+          <Show when={filtered().length > MAX_VISIBLE}>
+            <text style={{ fg: props.palette().overlay0, attributes: DIM }}>
+              {"  "}↕ {filtered().length - MAX_VISIBLE} more
+            </text>
+          </Show>
+        </Show>
+        <box height={1}>
+          <text style={{ fg: props.palette().surface2 }}>{DIVIDER}</text>
+        </box>
+        <text style={{ fg: props.palette().overlay0 }}>
+          <span style={{ attributes: DIM }}>↑↓</span>
+          {" browse  "}
+          <span style={{ attributes: DIM }}>⏎</span>
+          {" select  "}
+          <span style={{ attributes: DIM }}>esc</span>
+          {" close"}
+        </text>
+      </box>
+    </box>
+  );
+}
+
+// --- Detail Panel ---
+
+interface DetailPanelProps {
+  session: SessionData;
+  theme: Accessor<Theme>;
+  statusColors: Accessor<Theme["status"]>;
+  spinIdx: Accessor<number>;
+  focusedAgentIdx: number;
+  onDismissAgent: (agent: SessionData["agents"][number]) => void;
+  onFocusAgentPane: (agent: SessionData["agents"][number]) => void;
+  isResizeHover: boolean;
+  isResizing: boolean;
+  onResizeStart: (event: MouseEvent) => void;
+  onResizeDrag: (event: MouseEvent) => void;
+  onResizeEnd: (event?: MouseEvent) => void;
+  onResizeHoverChange: (hovered: boolean) => void;
+}
+
+function DetailPanel(props: DetailPanelProps) {
+  const P = () => props.theme().palette;
+
+  const agents = () => props.session.agents ?? [];
+  const hasAgents = () => agents().length > 0;
+  const meta = () => props.session.metadata;
+  const hasMeta = () => !!meta();
+  const visibleLogs = () => {
+    const m = meta();
+    if (!m || m.logs.length === 0) return [];
+    return m.logs.slice(-8);
+  };
+
+  const truncDir = () => {
+    const d = props.session.dir;
+    if (!d) return "";
+    const home = process.env.HOME ?? "";
+    const short = home && d.startsWith(home) ? "~" + d.slice(home.length) : d;
+    return short.length > 24 ? "…" + short.slice(short.length - 23) : short;
+  };
+
+  return (
+    <box flexDirection="column" flexShrink={0} paddingLeft={1}>
+      <box height={1}>
+        <text
+          selectable={false}
+          onMouseDown={(event) => {
+            logResizeDebug("separator:onMouseDown", {
+              x: event.x,
+              y: event.y,
+              button: event.button,
+              session: props.session.name,
+            });
+            event.preventDefault();
+            props.onResizeStart(event);
+          }}
+          onMouseDrag={(event) => {
+            logResizeDebug("separator:onMouseDrag", {
+              x: event.x,
+              y: event.y,
+              button: event.button,
+              session: props.session.name,
+            });
+            event.preventDefault();
+            props.onResizeDrag(event);
+          }}
+          onMouseDragEnd={(event) => {
+            logResizeDebug("separator:onMouseDragEnd", {
+              x: event.x,
+              y: event.y,
+              button: event.button,
+              session: props.session.name,
+            });
+            event.preventDefault();
+            props.onResizeEnd(event);
+          }}
+          onMouseUp={(event) => {
+            logResizeDebug("separator:onMouseUp", {
+              x: event.x,
+              y: event.y,
+              button: event.button,
+              session: props.session.name,
+            });
+            event.preventDefault();
+            props.onResizeEnd(event);
+          }}
+          onMouseOver={() => props.onResizeHoverChange(true)}
+          onMouseOut={() => {
+            if (!props.isResizing) props.onResizeHoverChange(false);
+          }}
+          style={{
+            fg: props.isResizing ? P().blue : props.isResizeHover ? P().overlay1 : P().surface2,
+          }}
+        >
+          {DIVIDER}
+        </text>
+      </box>
+
+      {/* Directory */}
+      <text truncate>
+        <span style={{ fg: P().overlay0, attributes: DIM }}>{truncDir()}</span>
+      </text>
+
+      {/* Agent instances */}
+      <Show when={hasAgents()}>
+        <For each={agents()}>
+          {(agent, i) => (
+            <AgentListItem
+              agent={agent}
+              palette={P}
+              statusColors={props.statusColors}
+              spinIdx={props.spinIdx}
+              isKeyboardFocused={i() === props.focusedAgentIdx}
+              onDismiss={() => props.onDismissAgent(agent)}
+              onFocusPane={() => props.onFocusAgentPane(agent)}
+            />
+          )}
+        </For>
+      </Show>
+
+      {/* Metadata: status, progress, logs */}
+      <Show when={hasMeta()}>
+        {(_) => {
+          const m = meta()!;
+          const progressText = () => {
+            const p = m.progress;
+            if (!p) return "";
+            if (p.current != null && p.total != null) return `${p.current}/${p.total}`;
+            if (p.percent != null) return `${Math.round(p.percent * 100)}%`;
+            return "";
+          };
+          return (
+            <box flexDirection="column">
+              <box height={1} />
+
+              {/* Status + progress on one line */}
+              <Show when={m.status || m.progress}>
+                <box flexDirection="row" paddingRight={1}>
+                  <Show when={m.status}>
+                    <text truncate flexGrow={1}>
+                      <span style={{ fg: toneColor(m.status!.tone, P()) }}>
+                        {TONE_ICONS[m.status!.tone ?? "neutral"]} {m.status!.text}
+                      </span>
+                    </text>
+                  </Show>
+                  <Show when={m.progress}>
+                    <text flexShrink={0}>
+                      <span style={{ fg: P().sky }}>
+                        {m.status ? " · " : ""}
+                        {progressText()}
+                        {m.progress!.label ? ` ${m.progress!.label}` : ""}
+                      </span>
+                    </text>
+                  </Show>
+                </box>
+              </Show>
+
+              {/* Log entries */}
+              <Show when={visibleLogs().length > 0}>
+                <For each={visibleLogs()}>
+                  {(entry) => (
+                    <text truncate>
+                      <span style={{ fg: toneColor(entry.tone, P()), attributes: DIM }}>
+                        {TONE_ICONS[entry.tone ?? "neutral"]}
+                      </span>
+                      <Show when={entry.source}>
+                        <span
+                          style={{ fg: P().surface2, attributes: DIM }}
+                        >{` [${entry.source}]`}</span>
+                      </Show>
+                      <span style={{ fg: P().overlay0 }}> {entry.message}</span>
+                    </text>
+                  )}
+                </For>
+              </Show>
+            </box>
+          );
+        }}
+      </Show>
+    </box>
+  );
+}
+
+interface AgentListItemProps {
+  agent: SessionData["agents"][number];
+  palette: Accessor<Theme["palette"]>;
+  statusColors: Accessor<Theme["status"]>;
+  spinIdx: Accessor<number>;
+  isKeyboardFocused: boolean;
+  onDismiss: () => void;
+  onFocusPane: () => void;
+}
+
+function AgentListItem(props: AgentListItemProps) {
+  const P = () => props.palette();
+  const SC = () => props.statusColors();
+  const [isDismissHover, setIsDismissHover] = createSignal(false);
+  const [isFlash, setIsFlash] = createSignal(false);
+
+  const isTerminal = () => ["done", "error", "interrupted"].includes(props.agent.status);
+  const isUnseen = () => isTerminal() && props.agent.unseen === true;
+
+  const icon = () => {
+    if (isUnseen()) return UNSEEN_ICON;
+    if (isTerminal())
+      return props.agent.status === "done" ? "✓" : props.agent.status === "error" ? "✗" : "⚠";
+    if (props.agent.status === "running") return SPINNERS[props.spinIdx() % SPINNERS.length]!;
+    if (props.agent.status === "waiting") return "◉";
+    return "○";
+  };
+
+  const color = () => {
+    if (isTerminal()) {
+      if (props.agent.status === "error") return P().red;
+      if (props.agent.status === "interrupted") return P().peach;
+      return isUnseen() ? P().teal : P().green;
+    }
+    return SC()[props.agent.status];
+  };
+
+  const statusText = () => {
+    if (props.agent.status === "running") return "running";
+    if (props.agent.status === "done") return "done";
+    if (props.agent.status === "error") return "error";
+    if (props.agent.status === "interrupted") return "stopped";
+    if (props.agent.status === "waiting") return "waiting";
+    return "";
+  };
+
+  const triggerFlash = () => {
+    setIsFlash(true);
+    setTimeout(() => setIsFlash(false), 150);
+  };
+
+  const bgColor = () => {
+    if (isFlash()) return P().surface1;
+    if (props.isKeyboardFocused) return P().surface0;
+    return "transparent";
+  };
+
+  return (
+    <box
+      flexDirection="column"
+      flexShrink={0}
+      onMouseDown={(event) => {
+        // Don't trigger focus if clicking the dismiss button
+        if ((event.target as any)?.id === "dismiss") return;
+        if (TUI_DEBUG)
+          appendFileSync(
+            "/tmp/agentboard2-tui-agent-click.log",
+            `[${new Date().toISOString()}] clicked agent=${props.agent.agent} thread=${props.agent.threadName ?? "?"}\n`,
+          );
+        triggerFlash();
+        props.onFocusPane();
+      }}
+    >
+      <box height={1} />
+      <box flexDirection="row" backgroundColor={bgColor()} paddingLeft={1}>
+        {/* Content column — name row + thread name row */}
+        <box flexDirection="column" flexGrow={1} paddingRight={1}>
+          {/* Row 1: icon + agent name + status + dismiss */}
+          <box flexDirection="row">
+            <text flexGrow={1} truncate>
+              <span style={{ fg: color() }}>{icon()}</span>
+              <span
+                style={{
+                  fg: props.isKeyboardFocused ? P().text : P().subtext1,
+                  attributes: props.isKeyboardFocused ? BOLD : undefined,
+                }}
+              >
+                {" "}
+                {props.agent.agent}
+              </span>
+            </text>
+            <Show when={!isTerminal() || !isUnseen()}>
+              <text flexShrink={0}>
+                <span style={{ fg: color(), attributes: DIM }}>{statusText()}</span>
+              </text>
+            </Show>
+            <text
+              flexShrink={0}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                props.onDismiss();
+              }}
+              onMouseOver={() => setIsDismissHover(true)}
+              onMouseOut={() => setIsDismissHover(false)}
+            >
+              <span style={{ fg: isDismissHover() ? P().red : P().overlay0 }}>{" ✕"}</span>
+            </text>
+          </box>
+
+          {/* Row 2: thread name */}
+          <Show when={props.agent.threadName}>
+            <text truncate>
+              <span style={{ fg: isUnseen() ? color() : P().overlay0 }}>
+                {props.agent.threadName}
+              </span>
+            </text>
+          </Show>
+        </box>
+      </box>
+    </box>
+  );
+}
+
+// --- Session Card ---
+
+interface SessionCardProps {
+  session: SessionData;
+  index: number;
+  isFocused: boolean;
+  isCurrent: boolean;
+  spinIdx: Accessor<number>;
+  theme: Accessor<Theme>;
+  statusColors: Accessor<Theme["status"]>;
+  onSelect: () => void;
+}
+
+function SessionCard(props: SessionCardProps) {
+  const P = () => props.theme().palette;
+  const SC = () => props.statusColors();
+
+  const status = () => props.session.agentState?.status ?? "idle";
+  const unseen = () => props.session.unseen;
+
+  const isUnseenTerminal = () => unseen() && ["done", "error", "interrupted"].includes(status());
+
+  const accentColor = () => {
+    if (props.isCurrent) return P().green;
+    if (isUnseenTerminal()) return unseenAccentColor();
+    const s = status();
+    if (s === "error") return P().red;
+    if (s === "interrupted") return P().peach;
+    if (s === "running") return P().yellow;
+    if (props.isFocused) return P().lavender;
+    return "transparent";
+  };
+
+  const unseenAccentColor = () => {
+    const s = status();
+    if (s === "error") return P().red;
+    if (s === "interrupted") return P().peach;
+    return P().teal;
+  };
+
+  const hasAgent = () => (props.session.agents?.length ?? 0) > 0;
+
+  const statusIcon = () => {
+    const s = status();
+    if (s === "running") return SPINNERS[props.spinIdx() % SPINNERS.length]!;
+    if (isUnseenTerminal()) return UNSEEN_ICON;
+    if (!hasAgent()) return "○";
+    return "";
+  };
+
+  const statusColor = () => {
+    if (isUnseenTerminal()) return unseenAccentColor();
+    if (!hasAgent()) return P().surface2;
+    return SC()[status()];
+  };
+
+  const nameColor = () => {
+    if (props.isFocused) return P().text;
+    if (props.isCurrent) return P().subtext1;
+    return P().subtext0;
+  };
+
+  const indexColor = () => {
+    if (props.isFocused) return P().subtext0;
+    return P().surface2;
+  };
+
+  const truncName = () => {
+    const n = props.session.name;
+    return n.length > 18 ? n.slice(0, 17) + "…" : n;
+  };
+
+  const truncBranch = () => {
+    const b = props.session.branch;
+    if (!b) return "";
+    return b.length > 30 ? b.slice(0, 29) + "…" : b;
+  };
+
+  const portHint = () => {
+    const ports = props.session.ports ?? [];
+    if (ports.length === 0) return "";
+    if (ports.length === 1) return `⌁${ports[0]}`;
+    return `⌁${ports[0]}+${ports.length - 1}`;
+  };
+
+  const metaSummary = () => {
+    const meta = props.session.metadata;
+    if (!meta) return "";
+    const parts: string[] = [];
+    if (meta.status) parts.push(meta.status.text);
+    if (meta.progress) {
+      if (meta.progress.current != null && meta.progress.total != null) {
+        parts.push(`${meta.progress.current}/${meta.progress.total}`);
+      } else if (meta.progress.percent != null) {
+        parts.push(`${Math.round(meta.progress.percent * 100)}%`);
+      }
+      if (meta.progress.label) parts.push(meta.progress.label);
+    }
+    return parts.join(" · ");
+  };
+
+  const metaTone = () => props.session.metadata?.status?.tone;
+
+  const bgColor = () => {
+    if (props.isFocused) return P().surface1;
+    return "transparent";
+  };
+
+  return (
+    <box flexDirection="column" flexShrink={0}>
+      <box
+        flexDirection="row"
+        backgroundColor={bgColor()}
+        onMouseDown={props.onSelect}
+        paddingLeft={1}
+      >
+        {/* Left accent — space-preserving, only colored for meaningful states */}
+        <text style={{ fg: accentColor() }}>{accentColor() === "transparent" ? " " : "▌"}</text>
+
+        {/* Index */}
+        <box width={3} flexShrink={0}>
+          <text style={{ fg: indexColor() }}>{String(props.index).padStart(2)}</text>
+        </box>
+
+        {/* Content */}
+        <box flexDirection="column" flexGrow={1} paddingRight={1}>
+          {/* Row 1: name + status */}
+          <box flexDirection="row">
+            <text truncate flexGrow={1}>
+              <span
+                style={{
+                  fg: nameColor(),
+                  attributes: props.isFocused || props.isCurrent ? BOLD : undefined,
+                }}
+              >
+                {truncName()}
+              </span>
+            </text>
+            <Show when={statusIcon()}>
+              <text flexShrink={0}>
+                <span style={{ fg: statusColor() }}> {statusIcon()}</span>
+              </text>
+            </Show>
+          </box>
+
+          {/* Row 2: branch plus a compact local-port hint when available */}
+          <Show when={props.session.branch || portHint()}>
+            <box flexDirection="row">
+              <Show when={props.session.branch}>
+                <text truncate flexGrow={1}>
+                  <span style={{ fg: props.isFocused ? P().pink : P().overlay0 }}>
+                    {truncBranch()}
+                  </span>
+                </text>
+              </Show>
+              <Show when={portHint()}>
+                <text flexShrink={0}>
+                  <span style={{ fg: props.isFocused ? P().sky : P().overlay0 }}>
+                    {props.session.branch ? " " : ""}
+                    {portHint()}
+                  </span>
+                </text>
+              </Show>
+            </box>
+          </Show>
+
+          {/* Row 3: metadata summary (status + progress) */}
+          <Show when={metaSummary()}>
+            <text truncate>
+              <span style={{ fg: toneColor(metaTone(), P()), attributes: DIM }}>
+                {metaSummary()}
+              </span>
+            </text>
+          </Show>
+        </box>
+      </box>
+
+      {/* Breathing room — 1 empty line between cards */}
+      <box height={1} />
+    </box>
+  );
+}
+
+async function main() {
+  await ensureServer();
+  render(() => <App />, {
+    exitOnCtrlC: true,
+    targetFPS: 30,
+    useMouse: true,
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/plugins/tt-agentboard2/apps/tui/src/mux-context.ts
+++ b/plugins/tt-agentboard2/apps/tui/src/mux-context.ts
@@ -1,0 +1,61 @@
+import { TmuxClient } from "@tt-agentboard2/mux-tmux";
+
+export type MuxContext = { type: "tmux"; sdk: TmuxClient; paneId: string } | { type: "none" };
+
+export function detectMuxContext(): MuxContext {
+  if (process.env.TMUX_PANE && process.env.TMUX) {
+    return { type: "tmux", sdk: new TmuxClient(), paneId: process.env.TMUX_PANE };
+  }
+  return { type: "none" };
+}
+
+/** Refocus the main (non-sidebar) pane after TUI capability detection finishes.
+ *  This must happen from the TUI process — doing it from start.sh races with
+ *  capability query responses and leaks escape sequences to the main pane. */
+export function refocusMainPane(muxCtx: MuxContext): void {
+  if (muxCtx.type === "tmux") {
+    try {
+      const windowId =
+        process.env.REFOCUS_WINDOW ||
+        Bun.spawnSync(["tmux", "display-message", "-t", muxCtx.paneId, "-p", "#{window_id}"], {
+          stdout: "pipe",
+          stderr: "pipe",
+        })
+          .stdout.toString()
+          .trim();
+      if (!windowId) return;
+      const r = Bun.spawnSync(
+        ["tmux", "list-panes", "-t", windowId, "-F", "#{pane_id} #{pane_title}"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const lines = r.stdout.toString().trim().split("\n");
+      const main = lines.find((l) => !l.includes("agentboard2-sidebar"));
+      if (main) {
+        const paneId = main.split(" ")[0];
+        Bun.spawnSync(["tmux", "select-pane", "-t", paneId], { stdout: "pipe", stderr: "pipe" });
+      }
+    } catch {}
+  }
+}
+
+export function getClientTty(muxCtx: MuxContext): string {
+  if (muxCtx.type === "tmux") {
+    const { sdk, paneId } = muxCtx;
+    const sessName = sdk.display("#{session_name}", { target: paneId });
+    if (sessName) {
+      const clients = sdk.listClients();
+      const client = clients.find((c) => c.sessionName === sessName);
+      if (client) return client.tty;
+    }
+    return sdk.getClientTty();
+  }
+  return "";
+}
+
+export function getLocalSessionName(muxCtx: MuxContext): string | null {
+  if (muxCtx.type === "tmux") {
+    const sessionName = muxCtx.sdk.display("#{session_name}", { target: muxCtx.paneId });
+    return sessionName || null;
+  }
+  return null;
+}

--- a/plugins/tt-agentboard2/apps/tui/tsconfig.json
+++ b/plugins/tt-agentboard2/apps/tui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "@opentui/solid",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/plugins/tt-agentboard2/bun.lock
+++ b/plugins/tt-agentboard2/bun.lock
@@ -1,0 +1,444 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@towles/tt-agentboard2",
+      "dependencies": {
+        "@tt-agentboard2/mux-tmux": "workspace:*",
+        "@tt-agentboard2/runtime": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.8.3",
+      },
+    },
+    "apps/server": {
+      "name": "@tt-agentboard2/server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tt-agentboard2/mux-tmux": "workspace:*",
+        "@tt-agentboard2/runtime": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
+    "apps/tui": {
+      "name": "@tt-agentboard2/tui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opentui/core": "^0.1.88",
+        "@opentui/solid": "^0.1.88",
+        "@tt-agentboard2/mux-tmux": "workspace:*",
+        "@tt-agentboard2/runtime": "workspace:*",
+        "solid-js": "^1.9.11",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
+    "packages/mux-tmux": {
+      "name": "@tt-agentboard2/mux-tmux",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tt-agentboard2/runtime": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
+    "packages/runtime": {
+      "name": "@tt-agentboard2/runtime",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.28.0", "", { "dependencies": { "@ampproject/remapping": "^2.2.0", "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.0", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.27.3", "@babel/helpers": "^7.27.6", "@babel/parser": "^7.28.0", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.0", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.27.3", "", { "dependencies": { "@babel/types": "^7.27.3" } }, "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/helper-replace-supers": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/traverse": "^7.28.6", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@7.28.5", "", { "dependencies": { "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5" } }, "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-optimise-call-expression": ["@babel/helper-optimise-call-expression@7.27.1", "", { "dependencies": { "@babel/types": "^7.27.1" } }, "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-replace-supers": ["@babel/helper-replace-supers@7.28.6", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w=="],
+
+    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A=="],
+
+    "@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.28.6", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA=="],
+
+    "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw=="],
+
+    "@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
+
+    "@jimp/core": ["@jimp/core@1.6.0", "", { "dependencies": { "@jimp/file-ops": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "await-to-js": "^3.0.0", "exif-parser": "^0.1.12", "file-type": "^16.0.0", "mime": "3" } }, "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w=="],
+
+    "@jimp/diff": ["@jimp/diff@1.6.0", "", { "dependencies": { "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "pixelmatch": "^5.3.0" } }, "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw=="],
+
+    "@jimp/file-ops": ["@jimp/file-ops@1.6.0", "", {}, "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ=="],
+
+    "@jimp/js-bmp": ["@jimp/js-bmp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "bmp-ts": "^1.0.9" } }, "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw=="],
+
+    "@jimp/js-gif": ["@jimp/js-gif@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "gifwrap": "^0.10.1", "omggif": "^1.0.10" } }, "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g=="],
+
+    "@jimp/js-jpeg": ["@jimp/js-jpeg@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "jpeg-js": "^0.4.4" } }, "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA=="],
+
+    "@jimp/js-png": ["@jimp/js-png@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "pngjs": "^7.0.0" } }, "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg=="],
+
+    "@jimp/js-tiff": ["@jimp/js-tiff@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "utif2": "^4.1.0" } }, "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw=="],
+
+    "@jimp/plugin-blit": ["@jimp/plugin-blit@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA=="],
+
+    "@jimp/plugin-blur": ["@jimp/plugin-blur@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw=="],
+
+    "@jimp/plugin-circle": ["@jimp/plugin-circle@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw=="],
+
+    "@jimp/plugin-color": ["@jimp/plugin-color@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "tinycolor2": "^1.6.0", "zod": "^3.23.8" } }, "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA=="],
+
+    "@jimp/plugin-contain": ["@jimp/plugin-contain@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ=="],
+
+    "@jimp/plugin-cover": ["@jimp/plugin-cover@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA=="],
+
+    "@jimp/plugin-crop": ["@jimp/plugin-crop@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang=="],
+
+    "@jimp/plugin-displace": ["@jimp/plugin-displace@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q=="],
+
+    "@jimp/plugin-dither": ["@jimp/plugin-dither@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0" } }, "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ=="],
+
+    "@jimp/plugin-fisheye": ["@jimp/plugin-fisheye@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA=="],
+
+    "@jimp/plugin-flip": ["@jimp/plugin-flip@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg=="],
+
+    "@jimp/plugin-hash": ["@jimp/plugin-hash@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "any-base": "^1.1.0" } }, "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q=="],
+
+    "@jimp/plugin-mask": ["@jimp/plugin-mask@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA=="],
+
+    "@jimp/plugin-print": ["@jimp/plugin-print@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/types": "1.6.0", "parse-bmfont-ascii": "^1.0.6", "parse-bmfont-binary": "^1.0.6", "parse-bmfont-xml": "^1.1.6", "simple-xml-to-json": "^1.2.2", "zod": "^3.23.8" } }, "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A=="],
+
+    "@jimp/plugin-quantize": ["@jimp/plugin-quantize@1.6.0", "", { "dependencies": { "image-q": "^4.0.0", "zod": "^3.23.8" } }, "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg=="],
+
+    "@jimp/plugin-resize": ["@jimp/plugin-resize@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA=="],
+
+    "@jimp/plugin-rotate": ["@jimp/plugin-rotate@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw=="],
+
+    "@jimp/plugin-threshold": ["@jimp/plugin-threshold@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w=="],
+
+    "@jimp/types": ["@jimp/types@1.6.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg=="],
+
+    "@jimp/utils": ["@jimp/utils@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "tinycolor2": "^1.6.0" } }, "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@opentui/core": ["@opentui/core@0.1.93", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.93", "@opentui/core-darwin-x64": "0.1.93", "@opentui/core-linux-arm64": "0.1.93", "@opentui/core-linux-x64": "0.1.93", "@opentui/core-win32-arm64": "0.1.93", "@opentui/core-win32-x64": "0.1.93", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-HlTM16ZiBKN0mPBNMHSILkSrbzNku6Pg/ovIpVVkEPqLeWeSC2bfZS4Uhc0Ej1sckVVVoU9HKBJanfHvpP+pMg=="],
+
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.93", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4I2mwhXLqRNUv7tu88hA6cBGaGpLZXkAa8W0VqBiGDV+Tx337x4T+vbQ7G57OwKXT787oTrEOF9rOOrGLov6qw=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.93", "", { "os": "darwin", "cpu": "x64" }, "sha512-jvYMgcg47a5qLhSv1DnQiafEWBQ1UukGutmsYV1TvNuhWtuDXYLVy2AhKIHPzbB9JNrV0IpjbxUC8QnJaP3n8g=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.93", "", { "os": "linux", "cpu": "arm64" }, "sha512-bvFqRcPftmg14iYmMc3d63XC9rhe4yF7pJRApH6klLBKp27WX/LU0iSO4mvyX7qhy65gcmyy4Sj9dl5jNJ+vlA=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.93", "", { "os": "linux", "cpu": "x64" }, "sha512-/wJXhwtNxdcpshrRl1KouyGE54ODAHxRQgBHtnlM/F4bB8cjzOlq2Yc+5cv5DxRz4Q0nQZFCPefwpg2U6ZwNdA=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.93", "", { "os": "win32", "cpu": "arm64" }, "sha512-g3PQobfM2yFPSzkBKRKFp8FgTG4ulWyJcU+GYXjyYmxQIT+ZbOU7UfR//ImRq3/FxUAfUC/MhC6WwjqccjEqBw=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.93", "", { "os": "win32", "cpu": "x64" }, "sha512-Spllte2W7q+WfB1zVHgHilVJNp+jpp77PkkxTWyMQNvT7vJNt9LABMNjGTGiJBBMkAuKvO0GgFNKxrda7tFKrQ=="],
+
+    "@opentui/solid": ["@opentui/solid@0.1.93", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.1.93", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.10", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.11" } }, "sha512-Qx+4qoLSjnRGoo/YY4sZJMyXj09Y5kaAMpVO+65Ax58MMj4TjABN4bOOiRT2KV7sKOMTjxiAgXAIaBuqBBJ0Qg=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tt-agentboard2/mux-tmux": ["@tt-agentboard2/mux-tmux@workspace:packages/mux-tmux"],
+
+    "@tt-agentboard2/runtime": ["@tt-agentboard2/runtime@workspace:packages/runtime"],
+
+    "@tt-agentboard2/server": ["@tt-agentboard2/server@workspace:apps/server"],
+
+    "@tt-agentboard2/tui": ["@tt-agentboard2/tui@workspace:apps/tui"],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
+
+    "await-to-js": ["await-to-js@3.0.0", "", {}, "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="],
+
+    "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.6", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ=="],
+
+    "babel-plugin-module-resolver": ["babel-plugin-module-resolver@5.0.2", "", { "dependencies": { "find-babel-config": "^2.1.1", "glob": "^9.3.3", "pkg-up": "^3.1.0", "reselect": "^4.1.7", "resolve": "^1.22.8" } }, "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg=="],
+
+    "babel-preset-solid": ["babel-preset-solid@1.9.10", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.3" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.10" }, "optionalPeers": ["solid-js"] }, "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ=="],
+
+    "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
+
+    "brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
+
+    "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "bun-webgpu": ["bun-webgpu@0.1.5", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.5", "bun-webgpu-darwin-x64": "^0.1.5", "bun-webgpu-linux-x64": "^0.1.5", "bun-webgpu-win32-x64": "^0.1.5" } }, "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA=="],
+
+    "bun-webgpu-darwin-arm64": ["bun-webgpu-darwin-arm64@0.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ=="],
+
+    "bun-webgpu-darwin-x64": ["bun-webgpu-darwin-x64@0.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng=="],
+
+    "bun-webgpu-linux-x64": ["bun-webgpu-linux-x64@0.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA=="],
+
+    "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001782", "", {}, "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.329", "", {}, "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
+
+    "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
+
+    "find-babel-config": ["find-babel-config@2.1.2", "", { "dependencies": { "json5": "^2.2.3" } }, "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg=="],
+
+    "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
+
+    "glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "jimp": ["jimp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/diff": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-gif": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-blur": "1.6.0", "@jimp/plugin-circle": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-contain": "1.6.0", "@jimp/plugin-cover": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-displace": "1.6.0", "@jimp/plugin-dither": "1.6.0", "@jimp/plugin-fisheye": "1.6.0", "@jimp/plugin-flip": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/plugin-mask": "1.6.0", "@jimp/plugin-print": "1.6.0", "@jimp/plugin-quantize": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/plugin-rotate": "1.6.0", "@jimp/plugin-threshold": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg=="],
+
+    "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "minimatch": ["minimatch@8.0.7", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg=="],
+
+    "minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
+
+    "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
+
+    "parse-bmfont-binary": ["parse-bmfont-binary@1.0.6", "", {}, "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="],
+
+    "parse-bmfont-xml": ["parse-bmfont-xml@1.1.6", "", { "dependencies": { "xml-parse-from-string": "^1.0.0", "xml2js": "^0.5.0" } }, "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
+
+    "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
+
+    "planck": ["planck@1.4.3", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-B+lHKhRSeg7vZOfEyEzyQVu7nx8JHcX3QgnAcHXrPW0j04XYKX5eXSiUrxH2Z5QR8OoqvjD6zKIaPMdMYAd0uA=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
+
+    "reselect": ["reselect@4.1.8", "", {}, "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="],
+
+    "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
+
+    "s-js": ["s-js@0.4.9", "", {}, "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "seroval": ["seroval@1.5.1", "", {}, "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.1", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw=="],
+
+    "simple-xml-to-json": ["simple-xml-to-json@1.2.4", "", {}, "sha512-3MY16e0ocMHL7N1ufpdObURGyX+lCo0T/A+y6VCwosLdH1HSda4QZl1Sdt/O+2qWp48WFi26XEp5rF0LoaL0Dg=="],
+
+    "solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
+
+    "stage-js": ["stage-js@1.0.1", "", {}, "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "three": ["three@0.177.0", "", {}, "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg=="],
+
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
+
+    "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+
+    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
+
+    "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
+
+    "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+  }
+}

--- a/plugins/tt-agentboard2/package.json
+++ b/plugins/tt-agentboard2/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@towles/tt-agentboard2",
+  "version": "0.0.1",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "type": "module",
+  "scripts": {
+    "start": "bun run scripts/start.ts",
+    "server": "bun run apps/server/src/main.ts",
+    "tui": "bun run apps/tui/src/index.tsx",
+    "dev:server": "bun --watch run apps/server/src/main.ts",
+    "dev:tui": "bun --watch run apps/tui/src/index.tsx",
+    "test": "bun test packages/runtime/test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tt-agentboard2/mux-tmux": "workspace:*",
+    "@tt-agentboard2/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.8.3"
+  }
+}

--- a/plugins/tt-agentboard2/packages/mux-tmux/package.json
+++ b/plugins/tt-agentboard2/packages/mux-tmux/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@tt-agentboard2/mux-tmux",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@tt-agentboard2/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/plugins/tt-agentboard2/packages/mux-tmux/src/client.ts
+++ b/plugins/tt-agentboard2/packages/mux-tmux/src/client.ts
@@ -1,0 +1,550 @@
+// --- Types ---
+
+export interface TmuxClientOptions {
+  /** Path to tmux binary (default: "tmux") */
+  bin?: string;
+  /** tmux socket name (-L flag) */
+  socketName?: string;
+  /** tmux socket path (-S flag) */
+  socketPath?: string;
+  /** Whether run() throws on non-zero exit (default: false) */
+  throwOnError?: boolean;
+}
+
+export interface TmuxRunResult {
+  args: readonly string[];
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  ok: boolean;
+}
+
+export class TmuxError extends Error {
+  readonly args: readonly string[];
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(result: TmuxRunResult) {
+    super(result.stderr || `tmux exited with code ${result.exitCode}`);
+    this.name = "TmuxError";
+    this.args = result.args;
+    this.exitCode = result.exitCode;
+    this.stdout = result.stdout;
+    this.stderr = result.stderr;
+  }
+}
+
+// --- Typed result interfaces ---
+
+export interface SessionInfo {
+  id: string;
+  name: string;
+  createdAt: number;
+  attachedClients: number;
+  windowCount: number;
+  dir: string;
+}
+
+export interface WindowInfo {
+  id: string;
+  sessionId: string;
+  sessionName: string;
+  index: number;
+  name: string;
+  active: boolean;
+  paneCount: number;
+}
+
+export interface PaneInfo {
+  id: string;
+  sessionName: string;
+  windowId: string;
+  windowIndex: number;
+  index: number;
+  active: boolean;
+  tty: string;
+  pid: number;
+  cwd: string;
+  command: string;
+  title: string;
+  width: number;
+  height: number;
+  left: number;
+  right: number;
+}
+
+export interface ClientInfo {
+  name: string;
+  tty: string;
+  pid: number;
+  sessionName: string;
+  width: number;
+  height: number;
+}
+
+// --- Hook types ---
+
+export const HOOK_NAMES = [
+  "client-session-changed",
+  "client-resized",
+  "client-attached",
+  "client-detached",
+  "client-focus-in",
+  "client-focus-out",
+  "session-created",
+  "session-closed",
+  "session-renamed",
+  "session-window-changed",
+  "window-linked",
+  "window-unlinked",
+  "window-renamed",
+  "window-layout-changed",
+  "after-select-window",
+  "after-new-window",
+  "after-resize-pane",
+  "pane-died",
+  "pane-exited",
+  "pane-focus-in",
+  "pane-focus-out",
+] as const;
+
+export type HookName = (typeof HOOK_NAMES)[number] | (string & {});
+
+// --- Pane list scoping ---
+
+export type PaneScope =
+  | { scope?: "all" }
+  | { scope: "session"; target: string }
+  | { scope: "window"; target: string };
+
+// --- Split-window options ---
+
+export interface SplitWindowOptions {
+  target: string;
+  direction?: "horizontal" | "vertical";
+  /** "before" = -b flag (split left/above), default is right/below */
+  before?: boolean;
+  /** Split against the entire window instead of only the target pane. */
+  fullWindow?: boolean;
+  size?: number;
+  command?: string;
+}
+
+// --- Internal parser helpers ---
+
+/** Field delimiter — tab character, universally supported by tmux */
+const SEP = "\t";
+
+type Parser<T> = (raw: string) => T;
+
+const str: Parser<string> = (s) => s;
+const int: Parser<number> = (s) => {
+  const n = Number.parseInt(s, 10);
+  return Number.isNaN(n) ? 0 : n;
+};
+const bool: Parser<boolean> = (s) => s === "1";
+
+type FieldSpec<T> = { [K in keyof T]: readonly [field: string, parse: Parser<T[K]>] };
+
+function buildFormat<T>(spec: FieldSpec<T>): string {
+  const keys = Object.keys(spec) as (keyof T)[];
+  return keys.map((k) => `#{${spec[k][0]}}`).join(SEP);
+}
+
+function parseRows<T>(spec: FieldSpec<T>, raw: string): T[] {
+  if (!raw) return [];
+  const keys = Object.keys(spec) as (keyof T)[];
+  return raw.split("\n").reduce<T[]>((acc, line) => {
+    if (!line) return acc;
+    const parts = line.split(SEP);
+    const obj = {} as T;
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]!;
+      const [, parse] = spec[key];
+      obj[key] = parse(parts[i] ?? "");
+    }
+    acc.push(obj);
+    return acc;
+  }, []);
+}
+
+// --- Specs ---
+
+const SESSION_SPEC: FieldSpec<SessionInfo> = {
+  id: ["session_id", str],
+  name: ["session_name", str],
+  createdAt: ["session_created", int],
+  attachedClients: ["session_attached", int],
+  windowCount: ["session_windows", int],
+  dir: ["session_path", str],
+};
+
+const WINDOW_SPEC: FieldSpec<WindowInfo> = {
+  id: ["window_id", str],
+  sessionId: ["session_id", str],
+  sessionName: ["session_name", str],
+  index: ["window_index", int],
+  name: ["window_name", str],
+  active: ["window_active", bool],
+  paneCount: ["window_panes", int],
+};
+
+const PANE_SPEC: FieldSpec<PaneInfo> = {
+  id: ["pane_id", str],
+  sessionName: ["session_name", str],
+  windowId: ["window_id", str],
+  windowIndex: ["window_index", int],
+  index: ["pane_index", int],
+  active: ["pane_active", bool],
+  tty: ["pane_tty", str],
+  pid: ["pane_pid", int],
+  cwd: ["pane_current_path", str],
+  command: ["pane_current_command", str],
+  title: ["pane_title", str],
+  width: ["pane_width", int],
+  height: ["pane_height", int],
+  left: ["pane_left", int],
+  right: ["pane_right", int],
+};
+
+const CLIENT_SPEC: FieldSpec<ClientInfo> = {
+  name: ["client_name", str],
+  tty: ["client_tty", str],
+  pid: ["client_pid", int],
+  sessionName: ["session_name", str],
+  width: ["client_width", int],
+  height: ["client_height", int],
+};
+
+// --- Format string constants (pre-built for performance) ---
+
+const SESSION_FORMAT = buildFormat(SESSION_SPEC);
+const WINDOW_FORMAT = buildFormat(WINDOW_SPEC);
+const PANE_FORMAT = buildFormat(PANE_SPEC);
+const CLIENT_FORMAT = buildFormat(CLIENT_SPEC);
+
+// --- TmuxClient ---
+
+export class TmuxClient {
+  private bin: string;
+  private globalArgs: string[];
+  private throwOnError: boolean;
+
+  constructor(options: TmuxClientOptions = {}) {
+    this.bin = options.bin ?? "tmux";
+    this.globalArgs = [];
+    if (options.socketName) this.globalArgs.push("-L", options.socketName);
+    if (options.socketPath) this.globalArgs.push("-S", options.socketPath);
+    this.throwOnError = options.throwOnError ?? false;
+  }
+
+  /**
+   * Direct tmux call bypassing the SDK's format parsing.
+   * Use for operations where format string parsing causes issues
+   * (e.g. join-pane, resize-window on stash sessions).
+   */
+  rawRun(args: readonly string[]): string {
+    try {
+      const result = Bun.spawnSync([this.bin, ...this.globalArgs, ...args], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return result.stdout.toString().trim();
+    } catch {
+      return "";
+    }
+  }
+
+  /**
+   * Low-level escape hatch: run any tmux subcommand and get typed result.
+   * All other methods use this internally.
+   */
+  run(args: readonly string[], options?: { throwOnError?: boolean }): TmuxRunResult {
+    const fullArgs = [this.bin, ...this.globalArgs, ...args];
+    const shouldThrow = options?.throwOnError ?? this.throwOnError;
+
+    try {
+      const result = Bun.spawnSync(fullArgs, { stdout: "pipe", stderr: "pipe" });
+      const out: TmuxRunResult = {
+        args: fullArgs,
+        exitCode: result.exitCode,
+        stdout: result.stdout.toString().trim(),
+        stderr: result.stderr.toString().trim(),
+        ok: result.exitCode === 0,
+      };
+      if (!out.ok && shouldThrow) throw new TmuxError(out);
+      return out;
+    } catch (e) {
+      if (e instanceof TmuxError) throw e;
+      return {
+        args: fullArgs,
+        exitCode: -1,
+        stdout: "",
+        stderr: e instanceof Error ? e.message : String(e),
+        ok: false,
+      };
+    }
+  }
+
+  // ─── Sessions ──────────────────────────────────────
+
+  listSessions(): SessionInfo[] {
+    const { stdout } = this.run(["list-sessions", "-F", SESSION_FORMAT]);
+    return parseRows(SESSION_SPEC, stdout);
+  }
+
+  newSession(options: { name?: string; cwd?: string; detached?: boolean } = {}): string {
+    const args = ["new-session"];
+    if (options.detached !== false) args.push("-d");
+    if (options.name) args.push("-s", options.name);
+    if (options.cwd) args.push("-c", options.cwd);
+    args.push("-P", "-F", "#{session_name}");
+    const { stdout } = this.run(args);
+    return stdout;
+  }
+
+  killSession(target: string): void {
+    this.run(["kill-session", "-t", target]);
+  }
+
+  // ─── Windows ───────────────────────────────────────
+
+  listWindows(options?: { scope?: "all" } | { scope: "session"; target: string }): WindowInfo[] {
+    const args = ["list-windows"];
+    if (!options || options.scope === "all" || !options.scope) {
+      args.push("-a");
+    } else if (options.scope === "session") {
+      args.push("-t", options.target);
+    }
+    args.push("-F", WINDOW_FORMAT);
+    const { stdout } = this.run(args);
+    return parseRows(WINDOW_SPEC, stdout);
+  }
+
+  killWindow(target: string): void {
+    this.run(["kill-window", "-t", target]);
+  }
+
+  // ─── Panes ─────────────────────────────────────────
+
+  listPanes(options?: PaneScope): PaneInfo[] {
+    const args = ["list-panes"];
+    if (!options || !options.scope || options.scope === "all") {
+      args.push("-a");
+    } else if (options.scope === "session") {
+      args.push("-s", "-t", options.target);
+    } else if (options.scope === "window") {
+      args.push("-t", options.target);
+    }
+    args.push("-F", PANE_FORMAT);
+    const { stdout } = this.run(args);
+    return parseRows(PANE_SPEC, stdout);
+  }
+
+  splitWindow(options: SplitWindowOptions): PaneInfo | null {
+    const args = ["split-window"];
+    if (options.direction === "horizontal" || !options.direction) {
+      args.push(options.before ? "-hb" : "-h");
+    } else {
+      args.push(options.before ? "-vb" : "-v");
+    }
+    if (options.fullWindow) args.push("-f");
+    if (options.size != null) args.push("-l", String(options.size));
+    args.push("-t", options.target);
+    args.push("-P", "-F", PANE_FORMAT);
+    if (options.command) args.push(options.command);
+    const { stdout, ok } = this.run(args);
+    if (!ok || !stdout) return null;
+    const rows = parseRows(PANE_SPEC, stdout);
+    return rows[0] ?? null;
+  }
+
+  selectPane(target: string): void {
+    this.run(["select-pane", "-t", target]);
+  }
+
+  setPaneStyle(target: string, style: string): void {
+    this.run(["select-pane", "-t", target, "-P", style]);
+  }
+
+  setPaneTitle(target: string, title: string): void {
+    this.run(["select-pane", "-t", target, "-T", title]);
+  }
+
+  killPane(target: string): void {
+    this.run(["kill-pane", "-t", target]);
+  }
+
+  resizePane(target: string, options: { width?: number; height?: number }): void {
+    const args = ["resize-pane", "-t", target];
+    if (options.width != null) args.push("-x", String(options.width));
+    if (options.height != null) args.push("-y", String(options.height));
+    this.run(args);
+  }
+
+  breakPane(options: { source: string; name?: string; detached?: boolean }): void {
+    const args = ["break-pane"];
+    if (options.detached !== false) args.push("-d");
+    args.push("-s", options.source);
+    if (options.name) args.push("-n", options.name);
+    this.run(args);
+  }
+
+  // ─── Clients ───────────────────────────────────────
+
+  listClients(): ClientInfo[] {
+    const { stdout } = this.run(["list-clients", "-F", CLIENT_FORMAT]);
+    return parseRows(CLIENT_SPEC, stdout);
+  }
+
+  switchClient(target: string, options?: { clientTty?: string }): void {
+    const args = ["switch-client"];
+    if (options?.clientTty) args.push("-c", options.clientTty);
+    args.push("-t", target);
+    this.run(args);
+  }
+
+  // ─── Display / query ───────────────────────────────
+
+  /**
+   * Run `display-message -p` to query a tmux format string.
+   * Returns the raw stdout string, trimmed.
+   */
+  display(format: string, options?: { target?: string }): string {
+    const args = ["display-message"];
+    if (options?.target) args.push("-t", options.target);
+    args.push("-p", format);
+    return this.run(args).stdout;
+  }
+
+  /**
+   * Get the current window ID (display-message -p '#{window_id}')
+   */
+  getCurrentWindowId(target?: string): string {
+    return this.display("#{window_id}", target ? { target } : undefined);
+  }
+
+  /**
+   * Get the current session name from the first attached client
+   */
+  getCurrentSession(): string | null {
+    const clients = this.listClients();
+    if (clients.length === 0) return null;
+    return clients[0]!.sessionName || null;
+  }
+
+  /**
+   * Get the client TTY for the current client
+   */
+  getClientTty(): string {
+    return this.display("#{client_tty}");
+  }
+
+  /**
+   * Get session directory (pane_current_path of the active pane)
+   */
+  getSessionDir(target: string): string {
+    return this.display("#{pane_current_path}", { target });
+  }
+
+  /**
+   * Get pane count for a session by listing panes with -s flag
+   */
+  getPaneCount(target: string): number {
+    const panes = this.listPanes({ scope: "session", target });
+    return panes.length;
+  }
+
+  /**
+   * Get the active pane's cwd for every session in one `list-panes -a` call.
+   * Uses tmux's -f filter to get only non-sidebar panes in active windows.
+   * First hit per session wins (tmux lists active pane first).
+   */
+  getActiveSessionDirs(): Map<string, string> {
+    const dirs = new Map<string, string>();
+    const { stdout } = this.run([
+      "list-panes",
+      "-a",
+      "-f",
+      "#{&&:#{window_active},#{!=:#{pane_title},agentboard2-sidebar}}",
+      "-F",
+      `#{session_name}${SEP}#{pane_current_path}`,
+    ]);
+    if (!stdout) return dirs;
+    for (const line of stdout.split("\n")) {
+      if (!line) continue;
+      const sep = line.indexOf(SEP);
+      if (sep < 0) continue;
+      const session = line.slice(0, sep);
+      const cwd = line.slice(sep + 1);
+      if (!dirs.has(session)) dirs.set(session, cwd);
+    }
+    return dirs;
+  }
+
+  /**
+   * Batch pane count retrieval for all sessions.
+   * Returns a Map of session name → pane count.
+   */
+  getAllPaneCounts(): Map<string, number> {
+    const counts = new Map<string, number>();
+    const panes = this.listPanes({ scope: "all" });
+    for (const p of panes) {
+      counts.set(p.sessionName, (counts.get(p.sessionName) ?? 0) + 1);
+    }
+    return counts;
+  }
+
+  // ─── Popups ────────────────────────────────────────
+
+  displayPopup(options: {
+    command: string;
+    title?: string;
+    width?: string | number;
+    height?: string | number;
+    style?: string;
+    borderStyle?: "rounded" | "sharp" | "double" | "heavy" | "simple" | "padded" | "none";
+    env?: Record<string, string>;
+    closeOnExit?: boolean;
+  }): void {
+    const args = ["display-popup"];
+    if (options.title) args.push("-T", options.title);
+    if (options.width) args.push("-w", String(options.width));
+    if (options.height) args.push("-h", String(options.height));
+    if (options.style) args.push("-s", options.style);
+    if (options.borderStyle) args.push("-b", options.borderStyle);
+    if (options.env) {
+      for (const [k, v] of Object.entries(options.env)) {
+        args.push("-e", `${k}=${v}`);
+      }
+    }
+    const closeOnExit = options.closeOnExit ?? true;
+    if (closeOnExit) args.push("-E");
+    args.push(options.command);
+    this.run(args);
+  }
+
+  // ─── Hooks ─────────────────────────────────────────
+
+  setGlobalHook(name: HookName, command: string): void {
+    this.run(["set-hook", "-g", name, command]);
+  }
+
+  unsetGlobalHook(name: HookName): void {
+    this.run(["set-hook", "-gu", name]);
+  }
+
+  // ─── Environment ───────────────────────────────────
+
+  setGlobalEnv(name: string, value: string): void {
+    this.run(["set-environment", "-g", name, value]);
+  }
+
+  getGlobalEnv(name: string): string | null {
+    const { stdout, ok } = this.run(["show-environment", "-g", name]);
+    if (!ok || !stdout) return null;
+    const eqIdx = stdout.indexOf("=");
+    return eqIdx >= 0 ? stdout.slice(eqIdx + 1) : null;
+  }
+}

--- a/plugins/tt-agentboard2/packages/mux-tmux/src/index.ts
+++ b/plugins/tt-agentboard2/packages/mux-tmux/src/index.ts
@@ -1,0 +1,18 @@
+// Re-export TmuxClient and types from client module
+export {
+  TmuxClient,
+  TmuxError,
+  HOOK_NAMES,
+  type TmuxClientOptions,
+  type TmuxRunResult,
+  type SessionInfo,
+  type WindowInfo,
+  type PaneInfo,
+  type ClientInfo,
+  type HookName,
+  type PaneScope,
+  type SplitWindowOptions,
+} from "./client";
+
+// Re-export TmuxProvider from provider module
+export { TmuxProvider, type TmuxProviderSettings } from "./provider";

--- a/plugins/tt-agentboard2/packages/mux-tmux/src/provider.ts
+++ b/plugins/tt-agentboard2/packages/mux-tmux/src/provider.ts
@@ -1,0 +1,260 @@
+import type {
+  MuxProviderV1,
+  MuxSessionInfo,
+  ActiveWindow,
+  SidebarPane,
+  SidebarPosition,
+  WindowCapable,
+  SidebarCapable,
+  BatchCapable,
+} from "@tt-agentboard2/runtime";
+import { TmuxClient } from "./client";
+import { debugLog } from "@tt-agentboard2/runtime";
+
+/** Settings for creating a tmux provider (ai-sdk style) */
+export interface TmuxProviderSettings {
+  /** Override the provider name */
+  name?: string;
+  /** Override the TmuxClient instance (for testing) */
+  client?: TmuxClient;
+}
+
+function plog(msg: string, data?: Record<string, unknown>) {
+  debugLog("provider", msg, data);
+}
+
+const STASH_SESSION = "_ab2_stash";
+const SIDEBAR_PANE_TITLE = "agentboard2-sidebar";
+
+export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapable, BatchCapable {
+  readonly specificationVersion = "v1" as const;
+  readonly name: string;
+  private readonly tmux: TmuxClient;
+
+  constructor(settings?: TmuxProviderSettings) {
+    this.name = settings?.name ?? "tmux";
+    this.tmux = settings?.client ?? new TmuxClient();
+  }
+
+  listSessions(): MuxSessionInfo[] {
+    const sessions = this.tmux.listSessions().filter((s) => s.name !== STASH_SESSION);
+    const activeDirs = this.tmux.getActiveSessionDirs();
+    return sessions.map((s) => ({
+      name: s.name,
+      createdAt: s.createdAt,
+      dir: activeDirs.get(s.name) ?? s.dir,
+      windows: s.windowCount,
+    }));
+  }
+
+  switchSession(name: string, clientTty?: string): void {
+    this.tmux.switchClient(name, clientTty ? { clientTty } : undefined);
+  }
+
+  getCurrentSession(): string | null {
+    return this.tmux.getCurrentSession();
+  }
+
+  getSessionDir(name: string): string {
+    return this.tmux.getSessionDir(name);
+  }
+
+  getPaneCount(name: string): number {
+    return this.tmux.getPaneCount(name);
+  }
+
+  getClientTty(): string {
+    return this.tmux.getClientTty();
+  }
+
+  createSession(name?: string, dir?: string): void {
+    this.tmux.newSession({ name, cwd: dir });
+  }
+
+  killSession(name: string): void {
+    this.tmux.killSession(name);
+  }
+
+  setupHooks(serverHost: string, serverPort: number): void {
+    const base = `http://${serverHost}:${serverPort}`;
+    const hookPost = (path: string, data?: string) => {
+      // #{q:...} escapes shell metacharacters in each tmux variable.
+      // Use escaped double quotes (\") inside the outer run-shell "..." to wrap the body.
+      const body = data ? ` -d \\"${data}\\"` : "";
+      return `run-shell -b "curl -s -o /dev/null -X POST ${base}${path}${body} >/dev/null 2>&1 || true"`;
+    };
+    // tmux expands #{} formats at hook-fire time — no need for $(tmux display-message)
+    // #{q:...} shell-escapes each value to prevent injection from session names etc.
+    const focusCmd = hookPost("/focus", "#{q:client_tty}|#{q:session_name}|#{q:window_id}");
+    const refreshCmd = hookPost("/refresh");
+    const resizeCmd = hookPost("/resize-sidebars");
+    const resizePaneCmd = hookPost(
+      "/resize-sidebars",
+      "#{q:pane_id}|#{q:session_name}|#{q:window_id}|#{q:pane_width}|#{q:window_width}",
+    );
+    const ensureCmd = hookPost(
+      "/ensure-sidebar",
+      "#{q:client_tty}|#{q:session_name}|#{q:window_id}",
+    );
+
+    // client-session-changed: update focus AND ensure sidebar in the new session's window
+    this.tmux.setGlobalHook("client-session-changed", `${focusCmd} ; ${ensureCmd}`);
+    this.tmux.setGlobalHook("session-created", refreshCmd);
+    this.tmux.setGlobalHook("session-closed", refreshCmd);
+    this.tmux.setGlobalHook("client-resized", resizeCmd);
+    this.tmux.setGlobalHook("after-select-window", ensureCmd);
+    this.tmux.setGlobalHook("after-new-window", ensureCmd);
+    this.tmux.setGlobalHook("after-resize-pane", resizePaneCmd);
+  }
+
+  cleanupHooks(): void {
+    this.tmux.unsetGlobalHook("client-session-changed");
+    this.tmux.unsetGlobalHook("session-created");
+    this.tmux.unsetGlobalHook("session-closed");
+    this.tmux.unsetGlobalHook("client-resized");
+    this.tmux.unsetGlobalHook("after-select-window");
+    this.tmux.unsetGlobalHook("after-new-window");
+    this.tmux.unsetGlobalHook("after-resize-pane");
+  }
+
+  getAllPaneCounts(): Map<string, number> {
+    return this.tmux.getAllPaneCounts();
+  }
+
+  listActiveWindows(): ActiveWindow[] {
+    return this.tmux
+      .listWindows()
+      .filter((w) => w.active && w.sessionName !== STASH_SESSION)
+      .map((w) => ({ id: w.id, sessionName: w.sessionName, active: w.active }));
+  }
+
+  getCurrentWindowId(): string | null {
+    return this.tmux.getCurrentWindowId() || null;
+  }
+
+  cleanupSidebar(): void {
+    // Kill the stash session used for hiding sidebar panes
+    this.tmux.killSession(STASH_SESSION);
+  }
+
+  listSidebarPanes(sessionName?: string): SidebarPane[] {
+    const panes = sessionName
+      ? this.tmux.listPanes({ scope: "session", target: sessionName })
+      : this.tmux.listPanes();
+    const windowWidths = new Map<string, number>();
+    for (const pane of panes) {
+      windowWidths.set(
+        pane.windowId,
+        Math.max(windowWidths.get(pane.windowId) ?? 0, pane.right + 1),
+      );
+    }
+
+    return panes
+      .filter((p) => p.title === SIDEBAR_PANE_TITLE && p.sessionName !== STASH_SESSION)
+      .map((p) => ({
+        paneId: p.id,
+        sessionName: p.sessionName,
+        windowId: p.windowId,
+        width: p.width,
+        windowWidth: windowWidths.get(p.windowId),
+      }));
+  }
+
+  /** Ensure the invisible stash session exists for hiding sidebar panes */
+  private ensureStash(): void {
+    const r = this.tmux.run(["has-session", "-t", STASH_SESSION]);
+    if (!r.ok) {
+      this.tmux.rawRun(["new-session", "-d", "-s", STASH_SESSION, "-x", "80", "-y", "24"]);
+    }
+  }
+
+  spawnSidebar(
+    sessionName: string,
+    windowId: string,
+    width: number,
+    position: SidebarPosition,
+    scriptsDir: string,
+  ): string | null {
+    // Find the edge pane to split against
+    const panes = this.tmux.listPanes({ scope: "window", target: windowId });
+    plog("spawnSidebar", { windowId, paneCount: panes.length });
+    if (panes.length === 0) return null;
+
+    const targetPane =
+      position === "left"
+        ? panes.reduce((a, b) => (a.left <= b.left ? a : b))
+        : panes.reduce((a, b) => (a.right >= b.right ? a : b));
+
+    // --- Try to restore a stashed sidebar pane ---
+    try {
+      const stashPanes = this.tmux.listPanes({ scope: "session", target: STASH_SESSION });
+      const stashedPane = stashPanes.find((p) => p.title === SIDEBAR_PANE_TITLE);
+      if (stashedPane) {
+        plog("spawnSidebar: restoring from stash", {
+          paneId: stashedPane.id,
+          target: targetPane.id,
+        });
+        const joinFlag = position === "left" ? "-hb" : "-h";
+        this.tmux.rawRun([
+          "join-pane",
+          joinFlag,
+          "-f",
+          "-l",
+          String(width),
+          "-s",
+          stashedPane.id,
+          "-t",
+          targetPane.id,
+        ]);
+        this.tmux.setPaneTitle(stashedPane.id, SIDEBAR_PANE_TITLE);
+        // Do NOT selectPane here — same as fresh spawns. The TUI's
+        // restoreTerminalModes fires on focus-in after join-pane, generating
+        // capability query responses. Refocusing the main pane immediately
+        // causes those responses to leak as garbage escape sequences.
+        return stashedPane.id;
+      }
+    } catch {
+      /* stash session doesn't exist yet — spawn fresh */
+    }
+
+    // --- No stashed pane, spawn fresh ---
+    plog("spawnSidebar: spawning new", { target: targetPane.id, width, position });
+    const newPane = this.tmux.splitWindow({
+      target: targetPane.id,
+      direction: "horizontal",
+      before: position === "left",
+      fullWindow: true,
+      size: width,
+      command: `REFOCUS_WINDOW=${windowId} exec ${scriptsDir}/start.sh`,
+    });
+
+    if (!newPane) {
+      plog("spawnSidebar: splitWindow FAILED");
+      return null;
+    }
+
+    this.tmux.setPaneTitle(newPane.id, SIDEBAR_PANE_TITLE);
+    // Do NOT selectPane here for fresh spawns — the TUI's refocusMainPane()
+    // handles it after terminal capability detection finishes. Refocusing
+    // immediately causes capability query responses (DECRPM, DA1, Kitty
+    // graphics) to be routed to the main pane as garbage escape sequences.
+    return newPane.id;
+  }
+
+  hideSidebar(paneId: string): void {
+    this.ensureStash();
+    // Ensure the stash window is large enough to accept another pane.
+    // join-pane fails with "pane too small" when stash panes fill up.
+    this.tmux.rawRun(["resize-window", "-t", `${STASH_SESSION}:`, "-x", "200", "-y", "200"]);
+    plog("hideSidebar: stashing pane", { paneId });
+    this.tmux.rawRun(["join-pane", "-d", "-s", paneId, "-t", `${STASH_SESSION}:`]);
+  }
+
+  killSidebarPane(paneId: string): void {
+    this.tmux.killPane(paneId);
+  }
+
+  resizeSidebarPane(paneId: string, width: number): void {
+    this.tmux.resizePane(paneId, { width });
+  }
+}

--- a/plugins/tt-agentboard2/packages/mux-tmux/tsconfig.json
+++ b/plugins/tt-agentboard2/packages/mux-tmux/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/plugins/tt-agentboard2/packages/runtime/package.json
+++ b/plugins/tt-agentboard2/packages/runtime/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@tt-agentboard2/runtime",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/agents/tracker.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/agents/tracker.ts
@@ -1,0 +1,233 @@
+import type { AgentEvent } from "../contracts/agent";
+import { TERMINAL_STATUSES } from "../contracts/agent";
+
+const MAX_EVENT_TIMESTAMPS = 30;
+const TERMINAL_PRUNE_MS = 5 * 60 * 1000;
+
+const STATUS_PRIORITY: Record<string, number> = {
+  running: 5,
+  error: 4,
+  interrupted: 3,
+  waiting: 2,
+  done: 1,
+  idle: 0,
+};
+
+export function instanceKey(agent: string, threadId?: string): string {
+  return threadId ? `${agent}:${threadId}` : agent;
+}
+
+export class AgentTracker {
+  // Outer key: session name, inner key: instance key (agent or agent:threadId)
+  private instances = new Map<string, Map<string, AgentEvent>>();
+  private eventTimestamps = new Map<string, number[]>();
+  // Per-instance unseen tracking: "session\0instanceKey"
+  private unseenInstances = new Set<string>();
+  private active = new Set<string>();
+  // Pinned instances: agents backed by a live pane process — exempt from pruning
+  private pinnedKeys = new Map<string, Set<string>>(); // session → Set<instanceKey>
+
+  private unseenKey(session: string, key: string): string {
+    return `${session}\0${key}`;
+  }
+
+  applyEvent(event: AgentEvent, options?: { seed?: boolean }): void {
+    const key = instanceKey(event.agent, event.threadId);
+
+    // Store instance
+    let sessionInstances = this.instances.get(event.session);
+    if (!sessionInstances) {
+      sessionInstances = new Map();
+      this.instances.set(event.session, sessionInstances);
+    }
+    sessionInstances.set(key, event);
+
+    // Track event timestamps
+    let timestamps = this.eventTimestamps.get(event.session);
+    if (!timestamps) {
+      timestamps = [];
+      this.eventTimestamps.set(event.session, timestamps);
+    }
+    timestamps.push(event.ts);
+    if (timestamps.length > MAX_EVENT_TIMESTAMPS) {
+      timestamps.splice(0, timestamps.length - MAX_EVENT_TIMESTAMPS);
+    }
+
+    // Per-instance unseen tracking
+    // Seeded events always mark as unseen (they represent state from before the user connected)
+    const ukey = this.unseenKey(event.session, key);
+    if (TERMINAL_STATUSES.has(event.status)) {
+      if (options?.seed || !this.active.has(event.session)) {
+        this.unseenInstances.add(ukey);
+      }
+    } else {
+      // Non-terminal status for this instance = user is interacting, mark seen
+      this.unseenInstances.delete(ukey);
+    }
+  }
+
+  /** Returns the most important agent state for backward compat */
+  getState(session: string): AgentEvent | null {
+    const sessionInstances = this.instances.get(session);
+    if (!sessionInstances || sessionInstances.size === 0) return null;
+
+    let best: AgentEvent | null = null;
+    let bestPriority = -1;
+    for (const event of sessionInstances.values()) {
+      const p = STATUS_PRIORITY[event.status] ?? 0;
+      if (p > bestPriority) {
+        bestPriority = p;
+        best = event;
+      }
+    }
+    return best;
+  }
+
+  /** Returns all agent instances for a session, with unseen flag stamped */
+  getAgents(session: string): AgentEvent[] {
+    const sessionInstances = this.instances.get(session);
+    if (!sessionInstances) return [];
+    return [...sessionInstances.values()]
+      .map((event) => {
+        const key = instanceKey(event.agent, event.threadId);
+        const isUnseen = this.unseenInstances.has(this.unseenKey(session, key));
+        return isUnseen ? { ...event, unseen: true } : event;
+      })
+      .sort((a, b) => b.ts - a.ts);
+  }
+
+  /** Returns recent event timestamps for sparkline rendering */
+  getEventTimestamps(session: string): number[] {
+    return this.eventTimestamps.get(session) ?? [];
+  }
+
+  markSeen(session: string): boolean {
+    const hadUnseen = this.isUnseen(session);
+    if (!hadUnseen) return false;
+
+    // Clear unseen flags for all instances — keep the instances themselves
+    // (pruneTerminal will remove seen terminal instances after timeout)
+    const sessionInstances = this.instances.get(session);
+    if (sessionInstances) {
+      for (const key of sessionInstances.keys()) {
+        this.unseenInstances.delete(this.unseenKey(session, key));
+      }
+    }
+    return true;
+  }
+
+  dismiss(session: string, agent: string, threadId?: string): boolean {
+    const sessionInstances = this.instances.get(session);
+    if (!sessionInstances) return false;
+
+    const key = instanceKey(agent, threadId);
+    const removed = sessionInstances.delete(key);
+    if (!removed) return false;
+
+    this.unseenInstances.delete(this.unseenKey(session, key));
+    if (sessionInstances.size === 0) {
+      this.instances.delete(session);
+    }
+    return true;
+  }
+
+  pruneStuck(timeoutMs: number): void {
+    const now = Date.now();
+    for (const [session, sessionInstances] of this.instances) {
+      for (const [key, event] of sessionInstances) {
+        if (event.status === "running" && now - event.ts > timeoutMs) {
+          if (this.isPinned(session, key)) continue;
+          sessionInstances.delete(key);
+          this.unseenInstances.delete(this.unseenKey(session, key));
+        }
+      }
+      if (sessionInstances.size === 0) {
+        this.instances.delete(session);
+      }
+    }
+  }
+
+  /** Auto-prune terminal instances older than timeout, but only if instance is not unseen or pinned */
+  pruneTerminal(): void {
+    const now = Date.now();
+    for (const [session, sessionInstances] of this.instances) {
+      for (const [key, event] of sessionInstances) {
+        if (!TERMINAL_STATUSES.has(event.status)) continue;
+        const ukey = this.unseenKey(session, key);
+        if (this.unseenInstances.has(ukey)) continue; // Don't prune unseen — user hasn't looked yet
+        if (this.isPinned(session, key)) continue; // Don't prune agents backed by live panes
+        if (now - event.ts > TERMINAL_PRUNE_MS) {
+          sessionInstances.delete(key);
+        }
+      }
+      if (sessionInstances.size === 0) {
+        this.instances.delete(session);
+      }
+    }
+  }
+
+  isUnseen(session: string): boolean {
+    // Session is unseen if any instance within it is unseen
+    const sessionInstances = this.instances.get(session);
+    if (!sessionInstances) return false;
+    for (const key of sessionInstances.keys()) {
+      if (this.unseenInstances.has(this.unseenKey(session, key))) return true;
+    }
+    return false;
+  }
+
+  getUnseen(): string[] {
+    // Derive session-level unseen from per-instance tracking
+    const sessions = new Set<string>();
+    for (const ukey of this.unseenInstances) {
+      sessions.add(ukey.split("\0")[0]!);
+    }
+    return [...sessions];
+  }
+
+  handleFocus(session: string): boolean {
+    this.active.clear();
+    this.active.add(session);
+
+    const hadUnseen = this.isUnseen(session);
+    if (hadUnseen) {
+      // Clear unseen flags — keep terminal instances visible (as "seen")
+      // pruneTerminal will clean them up after timeout
+      const sessionInstances = this.instances.get(session);
+      if (sessionInstances) {
+        for (const key of sessionInstances.keys()) {
+          this.unseenInstances.delete(this.unseenKey(session, key));
+        }
+      }
+    }
+    return hadUnseen;
+  }
+
+  setActiveSessions(sessions: string[]): void {
+    this.active.clear();
+    for (const s of sessions) this.active.add(s);
+  }
+
+  /** Update the set of pinned instance keys for a session (live pane-backed agents). */
+  setPinnedInstances(session: string | null, keys: string[]): void {
+    this.pinnedKeys.clear();
+    if (session && keys.length > 0) {
+      this.pinnedKeys.set(session, new Set(keys));
+    }
+  }
+
+  /** Update pinned instance keys for multiple sessions at once. */
+  setPinnedInstancesMulti(keysBySession: Map<string, string[]>): void {
+    this.pinnedKeys.clear();
+    for (const [session, keys] of keysBySession) {
+      if (keys.length > 0) {
+        this.pinnedKeys.set(session, new Set(keys));
+      }
+    }
+  }
+
+  /** Check if an instance is pinned (backed by a live pane process). */
+  isPinned(session: string, key: string): boolean {
+    return this.pinnedKeys.get(session)?.has(key) ?? false;
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/agents/watchers/amp.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/agents/watchers/amp.ts
@@ -1,0 +1,316 @@
+/**
+ * Amp agent watcher
+ *
+ * Watches ~/.local/share/amp/threads/ for JSON file changes,
+ * determines agent status from the last message, and emits events
+ * mapped to mux sessions via the project directory in each thread.
+ *
+ * All file I/O is async to avoid blocking the server event loop.
+ */
+
+import { watch } from "node:fs";
+import type { FSWatcher } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
+import type { AgentStatus } from "../../contracts/agent";
+import type { AgentWatcher, AgentWatcherContext } from "../../contracts/agent-watcher";
+
+// --- Thread file types ---
+
+interface MessageState {
+  type?: string;
+  stopReason?: string;
+}
+
+interface Message {
+  role?: string;
+  state?: MessageState;
+}
+
+interface ThreadSnapshot {
+  status: AgentStatus;
+  version: number;
+  title?: string;
+  projectDir?: string;
+  mtimeMs: number;
+}
+
+const STALE_MS = 5 * 60 * 1000;
+const POLL_MS = 2000;
+
+// --- Status detection ---
+
+export function determineStatus(
+  lastMsg: { role?: string; state?: MessageState } | null,
+): AgentStatus {
+  if (!lastMsg?.role) return "idle";
+
+  if (lastMsg.role === "user") return "running";
+
+  if (lastMsg.role === "assistant") {
+    const state = lastMsg.state;
+    if (!state) return "running";
+    if (state.type === "streaming") return "running";
+    if (state.type === "cancelled" || state.type === "aborted" || state.type === "interrupted")
+      return "interrupted";
+    if (state.type === "error" || state.type === "errored" || state.type === "failed")
+      return "error";
+    if (state.type === "complete") {
+      if (state.stopReason === "tool_use") return "running";
+      if (state.stopReason === "end_turn") return "done";
+      // Amp uses other stop reasons such as max_tokens for terminal failures.
+      return "error";
+    }
+    return "waiting";
+  }
+
+  return "idle";
+}
+
+// --- Async thread file parsing ---
+
+async function parseThreadFile(filePath: string): Promise<{
+  version: number;
+  title?: string;
+  projectDir?: string;
+  lastMessage: Message | null;
+} | null> {
+  try {
+    const raw = await Bun.file(filePath).text();
+    const thread = JSON.parse(raw);
+    const messages = thread.messages ?? [];
+    const lastMsg = messages.length > 0 ? messages[messages.length - 1] : null;
+    const uri: string = thread.env?.initial?.trees?.[0]?.uri ?? "";
+    const projectDir = uri.startsWith("file://") ? uri.slice(7) : undefined;
+
+    return {
+      version: thread.v ?? 0,
+      title: thread.title || undefined,
+      projectDir,
+      lastMessage: lastMsg ? { role: lastMsg.role, state: lastMsg.state } : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// --- Watcher implementation ---
+
+export class AmpAgentWatcher implements AgentWatcher {
+  readonly name = "amp";
+
+  private threads = new Map<string, ThreadSnapshot>();
+  private fsWatcher: FSWatcher | null = null;
+  private sessionWatcher: FSWatcher | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private ctx: AgentWatcherContext | null = null;
+  private threadsDir: string;
+  private sessionFile: string;
+  private scanning = false;
+  private seeded = false;
+  private lastFocusedThread: string | null = null;
+
+  constructor() {
+    const dataDir = join(homedir(), ".local", "share", "amp");
+    this.threadsDir = join(dataDir, "threads");
+    this.sessionFile = join(dataDir, "session.json");
+  }
+
+  start(ctx: AgentWatcherContext): void {
+    this.ctx = ctx;
+    this.setupWatch();
+    this.setupSessionWatch();
+    setTimeout(() => this.scan(), 50);
+    this.pollTimer = setInterval(() => this.scan(), POLL_MS);
+  }
+
+  stop(): void {
+    if (this.fsWatcher) {
+      try {
+        this.fsWatcher.close();
+      } catch {}
+      this.fsWatcher = null;
+    }
+    if (this.sessionWatcher) {
+      try {
+        this.sessionWatcher.close();
+      } catch {}
+      this.sessionWatcher = null;
+    }
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.ctx = null;
+  }
+
+  private emitThread(threadId: string, snapshot: ThreadSnapshot): boolean {
+    if (!this.ctx || !snapshot.projectDir || snapshot.status === "idle") return false;
+
+    const session = this.ctx.resolveSession(snapshot.projectDir);
+    if (!session || session === "unknown") return false;
+
+    this.ctx.emit({
+      agent: "amp",
+      session,
+      status: snapshot.status,
+      ts: Date.now(),
+      threadId,
+      threadName: snapshot.title,
+    });
+    return true;
+  }
+
+  private async processThread(filePath: string): Promise<boolean> {
+    if (!this.ctx) return false;
+
+    let fileStat;
+    try {
+      fileStat = await stat(filePath);
+    } catch {
+      return false;
+    }
+
+    const threadId = basename(filePath, ".json");
+    const prev = this.threads.get(threadId);
+
+    // Quick mtime check — skip if file hasn't changed since we last saw this version
+    if (prev && fileStat.mtimeMs <= prev.mtimeMs) return false;
+
+    const parsed = await parseThreadFile(filePath);
+    if (!parsed) return false;
+
+    const status = determineStatus(parsed.lastMessage);
+    const statusChanged = prev?.status !== status;
+    const titleChanged = prev?.title !== parsed.title;
+    const projectDirChanged = prev?.projectDir !== parsed.projectDir;
+
+    if (
+      prev &&
+      parsed.version === prev.version &&
+      !statusChanged &&
+      !titleChanged &&
+      !projectDirChanged
+    ) {
+      // Update mtime even if version unchanged to avoid re-reading
+      prev.mtimeMs = fileStat.mtimeMs;
+      return false;
+    }
+
+    const snapshot: ThreadSnapshot = {
+      status,
+      version: parsed.version,
+      title: parsed.title,
+      projectDir: parsed.projectDir,
+      mtimeMs: fileStat.mtimeMs,
+    };
+    this.threads.set(threadId, snapshot);
+
+    // Seed mode: record state without emitting
+    if (!this.seeded) return false;
+
+    return (statusChanged || titleChanged) && this.emitThread(threadId, snapshot);
+  }
+
+  private async scan(): Promise<void> {
+    if (this.scanning || !this.ctx) return;
+    this.scanning = true;
+    const initialSeed = !this.seeded;
+
+    try {
+      let files: string[];
+      try {
+        files = await readdir(this.threadsDir);
+      } catch {
+        return;
+      }
+
+      const now = Date.now();
+      for (const file of files) {
+        if (!file.startsWith("T-") || !file.endsWith(".json")) continue;
+        const filePath = join(this.threadsDir, file);
+        let fileStat;
+        try {
+          fileStat = await stat(filePath);
+        } catch {
+          continue;
+        }
+        if (now - fileStat.mtimeMs > STALE_MS) continue;
+        await this.processThread(filePath);
+      }
+    } finally {
+      if (initialSeed) {
+        this.seeded = true;
+        for (const [threadId, snapshot] of this.threads) {
+          this.emitThread(threadId, snapshot);
+        }
+      }
+      this.scanning = false;
+    }
+  }
+
+  private setupWatch(): void {
+    try {
+      this.fsWatcher = watch(this.threadsDir, (_eventType, filename) => {
+        if (!filename?.startsWith("T-") || !filename.endsWith(".json")) return;
+        this.processThread(join(this.threadsDir, filename));
+      });
+    } catch {
+      // fs.watch failed; polling handles it
+    }
+  }
+
+  /** Watch Amp's session.json for lastThreadId changes — thread-level "seen" signal */
+  private setupSessionWatch(): void {
+    // Seed the initial focused thread
+    this.checkSessionFocus();
+
+    try {
+      this.sessionWatcher = watch(this.sessionFile, () => {
+        this.checkSessionFocus();
+      });
+    } catch {
+      // session.json doesn't exist yet or can't be watched; ignore
+    }
+  }
+
+  /** Read session.json and emit "idle" for a terminal thread the user has focused in Amp */
+  private async checkSessionFocus(): Promise<void> {
+    if (!this.ctx || !this.seeded) return;
+
+    try {
+      const raw = await Bun.file(this.sessionFile).text();
+      const session = JSON.parse(raw);
+      const threadId: string | undefined = session.lastThreadId;
+      if (!threadId || threadId === this.lastFocusedThread) return;
+
+      this.lastFocusedThread = threadId;
+
+      // If this thread is tracked and in a terminal state, the user just "saw" it
+      const snapshot = this.threads.get(threadId);
+      if (!snapshot || !snapshot.projectDir) return;
+      if (
+        snapshot.status !== "done" &&
+        snapshot.status !== "error" &&
+        snapshot.status !== "interrupted"
+      )
+        return;
+
+      const muxSession = this.ctx.resolveSession(snapshot.projectDir);
+      if (!muxSession || muxSession === "unknown") return;
+
+      // Emit "idle" to clear the unseen flag for this specific thread
+      this.ctx.emit({
+        agent: "amp",
+        session: muxSession,
+        status: "idle",
+        ts: Date.now(),
+        threadId,
+        threadName: snapshot.title,
+      });
+    } catch {
+      // session.json unreadable; ignore
+    }
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/agents/watchers/claude-code.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/agents/watchers/claude-code.ts
@@ -1,0 +1,344 @@
+/**
+ * Claude Code agent watcher
+ *
+ * Watches ~/.claude/projects/ for JSONL file changes,
+ * determines agent status from journal entries, and emits events
+ * mapped to mux sessions via the project directory encoded in folder names.
+ *
+ * Directory structure: ~/.claude/projects/<encoded-path>/<session-id>.jsonl
+ * Encoded path: /Users/foo/myproject → -Users-foo-myproject
+ *
+ * All file I/O is async to avoid blocking the server event loop.
+ */
+
+import { watch } from "node:fs";
+import type { FSWatcher } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
+import type { AgentStatus } from "../../contracts/agent";
+import type { AgentWatcher, AgentWatcherContext } from "../../contracts/agent-watcher";
+
+// --- Types ---
+
+interface ContentItem {
+  type?: string;
+  text?: string;
+}
+
+interface JournalEntry {
+  type?: string;
+  message?: {
+    role?: string;
+    content?: ContentItem[] | string;
+  };
+}
+
+interface SessionState {
+  status: AgentStatus;
+  fileSize: number;
+  threadName?: string;
+  projectDir?: string;
+}
+
+const POLL_MS = 2000;
+const STALE_MS = 5 * 60 * 1000;
+
+// --- Status detection ---
+
+export function determineStatus(entry: JournalEntry): AgentStatus {
+  const msg = entry.message;
+  if (!msg?.role) return "idle";
+
+  const content = msg.content;
+  const items: ContentItem[] = Array.isArray(content)
+    ? content
+    : typeof content === "string"
+      ? [{ type: "text", text: content }]
+      : [];
+
+  if (msg.role === "assistant") {
+    const hasToolUse = items.some((c) => c.type === "tool_use");
+    return hasToolUse ? "running" : "done";
+  }
+
+  if (msg.role === "user") return "running";
+
+  return "idle";
+}
+
+function extractThreadName(entry: JournalEntry): string | undefined {
+  const msg = entry.message;
+  if (msg?.role !== "user") return undefined;
+
+  const content = msg.content;
+  let text: string | undefined;
+
+  if (typeof content === "string") {
+    text = content;
+  } else if (Array.isArray(content)) {
+    text = content.find((c) => c.type === "text" && c.text)?.text;
+  }
+
+  if (!text) return undefined;
+  // Skip system/internal messages
+  if (text.startsWith("<") || text.startsWith("{")) return undefined;
+  return text.slice(0, 80);
+}
+
+/** Decode Claude's encoded project dir name back to a path.
+ * Claude Code encodes `/` as `-` with no escape for literal dashes,
+ * so paths like `/home/user/my-project` are ambiguous with `/home/user/my/project`.
+ * This is a known Claude Code limitation. */
+function decodeProjectDir(encoded: string): string {
+  return encoded.replace(/-/g, "/");
+}
+
+// --- Watcher implementation ---
+
+export class ClaudeCodeAgentWatcher implements AgentWatcher {
+  readonly name = "claude-code";
+
+  private sessions = new Map<string, SessionState>();
+  private fsWatchers: FSWatcher[] = [];
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private ctx: AgentWatcherContext | null = null;
+  private projectsDir: string;
+  private scanning = false;
+  private seeded = false;
+
+  constructor() {
+    this.projectsDir = join(homedir(), ".claude", "projects");
+  }
+
+  start(ctx: AgentWatcherContext): void {
+    this.ctx = ctx;
+    this.setupWatchers();
+    setTimeout(() => this.scan(), 50);
+    this.pollTimer = setInterval(() => this.scan(), POLL_MS);
+  }
+
+  stop(): void {
+    for (const w of this.fsWatchers) {
+      try {
+        w.close();
+      } catch {}
+    }
+    this.fsWatchers = [];
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.ctx = null;
+  }
+
+  private async processFile(filePath: string, projectDir: string): Promise<void> {
+    if (!this.ctx) return;
+
+    let size: number;
+    try {
+      size = (await stat(filePath)).size;
+    } catch {
+      return;
+    }
+
+    const threadId = basename(filePath, ".jsonl");
+    const prev = this.sessions.get(threadId);
+
+    if (prev && size === prev.fileSize) return;
+
+    // Seed mode: read last entry to capture real status for post-seed emit
+    if (!this.seeded) {
+      let text: string;
+      try {
+        text = await Bun.file(filePath).text();
+      } catch {
+        return;
+      }
+
+      const lines = text.split("\n").filter(Boolean);
+      let latestStatus: AgentStatus = "idle";
+      let threadName: string | undefined;
+
+      for (const line of lines) {
+        let entry: JournalEntry;
+        try {
+          entry = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (!threadName) {
+          const name = extractThreadName(entry);
+          if (name) threadName = name;
+        }
+        latestStatus = determineStatus(entry);
+      }
+
+      this.sessions.set(threadId, { status: latestStatus, fileSize: size, threadName, projectDir });
+      return;
+    }
+
+    const offset = prev?.fileSize ?? 0;
+    if (size <= offset) return;
+
+    let text: string;
+    try {
+      const buf = await Bun.file(filePath).arrayBuffer();
+      text = new TextDecoder().decode(new Uint8Array(buf).subarray(offset, size));
+    } catch {
+      return;
+    }
+
+    const lines = text.split("\n").filter(Boolean);
+    let latestStatus: AgentStatus = prev?.status ?? "idle";
+    let threadName = prev?.threadName;
+
+    for (const line of lines) {
+      let entry: JournalEntry;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (!threadName) {
+        const name = extractThreadName(entry);
+        if (name) threadName = name;
+      }
+
+      latestStatus = determineStatus(entry);
+    }
+
+    const prevStatus = prev?.status;
+    this.sessions.set(threadId, { status: latestStatus, fileSize: size, threadName, projectDir });
+
+    if (latestStatus !== prevStatus) {
+      const session = this.ctx.resolveSession(projectDir);
+      if (session) {
+        this.ctx.emit({
+          agent: "claude-code",
+          session,
+          status: latestStatus,
+          ts: Date.now(),
+          threadId,
+          threadName,
+        });
+      }
+    }
+  }
+
+  private async scan(): Promise<void> {
+    if (this.scanning || !this.ctx) return;
+    this.scanning = true;
+
+    try {
+      let dirs: string[];
+      try {
+        dirs = await readdir(this.projectsDir);
+      } catch {
+        return;
+      }
+      const now = Date.now();
+
+      for (const dir of dirs) {
+        const dirPath = join(this.projectsDir, dir);
+        try {
+          if (!(await stat(dirPath)).isDirectory()) continue;
+        } catch {
+          continue;
+        }
+
+        const projectDir = decodeProjectDir(dir);
+
+        let files: string[];
+        try {
+          files = await readdir(dirPath);
+        } catch {
+          continue;
+        }
+
+        for (const file of files) {
+          if (!file.endsWith(".jsonl")) continue;
+          const filePath = join(dirPath, file);
+          let fileStat;
+          try {
+            fileStat = await stat(filePath);
+          } catch {
+            continue;
+          }
+          if (now - fileStat.mtimeMs > STALE_MS) continue;
+          await this.processFile(filePath, projectDir);
+        }
+      }
+    } finally {
+      if (!this.seeded) {
+        this.seeded = true;
+        // Emit seeded sessions with non-idle status (like amp watcher does)
+        for (const [threadId, state] of this.sessions) {
+          if (state.status === "idle" || !state.projectDir) continue;
+          const session = this.ctx?.resolveSession(state.projectDir);
+          if (!session) continue;
+          this.ctx?.emit({
+            agent: "claude-code",
+            session,
+            status: state.status,
+            ts: Date.now(),
+            threadId,
+            threadName: state.threadName,
+          });
+        }
+      }
+      this.scanning = false;
+    }
+  }
+
+  private setupWatchers(): void {
+    let dirs: string[];
+    try {
+      dirs = require("node:fs").readdirSync(this.projectsDir);
+    } catch {
+      return;
+    }
+
+    for (const dir of dirs) {
+      const dirPath = join(this.projectsDir, dir);
+      try {
+        if (!require("node:fs").statSync(dirPath).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
+      const projectDir = decodeProjectDir(dir);
+      try {
+        const w = watch(dirPath, (_eventType, filename) => {
+          if (!filename?.endsWith(".jsonl")) return;
+          this.processFile(join(dirPath, filename), projectDir);
+        });
+        this.fsWatchers.push(w);
+      } catch {}
+    }
+
+    // Watch projects dir for new project directories
+    try {
+      const w = watch(this.projectsDir, (eventType, filename) => {
+        if (eventType !== "rename" || !filename) return;
+        const dirPath = join(this.projectsDir, filename);
+        try {
+          if (!require("node:fs").statSync(dirPath).isDirectory()) return;
+        } catch {
+          return;
+        }
+
+        const projectDir = decodeProjectDir(filename);
+        try {
+          const sub = watch(dirPath, (_et, fn) => {
+            if (!fn?.endsWith(".jsonl")) return;
+            this.processFile(join(dirPath, fn), projectDir);
+          });
+          this.fsWatchers.push(sub);
+        } catch {}
+      });
+      this.fsWatchers.push(w);
+    } catch {}
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/agents/watchers/codex.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/agents/watchers/codex.ts
@@ -1,0 +1,364 @@
+/**
+ * Codex agent watcher
+ *
+ * Watches Codex transcript files under ~/.codex/sessions/ (or $CODEX_HOME/sessions),
+ * determines agent status from the latest transcript events, and emits events
+ * mapped to mux sessions via the working directory captured in turn_context.
+ *
+ * Detection uses a recursive fs.watch when available plus a periodic poll to
+ * catch missed writes and new files.
+ */
+
+import { watch } from "node:fs";
+import type { FSWatcher } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import type { AgentStatus } from "../../contracts/agent";
+import type { AgentWatcher, AgentWatcherContext } from "../../contracts/agent-watcher";
+
+interface CodexEntry {
+  type?: string;
+  payload?: {
+    type?: string;
+    role?: string;
+    phase?: string;
+    cwd?: string;
+    message?: string;
+    content?: Array<{ type?: string; text?: string }>;
+  };
+}
+
+interface SessionSnapshot {
+  status: AgentStatus;
+  fileSize: number;
+  projectDir?: string;
+  threadName?: string;
+}
+
+const POLL_MS = 2000;
+const STALE_MS = 5 * 60 * 1000;
+const THREAD_NAME_MAX = 80;
+
+function assistantStatus(phase?: string): AgentStatus {
+  return phase === "commentary" ? "running" : "done";
+}
+
+export function determineStatus(entry: CodexEntry): AgentStatus | null {
+  const payload = entry.payload;
+  if (!payload) return null;
+
+  if (entry.type === "event_msg") {
+    switch (payload.type) {
+      case "task_complete":
+        return "done";
+      case "turn_aborted":
+        return "interrupted";
+      case "user_message":
+        return "running";
+      case "agent_message":
+        return assistantStatus(payload.phase);
+      case "error":
+        return "error";
+      default:
+        return null;
+    }
+  }
+
+  if (entry.type === "response_item") {
+    if (payload.type === "message") {
+      if (payload.role === "user") return "running";
+      if (payload.role === "assistant") return assistantStatus(payload.phase);
+      return null;
+    }
+
+    if (
+      payload.type === "function_call" ||
+      payload.type === "function_call_output" ||
+      payload.type === "reasoning"
+    ) {
+      return "running";
+    }
+  }
+
+  return null;
+}
+
+function parseThreadId(filePath: string): string {
+  const name = basename(filePath, ".jsonl");
+  return name.match(/[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i)?.[0] ?? name;
+}
+
+function normalizeThreadName(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  const line = text
+    .split("\n")
+    .map((part) => part.trim())
+    .find(Boolean);
+  return line ? line.slice(0, THREAD_NAME_MAX) : undefined;
+}
+
+function extractThreadName(entry: CodexEntry): string | undefined {
+  const payload = entry.payload;
+  if (!payload) return undefined;
+
+  if (entry.type === "event_msg" && payload.type === "user_message") {
+    return normalizeThreadName(payload.message);
+  }
+
+  if (entry.type === "response_item" && payload.type === "message" && payload.role === "user") {
+    const text = Array.isArray(payload.content)
+      ? payload.content
+          .filter((item) => item?.type === "input_text")
+          .map((item) => item.text ?? "")
+          .join("\n")
+      : undefined;
+    const candidate = normalizeThreadName(text);
+    if (!candidate) return undefined;
+    if (candidate.startsWith("# AGENTS.md") || candidate.startsWith("<environment_context>"))
+      return undefined;
+    return candidate;
+  }
+
+  return undefined;
+}
+
+function applyEntries(
+  text: string,
+  base: SessionSnapshot,
+  indexedThreadName?: string,
+): SessionSnapshot {
+  let status = base.status;
+  let projectDir = base.projectDir;
+  let threadName = indexedThreadName ?? base.threadName;
+
+  for (const rawLine of text.split("\n")) {
+    if (!rawLine.trim()) continue;
+
+    let entry: CodexEntry;
+    try {
+      entry = JSON.parse(rawLine);
+    } catch {
+      continue;
+    }
+
+    if (!projectDir && entry.type === "turn_context" && typeof entry.payload?.cwd === "string") {
+      projectDir = entry.payload.cwd;
+    }
+
+    if (!threadName) {
+      threadName = extractThreadName(entry);
+    }
+
+    const nextStatus = determineStatus(entry);
+    if (nextStatus) {
+      status = nextStatus;
+    }
+  }
+
+  return { ...base, status, projectDir, threadName };
+}
+
+async function collectSessionFiles(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectSessionFiles(fullPath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+export class CodexAgentWatcher implements AgentWatcher {
+  readonly name = "codex";
+
+  private sessions = new Map<string, SessionSnapshot>();
+  private threadNames = new Map<string, string>();
+  private fsWatcher: FSWatcher | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private ctx: AgentWatcherContext | null = null;
+  private sessionsDir: string;
+  private sessionIndexFile: string;
+  private scanning = false;
+  private seeded = false;
+
+  constructor() {
+    const codexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
+    this.sessionsDir = join(codexHome, "sessions");
+    this.sessionIndexFile = join(codexHome, "session_index.jsonl");
+  }
+
+  start(ctx: AgentWatcherContext): void {
+    this.ctx = ctx;
+    this.setupWatch();
+    setTimeout(() => this.scan(), 50);
+    this.pollTimer = setInterval(() => this.scan(), POLL_MS);
+  }
+
+  stop(): void {
+    if (this.fsWatcher) {
+      try {
+        this.fsWatcher.close();
+      } catch {}
+      this.fsWatcher = null;
+    }
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.ctx = null;
+  }
+
+  private async loadThreadIndex(): Promise<void> {
+    let text: string;
+    try {
+      text = await Bun.file(this.sessionIndexFile).text();
+    } catch {
+      return;
+    }
+
+    const names = new Map<string, string>();
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line) as { id?: string; thread_name?: string };
+        if (entry.id && entry.thread_name) {
+          names.set(entry.id, entry.thread_name);
+        }
+      } catch {}
+    }
+
+    this.threadNames = names;
+  }
+
+  private async processFile(filePath: string): Promise<void> {
+    if (!this.ctx) return;
+
+    let fileStat;
+    try {
+      fileStat = await stat(filePath);
+    } catch {
+      return;
+    }
+
+    const threadId = parseThreadId(filePath);
+    const prev = this.sessions.get(threadId);
+
+    if (prev && fileStat.size === prev.fileSize) return;
+
+    const indexedThreadName = this.threadNames.get(threadId);
+    let nextSnapshot: SessionSnapshot;
+
+    if (prev && fileStat.size > prev.fileSize) {
+      let text: string;
+      try {
+        const buf = await Bun.file(filePath).arrayBuffer();
+        text = new TextDecoder().decode(new Uint8Array(buf).subarray(prev.fileSize, fileStat.size));
+      } catch {
+        return;
+      }
+
+      nextSnapshot = applyEntries(text, { ...prev, fileSize: fileStat.size }, indexedThreadName);
+    } else {
+      let text: string;
+      try {
+        text = await Bun.file(filePath).text();
+      } catch {
+        return;
+      }
+
+      nextSnapshot = applyEntries(
+        text,
+        { status: "idle", fileSize: fileStat.size },
+        indexedThreadName,
+      );
+    }
+
+    this.sessions.set(threadId, nextSnapshot);
+
+    if (!this.seeded) return;
+
+    const prevStatus = prev?.status;
+    if (nextSnapshot.status === prevStatus) return;
+
+    const session = nextSnapshot.projectDir
+      ? this.ctx.resolveSession(nextSnapshot.projectDir)
+      : null;
+    if (!session) return;
+    if (!prev && nextSnapshot.status === "idle") return;
+
+    this.ctx.emit({
+      agent: "codex",
+      session,
+      status: nextSnapshot.status,
+      ts: Date.now(),
+      threadId,
+      ...(nextSnapshot.threadName && { threadName: nextSnapshot.threadName }),
+    });
+  }
+
+  private async scan(): Promise<void> {
+    if (this.scanning || !this.ctx) return;
+    this.scanning = true;
+
+    try {
+      await this.loadThreadIndex();
+
+      const files = await collectSessionFiles(this.sessionsDir);
+      const now = Date.now();
+
+      for (const filePath of files) {
+        let fileStat;
+        try {
+          fileStat = await stat(filePath);
+        } catch {
+          continue;
+        }
+
+        if (now - fileStat.mtimeMs > STALE_MS) continue;
+        await this.processFile(filePath);
+      }
+    } finally {
+      if (!this.seeded) {
+        this.seeded = true;
+        // Emit seeded sessions with non-idle status (like amp watcher does)
+        for (const [threadId, snapshot] of this.sessions) {
+          if (snapshot.status === "idle" || !snapshot.projectDir) continue;
+          const session = this.ctx?.resolveSession(snapshot.projectDir);
+          if (!session) continue;
+          this.ctx?.emit({
+            agent: "codex",
+            session,
+            status: snapshot.status,
+            ts: Date.now(),
+            threadId,
+            ...(snapshot.threadName && { threadName: snapshot.threadName }),
+          });
+        }
+      }
+      this.scanning = false;
+    }
+  }
+
+  private setupWatch(): void {
+    try {
+      this.fsWatcher = watch(this.sessionsDir, { recursive: true }, (_eventType, filename) => {
+        if (!filename?.endsWith(".jsonl")) return;
+        this.processFile(join(this.sessionsDir, filename));
+      });
+    } catch {}
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/agents/watchers/opencode.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/agents/watchers/opencode.ts
@@ -1,0 +1,249 @@
+/**
+ * OpenCode agent watcher
+ *
+ * Polls the OpenCode SQLite database (~/.local/share/opencode/opencode.db)
+ * to determine agent status and emits events mapped to mux sessions
+ * via the `directory` field on each OpenCode session row.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AgentStatus } from "../../contracts/agent";
+import type { AgentWatcher, AgentWatcherContext } from "../../contracts/agent-watcher";
+
+// --- Types ---
+
+interface SessionRow {
+  id: string;
+  title: string | null;
+  directory: string;
+  time_updated: number;
+}
+
+interface MessageRow {
+  id: string;
+  data: string;
+}
+
+interface MessageData {
+  role?: string;
+  finish?: string;
+}
+
+interface PartData {
+  type?: string;
+}
+
+const POLL_MS = 3000;
+const STALE_MS = 5 * 60 * 1000;
+
+// --- Status detection ---
+
+export function determineStatus(msg: MessageData | null, parts: PartData[]): AgentStatus {
+  if (!msg) return "idle";
+
+  if (msg.role === "assistant") {
+    if (msg.finish === "tool-calls") return "running";
+    if (parts.some((p) => p.type === "tool")) return "running";
+    return "done";
+  }
+
+  if (msg.role === "user") return "running";
+
+  return "idle";
+}
+
+// --- Watcher implementation ---
+
+export class OpenCodeAgentWatcher implements AgentWatcher {
+  readonly name = "opencode";
+
+  private sessionTimestamps = new Map<string, number>();
+  private sessionStatuses = new Map<string, AgentStatus>();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private ctx: AgentWatcherContext | null = null;
+  private db: any = null;
+  private dbPath: string;
+
+  constructor() {
+    this.dbPath =
+      process.env.OPENCODE_DB_PATH ?? join(homedir(), ".local", "share", "opencode", "opencode.db");
+  }
+
+  private polling = false;
+
+  start(ctx: AgentWatcherContext): void {
+    this.ctx = ctx;
+    setTimeout(() => this.poll(), 50);
+    this.pollTimer = setInterval(() => this.poll(), POLL_MS);
+  }
+
+  stop(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    try {
+      this.db?.close();
+    } catch {}
+    this.db = null;
+    this.ctx = null;
+  }
+
+  private openDb(): boolean {
+    if (this.db) return true;
+    if (!existsSync(this.dbPath)) return false;
+    try {
+      // Dynamic import to avoid hard dependency on bun:sqlite at module level
+      const { Database } = require("bun:sqlite");
+      this.db = new Database(this.dbPath, { readonly: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private seeded = false;
+
+  private poll(): void {
+    if (!this.ctx || this.polling) return;
+    this.polling = true;
+
+    try {
+      if (!this.openDb()) return;
+
+      let sessions: SessionRow[];
+      const staleThreshold = Date.now() - STALE_MS;
+      try {
+        sessions = this.db
+          .query(
+            `SELECT id, title, directory, time_updated FROM session WHERE time_updated > ? ORDER BY time_updated DESC`,
+          )
+          .all(staleThreshold);
+      } catch {
+        try {
+          this.db.close();
+        } catch {}
+        this.db = null;
+        return;
+      }
+
+      // First poll: record timestamps, then emit current state for recent sessions.
+      if (!this.seeded) {
+        for (const row of sessions) {
+          this.sessionTimestamps.set(row.id, row.time_updated);
+        }
+        this.seeded = true;
+
+        // Emit seeded sessions by reading their current status (like amp watcher does)
+        for (const row of sessions) {
+          let lastMsg: MessageRow | null = null;
+          let lastParts: PartData[] = [];
+          try {
+            lastMsg = this.db
+              .query(
+                `SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created DESC LIMIT 1`,
+              )
+              .get(row.id);
+            if (lastMsg) {
+              const partRows: { data: string }[] = this.db
+                .query(`SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC`)
+                .all(lastMsg.id);
+              for (const pr of partRows) {
+                try {
+                  lastParts.push(JSON.parse(pr.data));
+                } catch {}
+              }
+            }
+          } catch {
+            continue;
+          }
+
+          let lastMsgData: MessageData | null = null;
+          if (lastMsg) {
+            try {
+              lastMsgData = JSON.parse(lastMsg.data);
+            } catch {}
+          }
+
+          const status = determineStatus(lastMsgData, lastParts);
+          if (status === "idle") continue;
+          this.sessionStatuses.set(row.id, status);
+
+          const session = this.ctx.resolveSession(row.directory);
+          if (!session) continue;
+
+          this.ctx.emit({
+            agent: "opencode",
+            session,
+            status,
+            ts: Date.now(),
+            threadId: row.id,
+            ...(row.title && { threadName: row.title }),
+          });
+        }
+        return;
+      }
+
+      for (const row of sessions) {
+        const prev = this.sessionTimestamps.get(row.id);
+        if (prev === row.time_updated) continue;
+        this.sessionTimestamps.set(row.id, row.time_updated);
+
+        // Only emit if we had a previous timestamp — a change means
+        // OpenCode is actively writing to this session right now.
+        if (prev === undefined) continue;
+
+        let lastMsg: MessageRow | null = null;
+        let lastParts: PartData[] = [];
+        try {
+          lastMsg = this.db
+            .query(
+              `SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created DESC LIMIT 1`,
+            )
+            .get(row.id);
+
+          if (lastMsg) {
+            const partRows: { data: string }[] = this.db
+              .query(`SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC`)
+              .all(lastMsg.id);
+            for (const pr of partRows) {
+              try {
+                lastParts.push(JSON.parse(pr.data));
+              } catch {}
+            }
+          }
+        } catch {
+          continue;
+        }
+
+        let lastMsgData: MessageData | null = null;
+        if (lastMsg) {
+          try {
+            lastMsgData = JSON.parse(lastMsg.data);
+          } catch {}
+        }
+
+        const status = determineStatus(lastMsgData, lastParts);
+        const prevStatus = this.sessionStatuses.get(row.id);
+        if (prevStatus === status) continue;
+        this.sessionStatuses.set(row.id, status);
+
+        const session = this.ctx.resolveSession(row.directory);
+        if (!session) continue;
+
+        this.ctx.emit({
+          agent: "opencode",
+          session,
+          status,
+          ts: Date.now(),
+          threadId: row.id,
+          ...(row.title && { threadName: row.title }),
+        });
+      }
+    } finally {
+      this.polling = false;
+    }
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/config.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/config.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import type { PartialTheme } from "./themes";
+
+export interface Agentboard2Config {
+  /** Explicit mux provider name (overrides auto-detect) */
+  mux?: string;
+  /** Custom server port */
+  port?: number;
+  /** Community plugin package names to load */
+  plugins: string[];
+  /** Theme: builtin name (e.g. "catppuccin-latte") or partial inline theme object */
+  theme?: string | PartialTheme;
+  /** Sidebar column width (default 26) */
+  sidebarWidth?: number;
+  /** Sidebar position relative to the terminal window (default "left") */
+  sidebarPosition?: "left" | "right";
+  /** Tmux prefix key for sidebar toggle (default "s") */
+  keybinding?: string;
+  /** Persisted detail panel heights keyed by mux session name */
+  detailPanelHeights?: Record<string, number>;
+}
+
+const DEFAULTS: Agentboard2Config = {
+  plugins: [],
+};
+
+/**
+ * Load config from ~/.config/towles-tool/agentboard2/config.json
+ * @param homeDir — override home directory (for testing)
+ */
+export function loadConfig(homeDir?: string): Agentboard2Config {
+  const home = homeDir ?? process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const configPath = join(home, ".config", "towles-tool", "agentboard2", "config.json");
+
+  if (!existsSync(configPath)) {
+    return { ...DEFAULTS };
+  }
+
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<Agentboard2Config>;
+    return {
+      ...DEFAULTS,
+      ...parsed,
+      plugins: parsed.plugins ?? DEFAULTS.plugins,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+/**
+ * Save partial config updates to ~/.config/towles-tool/agentboard2/config.json
+ * Merges with existing config on disk to preserve fields.
+ * @param updates — partial config fields to write
+ * @param homeDir — override home directory (for testing)
+ */
+export function saveConfig(updates: Partial<Agentboard2Config>, homeDir?: string): void {
+  const home = homeDir ?? process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const configDir = join(home, ".config", "towles-tool", "agentboard2");
+  const configPath = join(configDir, "config.json");
+
+  const existing = loadConfig(homeDir);
+  const merged = { ...existing, ...updates };
+
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(configPath, JSON.stringify(merged, null, 2) + "\n");
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/contracts/agent-watcher.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/contracts/agent-watcher.ts
@@ -1,0 +1,38 @@
+import type { AgentEvent } from "./agent";
+
+/**
+ * Callback context provided by the server to each watcher.
+ * Lets watchers resolve project directories to mux session names
+ * and emit events without knowing about server internals.
+ */
+export interface AgentWatcherContext {
+  /** Resolve a project directory path to a mux session name, or null if unmatched */
+  resolveSession(projectDir: string): string | null;
+  /** Emit an agent event (applied to tracker + broadcast automatically) */
+  emit(event: AgentEvent): void;
+}
+
+/**
+ * Interface for agent watchers that detect agent status by watching
+ * external data sources (thread files, databases, etc).
+ *
+ * Implementations:
+ *   - amp: watches ~/.local/share/amp/threads/*.json
+ *   - claude-code: watches ~/.claude/projects/ JSONL files
+ *   - codex: watches ~/.codex/sessions/ JSONL transcripts
+ *   - opencode: polls OpenCode SQLite database
+ *
+ * To add a new watcher:
+ *   1. Create a file implementing AgentWatcher
+ *   2. Register it via PluginAPI.registerWatcher() or in start.ts
+ */
+export interface AgentWatcher {
+  /** Unique name for this watcher (e.g. "amp", "claude-code") */
+  readonly name: string;
+
+  /** Start watching. Called once by the server with the watcher context. */
+  start(ctx: AgentWatcherContext): void;
+
+  /** Stop watching and clean up resources. */
+  stop(): void;
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/contracts/agent.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/contracts/agent.ts
@@ -1,0 +1,16 @@
+export type AgentStatus = "idle" | "running" | "done" | "error" | "waiting" | "interrupted";
+
+export interface AgentEvent {
+  agent: string;
+  session: string;
+  status: AgentStatus;
+  ts: number;
+  threadId?: string;
+  threadName?: string;
+  /** Set by tracker when serializing for the TUI — true if user hasn't seen this terminal state */
+  unseen?: boolean;
+  /** Set by pane scanner — the tmux pane ID where this agent was detected */
+  paneId?: string;
+}
+
+export const TERMINAL_STATUSES = new Set<AgentStatus>(["done", "error", "interrupted"]);

--- a/plugins/tt-agentboard2/packages/runtime/src/contracts/index.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/contracts/index.ts
@@ -1,0 +1,3 @@
+export type { AgentStatus, AgentEvent } from "./agent";
+export { TERMINAL_STATUSES } from "./agent";
+export type { MuxProvider, MuxSessionInfo } from "./mux";

--- a/plugins/tt-agentboard2/packages/runtime/src/contracts/mux.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/contracts/mux.ts
@@ -1,0 +1,149 @@
+// ─── Specification version ───────────────────────────────────────────────────
+// Like ai-sdk's specificationVersion — a literal discriminant for version compat.
+
+export type MuxSpecificationVersion = "v1";
+
+// ─── Core data types ─────────────────────────────────────────────────────────
+
+export interface MuxSessionInfo {
+  readonly name: string;
+  readonly createdAt: number;
+  readonly dir: string;
+  readonly windows: number;
+}
+
+export interface ActiveWindow {
+  readonly id: string;
+  readonly sessionName: string;
+  readonly active: boolean;
+}
+
+export interface SidebarPane {
+  readonly paneId: string;
+  readonly sessionName: string;
+  readonly windowId: string;
+  readonly width?: number;
+  readonly windowWidth?: number;
+}
+
+/** Position for sidebar placement */
+export type SidebarPosition = "left" | "right";
+
+/** Provider-specific metadata (escape hatch — like ai-sdk's providerMetadata) */
+export type MuxProviderMetadata = Record<string, Record<string, unknown>>;
+
+// ─── Capability interfaces ───────────────────────────────────────────────────
+// Split from one monolith into composable traits. Providers implement what they
+// support. The server narrows with type guards, not NonNullable hacks.
+
+/**
+ * Core mux operations — every provider MUST implement this.
+ *
+ * Like ai-sdk's ProviderV4 required methods (languageModel, embeddingModel).
+ */
+export interface MuxProviderV1 {
+  readonly specificationVersion: "v1";
+  readonly name: string;
+
+  // Session CRUD
+  listSessions(): MuxSessionInfo[];
+  switchSession(name: string, clientTty?: string): void;
+  getCurrentSession(): string | null;
+  getSessionDir(name: string): string;
+  getPaneCount(name: string): number;
+  getClientTty(): string;
+  createSession(name?: string, dir?: string): void;
+  killSession(name: string): void;
+
+  // Hooks
+  setupHooks(serverHost: string, serverPort: number): void;
+  cleanupHooks(): void;
+}
+
+/**
+ * Window/tab awareness — providers that can enumerate their windows/tabs.
+ */
+export interface WindowCapable {
+  listActiveWindows(): ActiveWindow[];
+  getCurrentWindowId(): string | null;
+}
+
+/**
+ * Sidebar management — providers that can spawn/manage sidebar panes.
+ */
+export interface SidebarCapable {
+  listSidebarPanes(sessionName?: string): SidebarPane[];
+  spawnSidebar(
+    sessionName: string,
+    windowId: string,
+    width: number,
+    position: SidebarPosition,
+    scriptsDir: string,
+  ): string | null;
+  hideSidebar(paneId: string): void;
+  killSidebarPane(paneId: string): void;
+  resizeSidebarPane(paneId: string, width: number): void;
+  cleanupSidebar(): void;
+}
+
+/**
+ * Batch operations — providers that can fetch data in bulk for performance.
+ */
+export interface BatchCapable {
+  getAllPaneCounts(): Map<string, number>;
+}
+
+// ─── Composite types ─────────────────────────────────────────────────────────
+
+/**
+ * A fully-featured provider with all capabilities.
+ * Most providers won't implement everything — use the type guards below to narrow.
+ */
+export type FullMuxProvider = MuxProviderV1 & WindowCapable & SidebarCapable & BatchCapable;
+
+/**
+ * The union type the server accepts — core is required, capabilities are optional.
+ *
+ * Like ai-sdk's LanguageModel = V2 | V3 | V4 — accepts any level of capability.
+ */
+export type MuxProvider = MuxProviderV1 & Partial<WindowCapable & SidebarCapable & BatchCapable>;
+
+// ─── Type guards ─────────────────────────────────────────────────────────────
+// Runtime narrowing — like ai-sdk's isInstance() pattern, but for capabilities.
+
+/** Check if a provider supports window operations */
+export function isWindowCapable(p: MuxProvider): p is MuxProviderV1 & WindowCapable {
+  return typeof p.listActiveWindows === "function" && typeof p.getCurrentWindowId === "function";
+}
+
+/** Check if a provider supports sidebar operations */
+export function isSidebarCapable(p: MuxProvider): p is MuxProviderV1 & SidebarCapable {
+  return (
+    typeof p.listSidebarPanes === "function" &&
+    typeof p.spawnSidebar === "function" &&
+    typeof p.hideSidebar === "function" &&
+    typeof p.killSidebarPane === "function" &&
+    typeof p.resizeSidebarPane === "function" &&
+    typeof p.cleanupSidebar === "function"
+  );
+}
+
+/** Check if a provider supports batch operations */
+export function isBatchCapable(p: MuxProvider): p is MuxProviderV1 & BatchCapable {
+  return typeof p.getAllPaneCounts === "function";
+}
+
+/** Check if a provider supports full sidebar management (window + sidebar) */
+export function isFullSidebarCapable(
+  p: MuxProvider,
+): p is MuxProviderV1 & WindowCapable & SidebarCapable {
+  return isWindowCapable(p) && isSidebarCapable(p);
+}
+
+// ─── Provider settings ───────────────────────────────────────────────────────
+// Like ai-sdk's OpenAIProviderSettings — each provider can extend this.
+
+export interface MuxProviderSettings {
+  /** Override the provider name (for custom/wrapped providers) */
+  name?: string;
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/debug.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/debug.ts
@@ -1,0 +1,19 @@
+import { appendFileSync } from "node:fs";
+
+export const DEBUG_LOG = "/tmp/agentboard2-debug.log";
+export const TUI_RESIZE_LOG = "/tmp/agentboard2-tui-resize.log";
+export const TUI_AGENT_CLICK_LOG = "/tmp/agentboard2-tui-agent-click.log";
+export const SERVER_ERR_LOG = "/tmp/agentboard2-server-err.log";
+export const INSTALL_LOG = "/tmp/agentboard2-install.log";
+
+const DEBUG_ENABLED = !!process.env.AGENTBOARD2_DEBUG;
+
+export function debugLog(category: string, msg: string, data?: Record<string, unknown>): void {
+  if (!DEBUG_ENABLED) return;
+  const ts = new Date().toISOString().slice(11, 23);
+  const extra = data ? " " + JSON.stringify(data) : "";
+  const line = `[${ts}] [${category}] ${msg}${extra}\n`;
+  try {
+    appendFileSync(DEBUG_LOG, line);
+  } catch {}
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/index.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/index.ts
@@ -1,0 +1,69 @@
+export type {
+  MuxProvider,
+  MuxProviderV1,
+  MuxSessionInfo,
+  ActiveWindow,
+  SidebarPane,
+  SidebarPosition,
+  WindowCapable,
+  SidebarCapable,
+  BatchCapable,
+  FullMuxProvider,
+  MuxProviderSettings,
+} from "./contracts/mux";
+export {
+  isWindowCapable,
+  isSidebarCapable,
+  isBatchCapable,
+  isFullSidebarCapable,
+} from "./contracts/mux";
+export type { AgentStatus, AgentEvent } from "./contracts/agent";
+export { TERMINAL_STATUSES } from "./contracts/agent";
+export type { AgentWatcher, AgentWatcherContext } from "./contracts/agent-watcher";
+export { AgentTracker } from "./agents/tracker";
+export { AmpAgentWatcher } from "./agents/watchers/amp";
+export { ClaudeCodeAgentWatcher } from "./agents/watchers/claude-code";
+export { CodexAgentWatcher } from "./agents/watchers/codex";
+export { OpenCodeAgentWatcher } from "./agents/watchers/opencode";
+export { MuxRegistry } from "./mux/registry";
+export { detectMux } from "./mux/detect";
+export { PluginLoader } from "./plugins/loader";
+export type { PluginAPI, PluginFactory } from "./plugins/loader";
+export {
+  debugLog,
+  DEBUG_LOG,
+  TUI_RESIZE_LOG,
+  TUI_AGENT_CLICK_LOG,
+  SERVER_ERR_LOG,
+  INSTALL_LOG,
+} from "./debug";
+export { loadConfig, saveConfig } from "./config";
+export type { Agentboard2Config } from "./config";
+export { resolveTheme, BUILTIN_THEMES, DEFAULT_THEME } from "./themes";
+export type { Theme, ThemePalette, PartialTheme } from "./themes";
+export { startServer } from "./server/index";
+export { ensureServer } from "./server/launcher";
+export {
+  SERVER_PORT,
+  SERVER_HOST,
+  PID_FILE,
+  SERVER_IDLE_TIMEOUT_MS,
+  STUCK_RUNNING_TIMEOUT_MS,
+  C,
+  STATUS_COLORS,
+  STATUS_ICONS,
+} from "./shared";
+export type {
+  SessionData,
+  ServerState,
+  FocusUpdate,
+  ResizeNotify,
+  QuitNotify,
+  ServerMessage,
+  ClientCommand,
+  MetadataTone,
+  MetadataStatus,
+  MetadataProgress,
+  MetadataLogEntry,
+  SessionMetadata,
+} from "./shared";

--- a/plugins/tt-agentboard2/packages/runtime/src/mux/detect.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/mux/detect.ts
@@ -1,0 +1,20 @@
+import type { MuxProvider } from "../contracts/mux";
+import { MuxRegistry } from "./registry";
+
+/**
+ * Auto-detect the terminal multiplexer from environment variables.
+ * Uses the registry to find matching providers.
+ *
+ * Detection: $TMUX → provider named "tmux"
+ *
+ * Users can override by passing their own MuxProvider.
+ */
+export function detectMux(registry?: MuxRegistry): MuxProvider | null {
+  if (!registry) return null;
+
+  if (process.env.TMUX) {
+    return registry.get("tmux");
+  }
+
+  return null;
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/mux/registry.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/mux/registry.ts
@@ -1,0 +1,45 @@
+import type { MuxProvider } from "../contracts/mux";
+
+/**
+ * Registry for MuxProvider implementations.
+ *
+ * The server resolves which provider to use via:
+ *   1. Explicit config override (user picks a mux by name)
+ *   2. Auto-detect from env ($TMUX)
+ *   3. First registered provider as fallback
+ */
+export class MuxRegistry {
+  private providers = new Map<string, MuxProvider>();
+
+  register(provider: MuxProvider): void {
+    this.providers.set(provider.name, provider);
+  }
+
+  get(name: string): MuxProvider | null {
+    return this.providers.get(name) ?? null;
+  }
+
+  list(): string[] {
+    return [...this.providers.keys()];
+  }
+
+  /**
+   * Resolve the active MuxProvider.
+   * @param preference — explicit mux name from config. Takes priority.
+   * @returns the resolved provider, or null if none found.
+   */
+  resolve(preference?: string): MuxProvider | null {
+    // 1. Explicit preference
+    if (preference) {
+      return this.providers.get(preference) ?? null;
+    }
+
+    // 2. Auto-detect from environment (tmux only)
+    if (process.env.TMUX && this.providers.has("tmux")) {
+      return this.providers.get("tmux")!;
+    }
+
+    // 3. No match
+    return null;
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/plugins/loader.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/plugins/loader.ts
@@ -1,0 +1,152 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+import type { MuxProvider } from "../contracts/mux";
+import type { AgentWatcher } from "../contracts/agent-watcher";
+import { MuxRegistry } from "../mux/registry";
+import { SERVER_PORT, SERVER_HOST } from "../shared";
+
+/**
+ * The API surface passed to every plugin factory function.
+ * Inspired by pi-mono's ExtensionAPI pattern:
+ *   export default function(api: PluginAPI) { ... }
+ */
+export interface PluginAPI {
+  registerMux(provider: MuxProvider): void;
+  registerWatcher(watcher: AgentWatcher): void;
+  readonly serverPort: number;
+  readonly serverHost: string;
+}
+
+/** Plugin factory — the single export a plugin must provide */
+export type PluginFactory = (api: PluginAPI) => void | Promise<void>;
+
+export class PluginLoader {
+  readonly registry = new MuxRegistry();
+  private watchers: AgentWatcher[] = [];
+
+  registerMux(provider: MuxProvider): void {
+    this.registry.register(provider);
+  }
+
+  registerWatcher(watcher: AgentWatcher): void {
+    this.watchers.push(watcher);
+  }
+
+  getWatchers(): AgentWatcher[] {
+    return [...this.watchers];
+  }
+
+  resolve(preference?: string): MuxProvider | null {
+    return this.registry.resolve(preference);
+  }
+
+  /**
+   * Build the PluginAPI object that gets passed to every factory function.
+   */
+  private createAPI(): PluginAPI {
+    return {
+      registerMux: (provider: MuxProvider) => this.registry.register(provider),
+      registerWatcher: (watcher: AgentWatcher) => this.registerWatcher(watcher),
+      serverPort: SERVER_PORT,
+      serverHost: SERVER_HOST,
+    };
+  }
+
+  /**
+   * Load plugins from a directory (like ~/.config/towles-tool/agentboard2/plugins/).
+   * Scans one level deep:
+   *   - *.ts / *.js files → loaded directly
+   *   - subdirs with index.ts / index.js → loaded as entry point
+   *
+   * Each must `export default function(api: PluginAPI) { ... }`
+   *
+   * Returns names of successfully loaded plugins.
+   */
+  loadDir(dir: string): string[] {
+    if (!existsSync(dir)) return [];
+
+    const loaded: string[] = [];
+    const api = this.createAPI();
+    const entries = readdirSync(dir);
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isFile()) {
+        const ext = extname(entry);
+        if (ext !== ".ts" && ext !== ".js") continue;
+        if (this.loadFactory(fullPath, api)) loaded.push(entry);
+      } else if (stat.isDirectory()) {
+        // Check for index.ts or index.js
+        const indexTs = join(fullPath, "index.ts");
+        const indexJs = join(fullPath, "index.js");
+        const indexPath = existsSync(indexTs) ? indexTs : existsSync(indexJs) ? indexJs : null;
+        if (indexPath && this.loadFactory(indexPath, api)) loaded.push(entry);
+      }
+    }
+
+    return loaded;
+  }
+
+  /**
+   * Load community plugins from npm package names.
+   * Each package should `export default function(api: PluginAPI) { ... }`
+   * or have a package.json "agentboard2" field pointing to the entry file.
+   *
+   * Returns names of successfully loaded packages.
+   */
+  loadPackages(packageNames: string[]): string[] {
+    const loaded: string[] = [];
+    const api = this.createAPI();
+
+    for (const pkg of packageNames) {
+      try {
+        const mod = require(pkg);
+        const factory: PluginFactory | undefined =
+          typeof mod.default === "function"
+            ? mod.default
+            : typeof mod === "function"
+              ? mod
+              : undefined;
+        if (factory) {
+          factory(api);
+          loaded.push(pkg);
+        }
+      } catch {
+        // Package not installed or broken — skip
+      }
+    }
+
+    return loaded;
+  }
+
+  /**
+   * Load a single factory from a file path.
+   */
+  private loadFactory(filePath: string, api: PluginAPI): boolean {
+    try {
+      const mod = require(filePath);
+      const factory: PluginFactory | undefined =
+        typeof mod.default === "function"
+          ? mod.default
+          : typeof mod === "function"
+            ? mod
+            : undefined;
+      if (!factory) return false;
+      factory(api);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  getSetupInfo(): { registeredMuxProviders: string[]; configPath: string; serverPort: number } {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+    return {
+      registeredMuxProviders: this.registry.list(),
+      configPath: join(home, ".config", "towles-tool", "agentboard2", "config.json"),
+      serverPort: SERVER_PORT,
+    };
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/context.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/context.ts
@@ -1,0 +1,114 @@
+import type { Server } from "bun";
+import type { MuxProvider, FullSidebarCapable, SidebarPane } from "../contracts/mux";
+import type { AgentTracker } from "../agents/tracker";
+import type { SessionOrder } from "./session-order";
+import type { SessionMetadataStore } from "./metadata-store";
+import type { SidebarResizeContext, SidebarResizeSuppression } from "./sidebar-width-sync";
+import type { ServerState } from "../shared";
+import type { AgentStatus } from "../contracts/agent";
+
+export interface PaneAgentPresence {
+  agent: string;
+  session: string;
+  paneId: string;
+  threadId?: string;
+  threadName?: string;
+  status?: AgentStatus;
+  lastSeenTs: number;
+}
+
+/**
+ * Shared mutable state for all server modules.
+ * Created once in startServer(), passed to all sub-modules.
+ */
+export interface ServerContext {
+  // Core dependencies
+  mux: MuxProvider;
+  allProviders: MuxProvider[];
+  tracker: AgentTracker;
+  sessionOrder: SessionOrder;
+  metadataStore: SessionMetadataStore;
+
+  // Config
+  currentTheme: string | undefined;
+  sidebarWidth: number;
+  sidebarPosition: "left" | "right";
+  sidebarVisible: boolean;
+  scriptsDir: string;
+  home: string;
+
+  // Session/focus state
+  focusedSession: string | null;
+  lastState: ServerState | null;
+  clientCount: number;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+  clientTtys: WeakMap<object, string>;
+  clientSessionNames: WeakMap<object, string>;
+  sessionProviders: Map<string, MuxProvider>;
+  clientTtyBySession: Map<string, string>;
+
+  // Current session cache
+  cachedCurrentSession: string | null;
+  cachedCurrentSessionTs: number;
+
+  // Sidebar state
+  pendingSidebarSpawns: Set<string>;
+  suppressedSidebarResizeAcks: Map<string, SidebarResizeSuppression>;
+  sidebarSnapshots: Map<string, { width?: number; windowWidth?: number }>;
+  pendingSidebarResize: ReturnType<typeof setTimeout> | null;
+  pendingSidebarResizeCtx: SidebarResizeContext | undefined;
+  sidebarPaneCache: { provider: FullSidebarCapable; panes: SidebarPane[] }[] | null;
+  sidebarPaneCacheTs: number;
+  ensureSidebarTimer: ReturnType<typeof setTimeout> | null;
+  ensureSidebarPendingCtx: { session: string; windowId: string } | undefined;
+
+  // Pane agent scanning
+  paneAgentsBySession: Map<string, Map<string, PaneAgentPresence>>;
+  paneScanTimer: ReturnType<typeof setInterval> | null;
+
+  // Port polling
+  portPollTimer: ReturnType<typeof setInterval> | null;
+
+  // Highlight tracking
+  pendingHighlightResets: Map<string, ReturnType<typeof setTimeout>>;
+
+  // Server ref (set after Bun.serve)
+  server: Server;
+
+  // Wired functions
+  broadcastState: () => void;
+  broadcastFocusOnly: (sender?: any) => void;
+  getCurrentSession: () => string | null;
+  getCachedCurrentSession: () => string | null;
+  invalidateCurrentSessionCache: () => void;
+  getProvidersWithSidebar: () => FullSidebarCapable[];
+  listSidebarPanesByProvider: () => { provider: FullSidebarCapable; panes: SidebarPane[] }[];
+  invalidateSidebarPaneCache: () => void;
+  handleFocus: (name: string) => void;
+  moveFocus: (delta: -1 | 1, sender?: any) => void;
+  setFocus: (name: string, sender?: any) => void;
+  refreshPaneAgents: () => void;
+  cleanup: () => void;
+  toggleSidebar: (ctx?: { session: string; windowId: string }) => void;
+  ensureSidebarInWindow: (
+    provider?: FullSidebarCapable,
+    ctx?: { session: string; windowId: string },
+  ) => void;
+  debouncedEnsureSidebar: (ctx?: { session: string; windowId: string }) => void;
+  scheduleSidebarResize: (ctx?: SidebarResizeContext) => void;
+  resizeSidebars: (ctx?: SidebarResizeContext) => void;
+  quitAll: () => void;
+  switchToVisibleIndex: (index: number, clientTty?: string) => void;
+  focusAgentPane: (
+    sessionName: string,
+    agentName: string,
+    threadId?: string,
+    threadName?: string,
+  ) => void;
+  killAgentPane: (
+    sessionName: string,
+    agentName: string,
+    threadId?: string,
+    threadName?: string,
+  ) => void;
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/git-info.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/git-info.ts
@@ -1,0 +1,106 @@
+import { existsSync, watch } from "node:fs";
+import type { FSWatcher } from "node:fs";
+import { join } from "node:path";
+import type { SessionData } from "../shared";
+
+// --- Shell helper (for git commands only) ---
+
+export function shell(cmd: string[]): string {
+  try {
+    const result = Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe" });
+    return result.stdout.toString().trim();
+  } catch {
+    return "";
+  }
+}
+
+// --- Git helpers ---
+
+export interface GitInfo {
+  branch: string;
+  dirty: boolean;
+  isWorktree: boolean;
+}
+
+const gitInfoCache = new Map<string, { info: GitInfo; ts: number }>();
+const GIT_CACHE_TTL_MS = 5000;
+
+export function getGitInfo(dir: string): GitInfo {
+  if (!dir) return { branch: "", dirty: false, isWorktree: false };
+
+  const cached = gitInfoCache.get(dir);
+  if (cached && Date.now() - cached.ts < GIT_CACHE_TTL_MS) return cached.info;
+
+  const branch = shell(["git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]);
+  if (!branch) return { branch: "", dirty: false, isWorktree: false };
+  const gitDir = shell(["git", "-C", dir, "rev-parse", "--git-dir"]);
+  const statusOut = shell(["git", "-C", dir, "status", "--porcelain"]);
+  const info: GitInfo = {
+    branch,
+    dirty: statusOut.length > 0,
+    isWorktree: gitDir.includes("/worktrees/"),
+  };
+  gitInfoCache.set(dir, { info, ts: Date.now() });
+  return info;
+}
+
+export function invalidateGitCache(dir?: string): void {
+  if (dir) gitInfoCache.delete(dir);
+  else gitInfoCache.clear();
+}
+
+// --- Git HEAD file watchers ---
+
+const gitHeadWatchers = new Map<string, FSWatcher>();
+
+function resolveGitHeadPath(dir: string): string | null {
+  if (!dir) return null;
+  const gitDir = shell(["git", "-C", dir, "rev-parse", "--git-dir"]);
+  if (!gitDir) return null;
+  const absGitDir = gitDir.startsWith("/") ? gitDir : join(dir, gitDir);
+  const headPath = join(absGitDir, "HEAD");
+  return existsSync(headPath) ? headPath : null;
+}
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function onGitHeadChange(broadcastFn: () => void): void {
+  if (debounceTimer) return;
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    invalidateGitCache();
+    broadcastFn();
+  }, 200);
+}
+
+export function syncGitWatchers(sessions: SessionData[], broadcastFn: () => void): void {
+  const currentDirs = new Set<string>();
+  for (const s of sessions) {
+    if (s.dir) currentDirs.add(s.dir);
+  }
+
+  for (const [dir, watcher] of gitHeadWatchers) {
+    if (!currentDirs.has(dir)) {
+      watcher.close();
+      gitHeadWatchers.delete(dir);
+    }
+  }
+
+  for (const dir of currentDirs) {
+    if (gitHeadWatchers.has(dir)) continue;
+    const headPath = resolveGitHeadPath(dir);
+    if (!headPath) continue;
+    try {
+      const watcher = watch(headPath, () => onGitHeadChange(broadcastFn));
+      gitHeadWatchers.set(dir, watcher);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export function teardownGitWatchers(): void {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  for (const watcher of gitHeadWatchers.values()) watcher.close();
+  gitHeadWatchers.clear();
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/index.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/index.ts
@@ -1,0 +1,1736 @@
+import { readFileSync, unlinkSync, writeFileSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { MuxProvider } from "../contracts/mux";
+import { isFullSidebarCapable, isBatchCapable } from "../contracts/mux";
+import type { AgentEvent } from "../contracts/agent";
+import type { AgentWatcher, AgentWatcherContext } from "../contracts/agent-watcher";
+import { AgentTracker, instanceKey } from "../agents/tracker";
+import { SessionOrder } from "./session-order";
+import { SessionMetadataStore } from "./metadata-store";
+import { loadConfig, saveConfig } from "../config";
+import { resolveSidebarWidthFromResizeContext, snapshotSidebarWindows } from "./sidebar-width-sync";
+import type { SidebarResizeContext, SidebarResizeSuppression } from "./sidebar-width-sync";
+import { shell, getGitInfo, syncGitWatchers, teardownGitWatchers } from "./git-info";
+import { refreshPortSnapshot, getSessionPorts } from "./port-scanner";
+import {
+  SERVER_PORT,
+  SERVER_HOST,
+  PID_FILE,
+  SERVER_IDLE_TIMEOUT_MS,
+  STUCK_RUNNING_TIMEOUT_MS,
+} from "../shared";
+import type { ServerState, SessionData, ClientCommand, FocusUpdate, MetadataTone } from "../shared";
+
+const VALID_TONES = new Set<string>(["neutral", "info", "success", "warn", "error"]);
+function parseTone(v: unknown): MetadataTone | undefined {
+  return typeof v === "string" && VALID_TONES.has(v) ? (v as MetadataTone) : undefined;
+}
+
+// --- Debug logger ---
+
+const DEBUG_LOG = "/tmp/agentboard2-debug.log";
+const DEBUG_ENABLED = !!process.env.AGENTBOARD2_DEBUG;
+
+function log(category: string, msg: string, data?: Record<string, unknown>) {
+  if (!DEBUG_ENABLED) return;
+  const ts = new Date().toISOString().slice(11, 23);
+  const extra = data ? " " + JSON.stringify(data) : "";
+  const line = `[${ts}] [${category}] ${msg}${extra}\n`;
+  try {
+    appendFileSync(DEBUG_LOG, line);
+  } catch {}
+}
+
+// shell, getGitInfo, invalidateGitCache imported from ./git-info
+
+// refreshPortSnapshot, getSessionPorts imported from ./port-scanner
+
+// syncGitWatchers, teardownGitWatchers imported from ./git-info
+
+// --- Server startup ---
+
+export function startServer(
+  mux: MuxProvider,
+  extraProviders?: MuxProvider[],
+  watchers?: AgentWatcher[],
+): void {
+  const allProviders = [mux, ...(extraProviders ?? [])];
+  const allWatchers = watchers ?? [];
+  const tracker = new AgentTracker();
+  const metadataStore = new SessionMetadataStore();
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const sessionOrderPath = join(
+    home,
+    ".config",
+    "towles-tool",
+    "agentboard2",
+    "session-order.json",
+  );
+  const sessionOrder = new SessionOrder(sessionOrderPath);
+
+  // Clear previous log on server start
+  try {
+    writeFileSync(DEBUG_LOG, "");
+  } catch {}
+  log("server", "starting", { providers: allProviders.map((p) => p.name) });
+
+  // Load initial theme from config
+  const config = loadConfig();
+  let currentTheme: string | undefined =
+    typeof config.theme === "string" ? config.theme : undefined;
+  let sidebarWidth = config.sidebarWidth ?? 26;
+  let sidebarPosition: "left" | "right" = config.sidebarPosition ?? "left";
+  let sidebarVisible = false;
+
+  // The sidebar launcher lives with the TUI app, not the tmux integration layer.
+  const scriptsDir = (() => {
+    const envDir = process.env.AGENTBOARD2_DIR;
+    if (envDir) return join(envDir, "apps", "tui", "scripts");
+    // Fallback: relative to this file
+    return join(import.meta.dir, "..", "..", "..", "..", "apps", "tui", "scripts");
+  })();
+
+  log("server", "config loaded", {
+    sidebarWidth,
+    sidebarPosition,
+    scriptsDir,
+    theme: currentTheme,
+    configKeys: Object.keys(config),
+  });
+
+  // Bootstrap active sessions
+  const currentSession = mux.getCurrentSession();
+  if (currentSession) {
+    tracker.setActiveSessions([currentSession]);
+  }
+
+  // --- Agent watcher context ---
+
+  let watcherBroadcastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function debouncedBroadcast() {
+    if (watcherBroadcastTimer) return;
+    watcherBroadcastTimer = setTimeout(() => {
+      watcherBroadcastTimer = null;
+      broadcastState();
+    }, 200);
+  }
+
+  // Cache for dir→session resolution (rebuilt per scan cycle)
+  let dirSessionCache: Map<string, string> | null = null;
+  let dirSessionCacheTs = 0;
+  const DIR_CACHE_TTL = 5000;
+
+  function getDirSessionMap(): Map<string, string> {
+    const now = Date.now();
+    if (dirSessionCache && now - dirSessionCacheTs < DIR_CACHE_TTL) return dirSessionCache;
+    const map = new Map<string, string>();
+    for (const p of allProviders) {
+      for (const s of p.listSessions()) {
+        if (s.dir) map.set(s.dir, s.name);
+      }
+    }
+    dirSessionCache = map;
+    dirSessionCacheTs = now;
+    return map;
+  }
+
+  const watcherCtx: AgentWatcherContext = {
+    resolveSession(projectDir: string): string | null {
+      const map = getDirSessionMap();
+      const direct = map.get(projectDir);
+      if (direct) return direct;
+      for (const [dir, name] of map) {
+        if (projectDir.startsWith(dir + "/") || dir.startsWith(projectDir + "/")) return name;
+      }
+      return null;
+    },
+    emit(event: AgentEvent) {
+      tracker.applyEvent(event, { seed: !watchersSeeded });
+      debouncedBroadcast();
+    },
+  };
+
+  // Flag to track when initial watcher seeding is complete
+  let watchersSeeded = false;
+  setTimeout(() => {
+    watchersSeeded = true;
+    // Re-apply focus for the current session to clear seed-unseen flags
+    // (handleFocus already ran before seed events arrived)
+    const current = getCurrentSession();
+    if (current && tracker.handleFocus(current)) {
+      broadcastState();
+    }
+  }, 3000);
+
+  let focusedSession: string | null = null;
+  let lastState: ServerState | null = null;
+  let clientCount = 0;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  const clientTtys = new WeakMap<object, string>();
+  const clientSessionNames = new WeakMap<object, string>();
+  const sessionProviders = new Map<string, MuxProvider>();
+  // Map session name → client TTY (from hook context, for multi-client setups)
+  const clientTtyBySession = new Map<string, string>();
+
+  function getCurrentSession(): string | null {
+    // Try all providers until one returns a session
+    for (const p of allProviders) {
+      const result = p.getCurrentSession();
+      if (result) {
+        log("getCurrentSession", "result", { result, provider: p.name });
+        return result;
+      }
+    }
+    log("getCurrentSession", "no provider returned a session");
+    return null;
+  }
+
+  /** Merge pane-detected agents into watcher-provided agents for a session.
+   *  Watcher events take precedence — pane presence only adds synthetic entries
+   *  for agents that aren't already tracked by watchers. */
+  function mergeAgentsWithPanePresence(
+    sessionName: string,
+    watcherAgents: AgentEvent[],
+  ): AgentEvent[] {
+    const paneAgents = paneAgentsBySession.get(sessionName);
+    if (!paneAgents || paneAgents.size === 0) return watcherAgents;
+
+    const result = [...watcherAgents];
+    // Build a set of tracked agent:threadId keys for matching
+    const trackedByKey = new Set(watcherAgents.map((a) => instanceKey(a.agent, a.threadId)));
+    // Also track which agent names + threadIds are covered by watchers
+    const trackedThreadIds = new Set(
+      watcherAgents.filter((a) => a.threadId).map((a) => `${a.agent}:${a.threadId}`),
+    );
+
+    for (const [, presence] of paneAgents) {
+      // If the pane scanner resolved a threadId, check if watcher already tracks it
+      if (presence.threadId && trackedThreadIds.has(`${presence.agent}:${presence.threadId}`))
+        continue;
+      // Check by instanceKey as well
+      if (trackedByKey.has(instanceKey(presence.agent, presence.threadId))) continue;
+      // If we have no threadId from pane scan and watcher tracks any instance of this agent, skip
+      if (!presence.threadId && watcherAgents.some((a) => a.agent === presence.agent)) continue;
+
+      result.push({
+        agent: presence.agent,
+        session: sessionName,
+        status: presence.status ?? "idle",
+        ts: presence.lastSeenTs,
+        threadId: presence.threadId,
+        threadName: presence.threadName,
+        paneId: presence.paneId,
+      });
+    }
+
+    return result;
+  }
+
+  function computeState(): ServerState {
+    // Merge sessions from all providers
+    const allMuxSessions: (import("../contracts/mux").MuxSessionInfo & {
+      provider: MuxProvider;
+    })[] = [];
+    for (const p of allProviders) {
+      for (const s of p.listSessions()) {
+        allMuxSessions.push({ ...s, provider: p });
+      }
+    }
+    allMuxSessions.sort((a, b) => {
+      if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+      return a.name.localeCompare(b.name);
+    });
+
+    const currentSession = getCurrentSession();
+
+    // Sync custom ordering with current session list
+    sessionOrder.sync(allMuxSessions.map((s) => s.name));
+    if (currentSession) {
+      sessionOrder.show(currentSession);
+    }
+
+    // Apply custom ordering
+    const orderedNames = sessionOrder.apply(allMuxSessions.map((s) => s.name));
+    const sessionByName = new Map(allMuxSessions.map((s) => [s.name, s]));
+    const orderedMuxSessions = orderedNames.map((n) => sessionByName.get(n)!);
+
+    // Batch pane counts per provider (uses BatchCapable type guard)
+    const paneCountMaps = new Map<MuxProvider, Map<string, number>>();
+    for (const p of allProviders) {
+      if (isBatchCapable(p)) {
+        paneCountMaps.set(p, p.getAllPaneCounts());
+      }
+    }
+
+    const sessions: SessionData[] = orderedMuxSessions.map(
+      ({ name, createdAt, windows, dir, provider }) => {
+        sessionProviders.set(name, provider);
+        const git = getGitInfo(dir);
+        const providerPaneCounts = paneCountMaps.get(provider);
+        const panes = providerPaneCounts?.get(name) ?? provider.getPaneCount(name);
+
+        let uptime = "";
+        const diff = Math.floor(Date.now() / 1000) - createdAt;
+        if (!Number.isNaN(diff) && diff >= 0) {
+          const days = Math.floor(diff / 86400);
+          const hours = Math.floor((diff % 86400) / 3600);
+          const mins = Math.floor((diff % 3600) / 60);
+          if (days > 0) uptime = `${days}d${hours}h`;
+          else if (hours > 0) uptime = `${hours}h${mins}m`;
+          else uptime = `${mins}m`;
+        }
+
+        return {
+          name,
+          createdAt,
+          dir,
+          branch: git.branch,
+          dirty: git.dirty,
+          isWorktree: git.isWorktree,
+          unseen: tracker.isUnseen(name),
+          panes,
+          ports: getSessionPorts(name),
+          windows,
+          uptime,
+          agentState: tracker.getState(name),
+          agents: mergeAgentsWithPanePresence(name, tracker.getAgents(name)),
+          eventTimestamps: tracker.getEventTimestamps(name),
+          metadata: metadataStore.get(name),
+        };
+      },
+    );
+
+    metadataStore.pruneSessions(new Set(sessions.map((s) => s.name)));
+
+    if (sessions.length === 0) {
+      focusedSession = null;
+    } else if (!focusedSession || !sessions.some((s) => s.name === focusedSession)) {
+      focusedSession = sessions.find((s) => s.name === currentSession)?.name ?? sessions[0]!.name;
+    }
+
+    return {
+      type: "state",
+      sessions,
+      focusedSession,
+      currentSession,
+      theme: currentTheme,
+      sidebarWidth,
+      ts: Date.now(),
+    };
+  }
+
+  let broadcastPending = false;
+
+  function broadcastState() {
+    if (broadcastPending) return;
+    broadcastPending = true;
+    queueMicrotask(() => {
+      broadcastPending = false;
+      broadcastStateImmediate();
+    });
+  }
+
+  function broadcastStateImmediate() {
+    invalidateCurrentSessionCache();
+    tracker.pruneStuck(STUCK_RUNNING_TIMEOUT_MS);
+    tracker.pruneTerminal();
+    lastState = computeState();
+    syncGitWatchers(lastState.sessions, broadcastState);
+    const msg = JSON.stringify(lastState);
+    server.publish("sidebar", msg);
+  }
+
+  // Lightweight current-session cache — avoids a tmux subprocess per focus update
+  let cachedCurrentSession: string | null = null;
+  let cachedCurrentSessionTs = 0;
+  const CURRENT_SESSION_CACHE_TTL = 500; // ms — short TTL, just enough to coalesce rapid switches
+
+  function getCachedCurrentSession(): string | null {
+    const now = Date.now();
+    if (now - cachedCurrentSessionTs < CURRENT_SESSION_CACHE_TTL) return cachedCurrentSession;
+    cachedCurrentSession = getCurrentSession();
+    cachedCurrentSessionTs = now;
+    return cachedCurrentSession;
+  }
+
+  function invalidateCurrentSessionCache(): void {
+    cachedCurrentSessionTs = 0;
+  }
+
+  function broadcastFocusOnly(sender?: any) {
+    if (!lastState) return;
+    const currentSession = getCachedCurrentSession();
+    lastState = { ...lastState, focusedSession, currentSession };
+    const msg: FocusUpdate = { type: "focus", focusedSession, currentSession };
+    const payload = JSON.stringify(msg);
+    if (sender) {
+      sender.publish("sidebar", payload);
+    } else {
+      server.publish("sidebar", payload);
+    }
+  }
+
+  function moveFocus(delta: -1 | 1, sender?: any) {
+    if (!lastState || lastState.sessions.length === 0) return;
+    const sessions = lastState.sessions;
+    const currentIdx = sessions.findIndex((s) => s.name === focusedSession);
+    const newIdx = Math.max(
+      0,
+      Math.min(sessions.length - 1, (currentIdx === -1 ? 0 : currentIdx) + delta),
+    );
+    focusedSession = sessions[newIdx]!.name;
+    broadcastFocusOnly(sender);
+  }
+
+  function setFocus(name: string, sender?: any) {
+    if (lastState && lastState.sessions.some((s) => s.name === name)) {
+      focusedSession = name;
+      broadcastFocusOnly(sender);
+    }
+  }
+
+  function handleFocus(name: string): void {
+    focusedSession = name;
+    invalidateCurrentSessionCache();
+    // Rescan pane agents when session focus changes
+    refreshPaneAgents();
+    const hadUnseen = tracker.handleFocus(name);
+    if (hadUnseen && lastState) {
+      // Patch unseen flags in-place — avoids a full computeState with many subprocesses
+      const currentSession = getCachedCurrentSession();
+      const updatedSessions = lastState.sessions.map((s) => {
+        if (s.name !== name) return s;
+        return {
+          ...s,
+          unseen: false,
+          agents: s.agents.map((a) => ({ ...a, unseen: false })),
+        };
+      });
+      lastState = { ...lastState, sessions: updatedSessions, focusedSession, currentSession };
+      server.publish("sidebar", JSON.stringify(lastState));
+    } else if (hadUnseen) {
+      broadcastState();
+    } else {
+      broadcastFocusOnly();
+    }
+  }
+
+  function switchToVisibleIndex(index: number, clientTty?: string): void {
+    if (!lastState) {
+      broadcastState();
+    }
+
+    if (!lastState) return;
+
+    const idx = index - 1;
+    if (idx < 0 || idx >= lastState.sessions.length) return;
+
+    const name = lastState.sessions[idx]!.name;
+    const p = sessionProviders.get(name) ?? mux;
+    p.switchSession(name, clientTty);
+  }
+
+  // --- Sidebar management ---
+
+  function getProvidersWithSidebar() {
+    return allProviders.filter(isFullSidebarCapable);
+  }
+
+  /** Parse "clientTty|session|windowId" or legacy "session:windowId" context from POST body */
+  function parseContext(
+    body: string,
+  ): { clientTty?: string; session: string; windowId: string } | null {
+    const trimmed = body
+      .trim()
+      .replace(/^"+|"+$/g, "")
+      .replace(/^'+|'+$/g, "");
+
+    // New format: pipe-separated "clientTty|session|windowId"
+    const pipeParts = trimmed.split("|");
+    if (pipeParts.length === 3 && pipeParts[1] && pipeParts[2]) {
+      const ctx = {
+        clientTty: pipeParts[0] || undefined,
+        session: pipeParts[1],
+        windowId: pipeParts[2],
+      };
+      if (ctx.clientTty && ctx.session) {
+        clientTtyBySession.set(ctx.session, ctx.clientTty);
+      }
+      return ctx;
+    }
+
+    // Legacy format: "session:windowId"
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx < 1) return null;
+    const session = trimmed.slice(0, colonIdx);
+    const windowId = trimmed.slice(colonIdx + 1);
+    if (!session || !windowId) return null;
+    return { session, windowId };
+  }
+
+  function parseResizeContext(body: string): SidebarResizeContext | null {
+    const trimmed = body
+      .trim()
+      .replace(/^"+|"+$/g, "")
+      .replace(/^'+|'+$/g, "");
+    if (!trimmed) return null;
+
+    const [paneId, sessionName, windowId, widthRaw, windowWidthRaw] = trimmed.split("|");
+    if (!paneId) return null;
+
+    const width = Number.parseInt(widthRaw ?? "", 10);
+    const windowWidth = Number.parseInt(windowWidthRaw ?? "", 10);
+
+    return {
+      paneId,
+      sessionName: sessionName || undefined,
+      windowId: windowId || undefined,
+      width: Number.isNaN(width) ? undefined : width,
+      windowWidth: Number.isNaN(windowWidth) ? undefined : windowWidth,
+    };
+  }
+
+  // Short-lived cache for sidebar pane listings — avoid repeated tmux list-panes -a
+  let sidebarPaneCache: ReturnType<typeof listSidebarPanesByProviderUncached> | null = null;
+  let sidebarPaneCacheTs = 0;
+  const SIDEBAR_PANE_CACHE_TTL = 300; // ms
+
+  function listSidebarPanesByProviderUncached() {
+    return getProvidersWithSidebar().map((provider) => ({
+      provider,
+      panes: provider.listSidebarPanes(),
+    }));
+  }
+
+  function listSidebarPanesByProvider() {
+    const now = Date.now();
+    if (sidebarPaneCache && now - sidebarPaneCacheTs < SIDEBAR_PANE_CACHE_TTL)
+      return sidebarPaneCache;
+    sidebarPaneCache = listSidebarPanesByProviderUncached();
+    sidebarPaneCacheTs = now;
+    return sidebarPaneCache;
+  }
+
+  function invalidateSidebarPaneCache(): void {
+    sidebarPaneCache = null;
+    sidebarPaneCacheTs = 0;
+  }
+
+  const pendingSidebarSpawns = new Set<string>();
+  const suppressedSidebarResizeAcks = new Map<string, SidebarResizeSuppression>();
+  let sidebarSnapshots = new Map<string, { width?: number; windowWidth?: number }>();
+  let pendingSidebarResize: ReturnType<typeof setTimeout> | null = null;
+  let pendingSidebarResizeCtx: SidebarResizeContext | undefined;
+
+  function scheduleSidebarResize(ctx?: SidebarResizeContext): void {
+    if (ctx) pendingSidebarResizeCtx = ctx;
+    resizeSidebars(ctx);
+    if (pendingSidebarResize) clearTimeout(pendingSidebarResize);
+    // tmux can finish layout changes slightly after the pane appears.
+    pendingSidebarResize = setTimeout(() => {
+      const nextCtx = pendingSidebarResizeCtx;
+      pendingSidebarResizeCtx = undefined;
+      pendingSidebarResize = null;
+      resizeSidebars(nextCtx);
+    }, 120);
+  }
+
+  function toggleSidebar(ctx?: { session: string; windowId: string }): void {
+    const providers = getProvidersWithSidebar();
+    if (providers.length === 0) {
+      log("toggle", "SKIP — no providers with sidebar methods");
+      return;
+    }
+
+    invalidateSidebarPaneCache();
+    if (sidebarVisible) {
+      for (const p of providers) {
+        const panes = p.listSidebarPanes();
+        log("toggle", "OFF — hiding panes", { provider: p.name, count: panes.length });
+        for (const pane of panes) {
+          p.hideSidebar(pane.paneId);
+        }
+      }
+      sidebarVisible = false;
+    } else {
+      sidebarVisible = true;
+      for (const p of providers) {
+        const allWindows = p.listActiveWindows();
+        log("toggle", "ON — spawning in active windows", {
+          provider: p.name,
+          count: allWindows.length,
+        });
+        for (const w of allWindows) {
+          ensureSidebarInWindow(p, { session: w.sessionName, windowId: w.id });
+        }
+      }
+      scheduleSidebarResize();
+      server.publish("sidebar", JSON.stringify({ type: "re-identify" }));
+    }
+    log("toggle", "done", { sidebarVisible });
+  }
+
+  function ensureSidebarInWindow(
+    provider?: ReturnType<typeof getProvidersWithSidebar>[number],
+    ctx?: { session: string; windowId: string },
+  ): void {
+    // If no specific provider, try to find one for the session
+    const p =
+      provider ??
+      (() => {
+        const providers = getProvidersWithSidebar();
+        if (ctx?.session) {
+          const sessionProvider = sessionProviders.get(ctx.session);
+          return providers.find((pp) => pp === sessionProvider) ?? providers[0];
+        }
+        return providers[0];
+      })();
+    if (!p || !sidebarVisible) {
+      log("ensure", "SKIP", { hasProvider: !!p, sidebarVisible });
+      return;
+    }
+
+    const curSession = ctx?.session ?? getCurrentSession();
+    if (!curSession) {
+      log("ensure", "SKIP — no current session");
+      return;
+    }
+
+    const windowId = ctx?.windowId ?? p.getCurrentWindowId();
+    if (!windowId) {
+      log("ensure", "SKIP — could not get window_id");
+      return;
+    }
+
+    const spawnKey = `${p.name}:${windowId}`;
+    if (pendingSidebarSpawns.has(spawnKey)) {
+      log("ensure", "SKIP — spawn already in progress", { curSession, windowId, provider: p.name });
+      return;
+    }
+
+    // Use cached pane listing to avoid redundant tmux list-panes -a calls
+    const allPanesByProvider = listSidebarPanesByProvider();
+    const providerEntry = allPanesByProvider.find((e) => e.provider === p);
+    const existingPanes = providerEntry?.panes ?? [];
+    const hasInWindow = existingPanes.some((ep) => ep.windowId === windowId);
+    log("ensure", "checking window", {
+      curSession,
+      windowId,
+      existingPanes: existingPanes.length,
+      hasInWindow,
+      paneIds: existingPanes.map((x) => `${x.paneId}@${x.windowId}`),
+    });
+
+    if (!hasInWindow) {
+      invalidateSidebarPaneCache();
+      pendingSidebarSpawns.add(spawnKey);
+      log("ensure", "SPAWNING sidebar", {
+        curSession,
+        windowId,
+        sidebarWidth,
+        sidebarPosition,
+        scriptsDir,
+      });
+      try {
+        const newPaneId = p.spawnSidebar(
+          curSession,
+          windowId,
+          sidebarWidth,
+          sidebarPosition,
+          scriptsDir,
+        );
+        log("ensure", "spawn result", { newPaneId });
+        // Do NOT refocus the main pane here — the TUI handles it.
+        // For fresh spawns, the TUI refocuses after capability detection.
+        // For stash restores, the TUI refocuses after restoreTerminalModes
+        // responses settle. Refocusing immediately from the server causes
+        // capability query responses to leak as garbage escape sequences.
+      } finally {
+        pendingSidebarSpawns.delete(spawnKey);
+      }
+      // Only schedule resize when we actually spawned — layout changed
+      scheduleSidebarResize();
+    }
+    // When sidebar already exists, no layout change — skip resize
+  }
+
+  // Debounced ensure-sidebar — collapses rapid hook-fired calls during fast
+  // session switching into a single check after switching settles.
+  let ensureSidebarTimer: ReturnType<typeof setTimeout> | null = null;
+  let ensureSidebarPendingCtx: { session: string; windowId: string } | undefined;
+
+  function debouncedEnsureSidebar(ctx?: { session: string; windowId: string }): void {
+    if (ctx) ensureSidebarPendingCtx = ctx;
+    if (ensureSidebarTimer) clearTimeout(ensureSidebarTimer);
+    ensureSidebarTimer = setTimeout(() => {
+      ensureSidebarTimer = null;
+      const nextCtx = ensureSidebarPendingCtx;
+      ensureSidebarPendingCtx = undefined;
+      ensureSidebarInWindow(undefined, nextCtx);
+    }, 150);
+  }
+
+  function quitAll(): void {
+    log("quit", "killing all sidebar panes");
+    for (const p of getProvidersWithSidebar()) {
+      const panes = p.listSidebarPanes();
+      log("quit", "found panes to kill", { provider: p.name, count: panes.length });
+      for (const pane of panes) {
+        p.killSidebarPane(pane.paneId);
+      }
+    }
+    // Provider-specific cleanup (uses type guard)
+    for (const p of getProvidersWithSidebar()) {
+      p.cleanupSidebar();
+    }
+    server.publish("sidebar", JSON.stringify({ type: "quit" }));
+    sidebarVisible = false;
+    cleanup();
+    process.exit(0);
+  }
+
+  // --- Sidebar resize enforcement ---
+
+  function resizeSidebars(ctx?: SidebarResizeContext) {
+    const panesByProvider = listSidebarPanesByProvider();
+    const allPanes = panesByProvider.flatMap(({ panes }) => panes);
+
+    if (allPanes.length === 0) {
+      sidebarSnapshots = new Map();
+      return;
+    }
+
+    const nextSidebarWidth = resolveSidebarWidthFromResizeContext({
+      ctx,
+      panes: allPanes,
+      previousByWindow: sidebarSnapshots,
+      suppressedByPane: suppressedSidebarResizeAcks,
+    });
+
+    if (nextSidebarWidth != null && nextSidebarWidth !== sidebarWidth) {
+      sidebarWidth = nextSidebarWidth;
+      saveConfig({ sidebarWidth });
+      log("resize", "adopted sidebar width from pane resize", {
+        paneId: ctx?.paneId ?? null,
+        sessionName: ctx?.sessionName ?? null,
+        windowId: ctx?.windowId ?? null,
+        sidebarWidth,
+      });
+      broadcastState();
+    }
+
+    const now = Date.now();
+    for (const { provider, panes } of panesByProvider) {
+      log("resize", "enforcing width on all panes", {
+        provider: provider.name,
+        sidebarWidth,
+        count: panes.length,
+        triggerPaneId: ctx?.paneId ?? null,
+      });
+      for (const pane of panes) {
+        if (pane.width === sidebarWidth) continue;
+        suppressedSidebarResizeAcks.set(pane.paneId, {
+          width: sidebarWidth,
+          expiresAt: now + 1_000,
+        });
+        provider.resizeSidebarPane(pane.paneId, sidebarWidth);
+      }
+    }
+
+    // After resizing, invalidate the sidebar pane cache since widths changed,
+    // and use the already-fetched list for the snapshot (avoid another tmux call).
+    if (panesByProvider.some(({ panes }) => panes.some((pane) => pane.width !== sidebarWidth))) {
+      invalidateSidebarPaneCache();
+    }
+    sidebarSnapshots = snapshotSidebarWindows(allPanes);
+  }
+
+  // --- Focus agent pane (click-to-focus from TUI) ---
+
+  /** Walk up to 3 levels of child processes looking for a command matching any pattern */
+  function matchProcessTree(pid: string, patterns: string[], depth = 0): boolean {
+    if (depth > 2) return false;
+    const children = shell(["pgrep", "-P", pid]);
+    if (!children) return false;
+    for (const childPid of children.split("\n")) {
+      const trimmed = childPid.trim();
+      if (!trimmed) continue;
+      const childCmd = shell(["ps", "-p", trimmed, "-o", "comm="]);
+      if (childCmd && patterns.some((pat) => childCmd.toLowerCase().includes(pat))) return true;
+      if (matchProcessTree(trimmed, patterns, depth + 1)) return true;
+    }
+    return false;
+  }
+
+  const AGENT_TITLE_PATTERNS: Record<string, string[]> = {
+    amp: ["amp"],
+    "claude-code": ["claude"],
+    codex: ["codex"],
+    opencode: ["opencode"],
+  };
+
+  const PANE_HIGHLIGHT_BORDER = "fg=#fab387,bold";
+  const PANE_HIGHLIGHT_MS = 300;
+  const pendingHighlightResets = new Map<string, ReturnType<typeof setTimeout>>();
+
+  /** Walk child processes (up to 3 levels) to find a process matching `name`, returning its PID. */
+  function findChildPid(pid: string, name: string, depth = 0): string | undefined {
+    if (depth > 2) return undefined;
+    const children = shell(["pgrep", "-P", pid]);
+    if (!children) return undefined;
+    for (const childPid of children.split("\n")) {
+      const trimmed = childPid.trim();
+      if (!trimmed) continue;
+      const childCmd = shell(["ps", "-p", trimmed, "-o", "comm="]);
+      if (childCmd?.trim().toLowerCase().includes(name)) return trimmed;
+      const found = findChildPid(trimmed, name, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  type PaneEntry = { id: string; pid: string; cmd: string; title: string };
+
+  /** Claude Code: ~/.claude/sessions/<pid>.json → sessionId */
+  function resolveClaudeCodePane(panes: PaneEntry[], threadId: string): string | undefined {
+    const sessionsDir = join(homedir(), ".claude", "sessions");
+    for (const pane of panes) {
+      const agentPid = findChildPid(pane.pid, "claude");
+      if (!agentPid) continue;
+      try {
+        const data = JSON.parse(readFileSync(join(sessionsDir, `${agentPid}.json`), "utf-8"));
+        if (data.sessionId === threadId) return pane.id;
+      } catch {}
+    }
+    return undefined;
+  }
+
+  /** Codex: logs_1.sqlite process_uuid='pid:<PID>:*' → thread_id */
+  function resolveCodexPane(panes: PaneEntry[], threadId: string): string | undefined {
+    const dbPath = join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "logs_1.sqlite");
+    let db: any;
+    try {
+      const { Database } = require("bun:sqlite");
+      db = new Database(dbPath, { readonly: true });
+    } catch {
+      return undefined;
+    }
+
+    try {
+      for (const pane of panes) {
+        const agentPid = findChildPid(pane.pid, "codex");
+        if (!agentPid) continue;
+        const row = db
+          .query(
+            `SELECT thread_id FROM logs WHERE process_uuid LIKE ? AND thread_id IS NOT NULL ORDER BY ts DESC LIMIT 1`,
+          )
+          .get(`pid:${agentPid}:%`);
+        if (row?.thread_id === threadId) return pane.id;
+      }
+    } finally {
+      try {
+        db.close();
+      } catch {}
+    }
+    return undefined;
+  }
+
+  /** OpenCode: lsof → log file → grep session ID */
+  function resolveOpenCodePane(panes: PaneEntry[], threadId: string): string | undefined {
+    for (const pane of panes) {
+      const agentPid = findChildPid(pane.pid, "opencode");
+      if (!agentPid) continue;
+      const lsofOut = shell(["lsof", "-p", agentPid]);
+      if (!lsofOut) continue;
+      // Find the log file path from open file descriptors
+      const logLine = lsofOut
+        .split("\n")
+        .find((l) => l.includes("/opencode/log/") && l.endsWith(".log"));
+      if (!logLine) continue;
+      // Extract absolute path — lsof NAME column starts at the last recognized path
+      const pathMatch = logLine.match(/\s(\/\S+\.log)$/);
+      if (!pathMatch) continue;
+      try {
+        const logText = readFileSync(pathMatch[1], "utf-8");
+        const match = logText.match(/ses_[A-Za-z0-9]+/);
+        if (match?.[0] === threadId) return pane.id;
+      } catch {}
+    }
+    return undefined;
+  }
+
+  /** Resolve a tmux pane ID for an agent using all available resolution strategies. */
+  function resolveAgentPaneId(
+    sessionName: string,
+    agentName: string,
+    threadId?: string,
+    threadName?: string,
+  ): string | undefined {
+    const p = sessionProviders.get(sessionName) ?? mux;
+    if (p.name !== "tmux") return undefined;
+
+    const patterns = AGENT_TITLE_PATTERNS[agentName];
+    if (!patterns) return undefined;
+
+    const raw = shell([
+      "tmux",
+      "list-panes",
+      "-t",
+      sessionName,
+      "-F",
+      "#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}",
+    ]);
+    if (!raw) return undefined;
+
+    const panes = raw.split("\n").map((line) => {
+      const idx1 = line.indexOf("|");
+      const idx2 = line.indexOf("|", idx1 + 1);
+      const idx3 = line.indexOf("|", idx2 + 1);
+      return {
+        id: line.slice(0, idx1),
+        pid: line.slice(idx1 + 1, idx2),
+        cmd: line.slice(idx2 + 1, idx3),
+        title: line.slice(idx3 + 1),
+      };
+    });
+
+    const sidebarPaneIds = new Set<string>();
+    for (const { panes: sbPanes } of listSidebarPanesByProvider()) {
+      for (const sb of sbPanes) sidebarPaneIds.add(sb.paneId);
+    }
+    const nonSidebar = panes.filter((p) => !sidebarPaneIds.has(p.id));
+
+    let targetPaneId: string | undefined;
+
+    if (agentName === "claude-code" && threadId) {
+      targetPaneId = resolveClaudeCodePane(nonSidebar, threadId);
+    }
+    if (!targetPaneId && agentName === "amp" && threadName) {
+      targetPaneId = nonSidebar.find(
+        (p) => p.title.toLowerCase().startsWith("amp - ") && p.title.includes(threadName),
+      )?.id;
+    }
+    if (!targetPaneId && agentName === "codex" && threadId) {
+      targetPaneId = resolveCodexPane(nonSidebar, threadId);
+    }
+    if (!targetPaneId && agentName === "opencode" && threadId) {
+      targetPaneId = resolveOpenCodePane(nonSidebar, threadId);
+    }
+    if (!targetPaneId) {
+      targetPaneId = nonSidebar.find((p) =>
+        patterns.some((pat) => p.title.toLowerCase().includes(pat)),
+      )?.id;
+    }
+    if (!targetPaneId) {
+      for (const pane of nonSidebar) {
+        if (matchProcessTree(pane.pid, patterns)) {
+          targetPaneId = pane.id;
+          break;
+        }
+      }
+    }
+    return targetPaneId;
+  }
+
+  function focusAgentPane(
+    sessionName: string,
+    agentName: string,
+    threadId?: string,
+    threadName?: string,
+  ): void {
+    log("focus-agent-pane", "received", { sessionName, agentName, threadId, threadName });
+    const targetPaneId = resolveAgentPaneId(sessionName, agentName, threadId, threadName);
+    if (!targetPaneId) return;
+
+    log("focus-agent-pane", "focusing", { sessionName, agentName, paneId: targetPaneId });
+    shell(["tmux", "select-pane", "-t", targetPaneId]);
+
+    const existing = pendingHighlightResets.get(targetPaneId);
+    if (existing) clearTimeout(existing);
+
+    shell([
+      "tmux",
+      "set-option",
+      "-p",
+      "-t",
+      targetPaneId,
+      "pane-active-border-style",
+      PANE_HIGHLIGHT_BORDER,
+    ]);
+    shell(["tmux", "select-pane", "-t", targetPaneId, "-P", "bg=#2a2a4a"]);
+    pendingHighlightResets.set(
+      targetPaneId,
+      setTimeout(() => {
+        shell(["tmux", "set-option", "-p", "-t", targetPaneId, "-u", "pane-active-border-style"]);
+        shell(["tmux", "select-pane", "-t", targetPaneId, "-P", ""]);
+        pendingHighlightResets.delete(targetPaneId);
+      }, PANE_HIGHLIGHT_MS),
+    );
+  }
+
+  function killAgentPane(
+    sessionName: string,
+    agentName: string,
+    threadId?: string,
+    threadName?: string,
+  ): void {
+    log("kill-agent-pane", "received", { sessionName, agentName, threadId, threadName });
+    const targetPaneId = resolveAgentPaneId(sessionName, agentName, threadId, threadName);
+    if (!targetPaneId) return;
+
+    log("kill-agent-pane", "killing", { sessionName, agentName, paneId: targetPaneId });
+    shell(["tmux", "kill-pane", "-t", targetPaneId]);
+  }
+
+  // --- Pane agent scanning (detect agents running in current session panes) ---
+
+  interface PaneAgentPresence {
+    agent: string;
+    session: string;
+    paneId: string;
+    threadId?: string;
+    threadName?: string;
+    status?: import("../contracts/agent").AgentStatus;
+    lastSeenTs: number;
+  }
+
+  // Pane agent presence per session: sessionName → Map<instanceKey, PaneAgentPresence>
+  let paneAgentsBySession = new Map<string, Map<string, PaneAgentPresence>>();
+
+  /** Build parent→children map from a single ps snapshot (avoids per-pane pgrep calls). */
+  function buildProcessTree(): { childrenOf: Map<number, number[]>; commOf: Map<number, string> } {
+    const childrenOf = new Map<number, number[]>();
+    const commOf = new Map<number, string>();
+    const psResult = Bun.spawnSync(["ps", "-eo", "pid=,ppid=,comm="], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    for (const line of psResult.stdout.toString().trim().split("\n")) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 3) continue;
+      const pid = Number.parseInt(parts[0], 10);
+      const ppid = Number.parseInt(parts[1], 10);
+      const comm = parts.slice(2).join(" ").toLowerCase();
+      if (Number.isNaN(pid) || Number.isNaN(ppid)) continue;
+      commOf.set(pid, comm);
+      let arr = childrenOf.get(ppid);
+      if (!arr) {
+        arr = [];
+        childrenOf.set(ppid, arr);
+      }
+      arr.push(pid);
+    }
+    return { childrenOf, commOf };
+  }
+
+  /** Walk up to 3 levels of child processes using a pre-built process tree. */
+  function matchProcessTreeFast(
+    pid: number,
+    patterns: string[],
+    tree: ReturnType<typeof buildProcessTree>,
+    depth = 0,
+  ): boolean {
+    if (depth > 2) return false;
+    const children = tree.childrenOf.get(pid);
+    if (!children) return false;
+    for (const childPid of children) {
+      const comm = tree.commOf.get(childPid);
+      if (comm && patterns.some((pat) => comm.includes(pat))) return true;
+      if (matchProcessTreeFast(childPid, patterns, tree, depth + 1)) return true;
+    }
+    return false;
+  }
+
+  /** Find child PID matching a name pattern using pre-built process tree. */
+  function findChildPidFast(
+    pid: number,
+    name: string,
+    tree: ReturnType<typeof buildProcessTree>,
+    depth = 0,
+  ): number | undefined {
+    if (depth > 2) return undefined;
+    const children = tree.childrenOf.get(pid);
+    if (!children) return undefined;
+    for (const childPid of children) {
+      const comm = tree.commOf.get(childPid);
+      if (comm?.includes(name)) return childPid;
+      const found = findChildPidFast(childPid, name, tree, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  /** Resolve threadId/threadName for an amp pane from its title. */
+  function resolveAmpPaneInfo(title: string): { threadId?: string; threadName?: string } {
+    // Amp pane title format: "amp - <threadName> - <dir>"
+    if (!title.toLowerCase().startsWith("amp - ")) return {};
+    const rest = title.slice(6);
+    const dashIdx = rest.lastIndexOf(" - ");
+    const threadName = dashIdx > 0 ? rest.slice(0, dashIdx) : rest;
+    return { threadName: threadName || undefined };
+  }
+
+  /** Resolve threadId/threadName/status for a Claude Code pane via ~/.claude/sessions/<pid>.json + journal. */
+  function resolveClaudeCodePaneInfo(
+    panePid: number,
+    tree: ReturnType<typeof buildProcessTree>,
+  ): { threadId?: string; threadName?: string; status?: import("../contracts/agent").AgentStatus } {
+    const agentPid = findChildPidFast(panePid, "claude", tree);
+    if (!agentPid) return {};
+    const sessionsDir = join(homedir(), ".claude", "sessions");
+    try {
+      const data = JSON.parse(readFileSync(join(sessionsDir, `${agentPid}.json`), "utf-8"));
+      const threadId: string | undefined = data.sessionId;
+      if (!threadId) return {};
+      // Try to get thread name and status from the journal
+      const journalInfo = resolveClaudeCodeJournalInfo(threadId);
+      return { threadId, ...journalInfo };
+    } catch {
+      return {};
+    }
+  }
+
+  /** Read the JSONL journal to extract thread name and current status. */
+  function resolveClaudeCodeJournalInfo(threadId: string): {
+    threadName?: string;
+    status?: import("../contracts/agent").AgentStatus;
+  } {
+    const projectsDir = join(homedir(), ".claude", "projects");
+    try {
+      const dirs = require("node:fs").readdirSync(projectsDir) as string[];
+      for (const dir of dirs) {
+        const filePath = join(projectsDir, dir, `${threadId}.jsonl`);
+        try {
+          const text = readFileSync(filePath, "utf-8");
+          const lines = text.split("\n").filter(Boolean);
+          let threadName: string | undefined;
+          let lastStatus: import("../contracts/agent").AgentStatus = "idle";
+
+          for (const line of lines) {
+            try {
+              const entry = JSON.parse(line);
+              const msg = entry.message;
+              if (!msg?.role) continue;
+
+              // Extract thread name from first user message
+              if (!threadName && msg.role === "user") {
+                const content = msg.content;
+                let t: string | undefined;
+                if (typeof content === "string") t = content;
+                else if (Array.isArray(content))
+                  t = content.find((c: any) => c.type === "text" && c.text)?.text;
+                if (t && !t.startsWith("<") && !t.startsWith("{")) threadName = t.slice(0, 80);
+              }
+
+              // Determine status from last entry (same logic as ClaudeCodeAgentWatcher)
+              if (msg.role === "assistant") {
+                const items = Array.isArray(msg.content) ? msg.content : [];
+                lastStatus = items.some((c: any) => c.type === "tool_use") ? "running" : "done";
+              } else if (msg.role === "user") {
+                lastStatus = "running";
+              }
+            } catch {
+              continue;
+            }
+          }
+
+          return { threadName, status: lastStatus };
+        } catch {
+          continue;
+        }
+      }
+    } catch {}
+    return {};
+  }
+
+  /** Resolve threadId for a Codex pane via logs_1.sqlite. */
+  function resolveCodexPaneInfo(
+    panePid: number,
+    tree: ReturnType<typeof buildProcessTree>,
+  ): { threadId?: string; threadName?: string } {
+    const agentPid = findChildPidFast(panePid, "codex", tree);
+    if (!agentPid) return {};
+    const dbPath = join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "logs_1.sqlite");
+    let db: any;
+    try {
+      const { Database } = require("bun:sqlite");
+      db = new Database(dbPath, { readonly: true });
+    } catch {
+      return {};
+    }
+    try {
+      const row = db
+        .query(
+          `SELECT thread_id FROM logs WHERE process_uuid LIKE ? AND thread_id IS NOT NULL ORDER BY ts DESC LIMIT 1`,
+        )
+        .get(`pid:${agentPid}:%`);
+      if (row?.thread_id) return { threadId: row.thread_id };
+    } catch {
+    } finally {
+      try {
+        db.close();
+      } catch {}
+    }
+    return {};
+  }
+
+  /** Scan all panes across all tmux sessions and identify running agents.
+   *  Uses a single `tmux list-panes -a` call for efficiency. */
+  function scanAllTmuxPaneAgents(): Map<string, Map<string, PaneAgentPresence>> {
+    const result = new Map<string, Map<string, PaneAgentPresence>>();
+
+    const raw = shell([
+      "tmux",
+      "list-panes",
+      "-a",
+      "-F",
+      "#{session_name}|#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}",
+    ]);
+    if (!raw) return result;
+
+    const panes = raw
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const idx1 = line.indexOf("|");
+        const idx2 = line.indexOf("|", idx1 + 1);
+        const idx3 = line.indexOf("|", idx2 + 1);
+        const idx4 = line.indexOf("|", idx3 + 1);
+        return {
+          session: line.slice(0, idx1),
+          id: line.slice(idx1 + 1, idx2),
+          pid: Number.parseInt(line.slice(idx2 + 1, idx3), 10),
+          cmd: line.slice(idx3 + 1, idx4),
+          title: line.slice(idx4 + 1),
+        };
+      });
+
+    // Exclude sidebar panes
+    const sidebarPaneIds = new Set<string>();
+    for (const { panes: sbPanes } of listSidebarPanesByProvider()) {
+      for (const sb of sbPanes) sidebarPaneIds.add(sb.paneId);
+    }
+
+    const nonSidebar = panes.filter((p) => !sidebarPaneIds.has(p.id));
+    if (nonSidebar.length === 0) return result;
+
+    // Build process tree once for all panes
+    const tree = buildProcessTree();
+    const now = Date.now();
+
+    for (const pane of nonSidebar) {
+      for (const [agentName, patterns] of Object.entries(AGENT_TITLE_PATTERNS)) {
+        // Only use process tree matching — title matching produces false positives
+        // (e.g. an Amp thread named "Detect Claude session names" matches "claude")
+        if (!matchProcessTreeFast(pane.pid, patterns, tree)) continue;
+
+        let threadId: string | undefined;
+        let threadName: string | undefined;
+        let status: import("../contracts/agent").AgentStatus | undefined;
+
+        // Resolve thread info per agent type
+        if (agentName === "amp") {
+          const info = resolveAmpPaneInfo(pane.title);
+          threadName = info.threadName;
+        } else if (agentName === "claude-code") {
+          const info = resolveClaudeCodePaneInfo(pane.pid, tree);
+          threadId = info.threadId;
+          threadName = info.threadName;
+          status = info.status;
+        } else if (agentName === "codex") {
+          const info = resolveCodexPaneInfo(pane.pid, tree);
+          threadId = info.threadId;
+        }
+
+        const key = `${agentName}:pane:${pane.id}`;
+        let sessionAgents = result.get(pane.session);
+        if (!sessionAgents) {
+          sessionAgents = new Map();
+          result.set(pane.session, sessionAgents);
+        }
+        sessionAgents.set(key, {
+          agent: agentName,
+          session: pane.session,
+          paneId: pane.id,
+          threadId,
+          threadName,
+          status,
+          lastSeenTs: now,
+        });
+      }
+    }
+
+    return result;
+  }
+
+  /** Refresh pane agent cache for all tmux sessions. */
+  function refreshPaneAgents(): void {
+    // Check if any provider is tmux
+    const hasTmux = allProviders.some((p) => p.name === "tmux");
+    if (!hasTmux) {
+      if (paneAgentsBySession.size > 0) {
+        paneAgentsBySession.clear();
+        tracker.setPinnedInstancesMulti(new Map());
+        broadcastState();
+      }
+      return;
+    }
+
+    const nextBySession = scanAllTmuxPaneAgents();
+    const allPinnedKeys = new Map<string, string[]>();
+    for (const [session, agents] of nextBySession) {
+      allPinnedKeys.set(session, [...agents.keys()]);
+    }
+
+    // Check if anything changed
+    let changed = paneAgentsBySession.size !== nextBySession.size;
+    if (!changed) {
+      for (const [session, agents] of nextBySession) {
+        const prev = paneAgentsBySession.get(session);
+        if (!prev || prev.size !== agents.size) {
+          changed = true;
+          break;
+        }
+        for (const key of agents.keys()) {
+          if (!prev.has(key)) {
+            changed = true;
+            break;
+          }
+        }
+        if (changed) break;
+      }
+    }
+
+    paneAgentsBySession = nextBySession;
+
+    // Update tracker pinning for all sessions
+    tracker.setPinnedInstancesMulti(allPinnedKeys);
+
+    if (changed) broadcastState();
+  }
+
+  // --- Pane agent polling (detect agents in current session every 3s) ---
+
+  const PANE_SCAN_INTERVAL_MS = 3_000;
+  let paneScanTimer: ReturnType<typeof setInterval> | null = null;
+
+  function startPaneScan() {
+    paneScanTimer = setInterval(() => {
+      if (clientCount === 0) return;
+      refreshPaneAgents();
+    }, PANE_SCAN_INTERVAL_MS);
+  }
+
+  function handleCommand(cmd: ClientCommand, ws: any) {
+    switch (cmd.type) {
+      case "identify":
+        clientTtys.set(ws, cmd.clientTty);
+        break;
+      case "switch-session": {
+        // Resolve TTY: hook-derived (authoritative) > client-provided > stored
+        const clientSess = clientSessionNames.get(ws);
+        const tty =
+          (clientSess ? clientTtyBySession.get(clientSess) : undefined) ??
+          cmd.clientTty ??
+          clientTtys.get(ws);
+        log("switch-session", "switching", { target: cmd.name, tty, clientSess });
+        const p = sessionProviders.get(cmd.name) ?? mux;
+
+        p.switchSession(cmd.name, tty);
+
+        // Optimistic server-side focus update — so other TUI instances see the
+        // change immediately via broadcastFocusOnly, without waiting for the
+        // tmux hook round-trip. The hook's /focus POST will reconcile if needed.
+        focusedSession = cmd.name;
+        cachedCurrentSession = cmd.name;
+        cachedCurrentSessionTs = Date.now();
+        const hadUnseen = tracker.handleFocus(cmd.name);
+        if (hadUnseen) {
+          broadcastState();
+        } else {
+          broadcastFocusOnly();
+        }
+
+        break;
+      }
+      case "switch-index": {
+        const clientSess = clientSessionNames.get(ws);
+        const tty =
+          (clientSess ? clientTtyBySession.get(clientSess) : undefined) ?? clientTtys.get(ws);
+        switchToVisibleIndex(cmd.index, tty);
+        break;
+      }
+      case "new-session":
+        mux.createSession();
+        broadcastState();
+        break;
+      case "hide-session":
+        sessionOrder.hide(cmd.name);
+        broadcastState();
+        break;
+      case "show-all-sessions":
+        sessionOrder.showAll();
+        broadcastState();
+        break;
+      case "kill-session": {
+        const p = sessionProviders.get(cmd.name) ?? mux;
+        p.killSession(cmd.name);
+        broadcastState();
+        break;
+      }
+      case "reorder-session":
+        sessionOrder.reorder(cmd.name, cmd.delta);
+        broadcastState();
+        break;
+      case "refresh":
+        broadcastState();
+        break;
+      case "move-focus":
+        moveFocus(cmd.delta, ws);
+        break;
+      case "focus-session":
+        setFocus(cmd.name, ws);
+        break;
+      case "mark-seen":
+        if (tracker.markSeen(cmd.name)) broadcastState();
+        break;
+      case "dismiss-agent":
+        if (tracker.dismiss(cmd.session, cmd.agent, cmd.threadId)) broadcastState();
+        break;
+      case "set-theme":
+        currentTheme = cmd.theme;
+        saveConfig({ theme: cmd.theme });
+        broadcastState();
+        break;
+      case "report-width":
+        // No-op: sidebar width is config-only, not auto-saved from drag
+        break;
+      case "quit":
+        quitAll();
+        break;
+      case "identify-pane":
+        // Store this client's session, reply with session + authoritative client TTY
+        clientSessionNames.set(ws, cmd.sessionName);
+        ws.send(
+          JSON.stringify({
+            type: "your-session",
+            name: cmd.sessionName,
+            clientTty: clientTtyBySession.get(cmd.sessionName) ?? null,
+          }),
+        );
+        break;
+      case "focus-agent-pane":
+        log("handleCommand", "focus-agent-pane received", {
+          session: cmd.session,
+          agent: cmd.agent,
+          threadId: cmd.threadId,
+          threadName: cmd.threadName,
+        });
+        focusAgentPane(cmd.session, cmd.agent, cmd.threadId, cmd.threadName);
+        break;
+      case "kill-agent-pane":
+        log("handleCommand", "kill-agent-pane received", {
+          session: cmd.session,
+          agent: cmd.agent,
+          threadId: cmd.threadId,
+          threadName: cmd.threadName,
+        });
+        killAgentPane(cmd.session, cmd.agent, cmd.threadId, cmd.threadName);
+        break;
+    }
+  }
+
+  // --- Port polling (detect new/stopped listeners every 10s) ---
+
+  const PORT_POLL_INTERVAL_MS = 10_000;
+  let portPollTimer: ReturnType<typeof setInterval> | null = null;
+
+  function startPortPoll() {
+    // Run initial snapshot immediately so first broadcast has ports
+    if (lastState) {
+      refreshPortSnapshot(lastState.sessions.map((s) => s.name));
+    }
+    portPollTimer = setInterval(() => {
+      if (!lastState || clientCount === 0) return;
+      const changed = refreshPortSnapshot(lastState.sessions.map((s) => s.name));
+      if (changed) broadcastState();
+    }, PORT_POLL_INTERVAL_MS);
+  }
+
+  function cleanup() {
+    for (const w of allWatchers) w.stop();
+    if (watcherBroadcastTimer) clearTimeout(watcherBroadcastTimer);
+    teardownGitWatchers();
+    if (portPollTimer) clearInterval(portPollTimer);
+    if (paneScanTimer) clearInterval(paneScanTimer);
+    if (pendingSidebarResize) clearTimeout(pendingSidebarResize);
+    for (const timer of pendingHighlightResets.values()) clearTimeout(timer);
+    pendingHighlightResets.clear();
+    if (idleTimer) clearTimeout(idleTimer);
+    try {
+      unlinkSync(PID_FILE);
+    } catch {}
+    for (const p of allProviders) p.cleanupHooks();
+  }
+
+  // --- Write PID + start server ---
+
+  writeFileSync(PID_FILE, String(process.pid));
+
+  const server = Bun.serve({
+    port: SERVER_PORT,
+    hostname: SERVER_HOST,
+    async fetch(req, server) {
+      const url = new URL(req.url);
+
+      // Any HTTP request proves tmux hooks are still active — reset idle timer
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
+      }
+
+      if (req.method === "POST" && url.pathname === "/refresh") {
+        broadcastState();
+        return new Response("ok", { status: 200 });
+      }
+
+      if (req.method === "POST" && url.pathname === "/resize-sidebars") {
+        const body = await req.text();
+        const ctx = parseResizeContext(body) ?? undefined;
+        log("http", "POST /resize-sidebars", { sidebarWidth, ctx });
+        scheduleSidebarResize(ctx);
+        return new Response("ok", { status: 200 });
+      }
+
+      if (req.method === "POST" && url.pathname === "/focus") {
+        try {
+          const body = await req.text();
+          const ctx = parseContext(body);
+          if (ctx) {
+            handleFocus(ctx.session);
+          } else {
+            // Legacy: body is just the session name
+            const name = body.trim().replace(/^"+|"+$/g, "");
+            if (name) handleFocus(name);
+          }
+        } catch {}
+        return new Response("ok", { status: 200 });
+      }
+
+      if (req.method === "POST" && url.pathname === "/toggle") {
+        try {
+          const body = await req.text();
+          const ctx = parseContext(body) ?? undefined;
+          log("http", "POST /toggle", { ctx });
+          toggleSidebar(ctx);
+          broadcastState();
+        } catch {}
+        return new Response("ok", { status: 200 });
+      }
+
+      if (req.method === "POST" && url.pathname === "/quit") {
+        log("http", "POST /quit");
+        quitAll();
+        return new Response("ok", { status: 200 });
+      }
+
+      if (req.method === "POST" && url.pathname === "/switch-index") {
+        try {
+          const index = Number.parseInt(url.searchParams.get("index") ?? "", 10);
+          if (Number.isNaN(index)) {
+            return new Response("missing index", { status: 400 });
+          }
+          const body = await req.text();
+          const ctx = parseContext(body) ?? undefined;
+          log("http", "POST /switch-index", { index, ctx });
+          switchToVisibleIndex(index, ctx?.clientTty);
+        } catch {}
+        return new Response("ok", { status: 200 });
+      }
+
+      if (req.method === "POST" && url.pathname === "/ensure-sidebar") {
+        try {
+          const body = await req.text();
+          const ctx = parseContext(body) ?? undefined;
+          log("http", "POST /ensure-sidebar", { sidebarVisible, ctx });
+          // Debounce ensure-sidebar during rapid switching — intermediate sessions
+          // don't need full sidebar validation immediately.
+          debouncedEnsureSidebar(ctx ?? undefined);
+        } catch {}
+        return new Response("ok", { status: 200 });
+      }
+
+      if (req.method === "POST" && url.pathname === "/set-status") {
+        try {
+          const body = (await req.json()) as {
+            session?: string;
+            text?: string | null;
+            tone?: string;
+          };
+          if (!body.session || typeof body.session !== "string") {
+            return new Response("missing session", { status: 400 });
+          }
+          if (body.text === null || body.text === undefined) {
+            metadataStore.setStatus(body.session, null);
+          } else if (typeof body.text !== "string") {
+            return new Response("text must be a string or null", { status: 400 });
+          } else {
+            metadataStore.setStatus(body.session, { text: body.text, tone: parseTone(body.tone) });
+          }
+          broadcastState();
+          return new Response(null, { status: 204 });
+        } catch {
+          return new Response("invalid json", { status: 400 });
+        }
+      }
+
+      if (req.method === "POST" && url.pathname === "/set-progress") {
+        try {
+          const body = (await req.json()) as {
+            session?: string;
+            current?: number;
+            total?: number;
+            percent?: number;
+            label?: string;
+            clear?: boolean;
+          };
+          if (!body.session || typeof body.session !== "string") {
+            return new Response("missing session", { status: 400 });
+          }
+          if (body.clear) {
+            metadataStore.setProgress(body.session, null);
+          } else {
+            metadataStore.setProgress(body.session, {
+              current: body.current,
+              total: body.total,
+              percent: body.percent,
+              label: body.label,
+            });
+          }
+          broadcastState();
+          return new Response(null, { status: 204 });
+        } catch {
+          return new Response("invalid json", { status: 400 });
+        }
+      }
+
+      if (req.method === "POST" && url.pathname === "/log") {
+        try {
+          const body = (await req.json()) as {
+            session?: string;
+            message?: string;
+            tone?: string;
+            source?: string;
+          };
+          if (!body.session || typeof body.session !== "string") {
+            return new Response("missing session", { status: 400 });
+          }
+          if (!body.message || typeof body.message !== "string") {
+            return new Response("missing message", { status: 400 });
+          }
+          metadataStore.appendLog(body.session, {
+            message: body.message,
+            tone: parseTone(body.tone),
+            source: body.source,
+          });
+          broadcastState();
+          return new Response(null, { status: 204 });
+        } catch {
+          return new Response("invalid json", { status: 400 });
+        }
+      }
+
+      if (req.method === "POST" && url.pathname === "/clear-log") {
+        try {
+          const body = (await req.json()) as { session?: string };
+          if (!body.session || typeof body.session !== "string") {
+            return new Response("missing session", { status: 400 });
+          }
+          metadataStore.clearLogs(body.session);
+          broadcastState();
+          return new Response(null, { status: 204 });
+        } catch {
+          return new Response("invalid json", { status: 400 });
+        }
+      }
+
+      if (server.upgrade(req, { data: {} })) return;
+      return new Response("agentboard2 server", { status: 200 });
+    },
+    websocket: {
+      open(ws) {
+        ws.subscribe("sidebar");
+        clientCount++;
+        log("ws", "client connected", { clientCount });
+        if (idleTimer) {
+          clearTimeout(idleTimer);
+          idleTimer = null;
+        }
+        if (lastState) {
+          ws.send(JSON.stringify(lastState));
+        } else {
+          broadcastState();
+        }
+      },
+      close(ws) {
+        ws.unsubscribe("sidebar");
+        clientCount--;
+        if (clientCount < 0) clientCount = 0;
+        log("ws", "client disconnected", { clientCount });
+        if (clientCount === 0 && !idleTimer) {
+          log("ws", "no clients remaining, starting idle timer", {
+            timeoutMs: SERVER_IDLE_TIMEOUT_MS,
+          });
+          idleTimer = setTimeout(() => {
+            log("ws", "idle timeout reached, shutting down");
+            quitAll();
+          }, SERVER_IDLE_TIMEOUT_MS);
+        }
+      },
+      message(ws, msg) {
+        try {
+          const cmd = JSON.parse(msg as string) as ClientCommand;
+          log("ws", "command", { type: cmd.type });
+          handleCommand(cmd, ws);
+        } catch {}
+      },
+    },
+  });
+
+  // --- Bootstrap ---
+
+  for (const p of allProviders) p.setupHooks(SERVER_HOST, SERVER_PORT);
+  // Seed port snapshot before first broadcast so clients see ports immediately
+  {
+    const allMuxSessions: string[] = [];
+    for (const p of allProviders) {
+      for (const s of p.listSessions()) allMuxSessions.push(s.name);
+    }
+    refreshPortSnapshot(allMuxSessions);
+  }
+  broadcastState();
+  startPortPoll();
+  startPaneScan();
+  // Run initial pane scan
+  refreshPaneAgents();
+
+  // Start agent watchers after server is ready
+  for (const w of allWatchers) {
+    w.start(watcherCtx);
+    log("server", `agent watcher started: ${w.name}`);
+  }
+
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
+
+  const names = allProviders.map((p) => p.name).join(", ");
+  console.log(`agentboard2 server listening on ${SERVER_HOST}:${SERVER_PORT} (mux: ${names})`);
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/launcher.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/launcher.ts
@@ -1,0 +1,71 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { connect } from "node:net";
+import { SERVER_PORT, SERVER_HOST, PID_FILE } from "../shared";
+import { SERVER_ERR_LOG } from "../debug";
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isPortOpen(host: string, port: number, timeoutMs = 200): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ host, port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.on("connect", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on("error", () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+function resolveAgentboard2Dir(): string {
+  if (process.env.AGENTBOARD2_DIR) return process.env.AGENTBOARD2_DIR;
+  // Walk up from packages/runtime/src/server/ to the plugin root
+  return new URL("../../../..", import.meta.url).pathname;
+}
+
+function resolveServerEntryPath(pluginDir: string): string {
+  return join(pluginDir, "apps", "server", "src", "main.ts");
+}
+
+export async function ensureServer(): Promise<void> {
+  if (existsSync(PID_FILE)) {
+    const pid = Number.parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
+    if (!Number.isNaN(pid) && isProcessAlive(pid) && (await isPortOpen(SERVER_HOST, SERVER_PORT))) {
+      return;
+    }
+  }
+
+  const pluginDir = resolveAgentboard2Dir();
+  const serverPath = resolveServerEntryPath(pluginDir);
+
+  const proc = Bun.spawn([process.execPath, "run", serverPath], {
+    stdio: ["ignore", "ignore", Bun.file(SERVER_ERR_LOG)],
+    cwd: pluginDir,
+    env: { ...process.env, AGENTBOARD2_DIR: pluginDir },
+  });
+  proc.unref();
+
+  for (let i = 0; i < 60; i++) {
+    await Bun.sleep(50);
+    if (await isPortOpen(SERVER_HOST, SERVER_PORT, 100)) return;
+  }
+
+  const errLog = existsSync(SERVER_ERR_LOG) ? readFileSync(SERVER_ERR_LOG, "utf-8").trim() : "";
+  const detail = errLog || `No error output. Check ${SERVER_ERR_LOG}`;
+  throw new Error(`AgentBoard server failed to start:\n${detail}`);
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/metadata-store.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/metadata-store.ts
@@ -1,0 +1,86 @@
+import type { MetadataTone, SessionMetadata } from "../shared";
+
+const MAX_LOGS = 50;
+const MAX_MESSAGE_LENGTH = 500;
+
+function truncate(s: string, max: number = MAX_MESSAGE_LENGTH): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+export class SessionMetadataStore {
+  private store = new Map<string, SessionMetadata>();
+
+  private getOrCreate(session: string): SessionMetadata {
+    let meta = this.store.get(session);
+    if (!meta) {
+      meta = { status: null, progress: null, logs: [] };
+      this.store.set(session, meta);
+    }
+    return meta;
+  }
+
+  get(session: string): SessionMetadata | null {
+    const meta = this.store.get(session);
+    if (!meta) return null;
+    // Return null if everything is empty
+    if (!meta.status && !meta.progress && meta.logs.length === 0) return null;
+    return meta;
+  }
+
+  setStatus(session: string, status: { text: string; tone?: MetadataTone } | null): void {
+    if (!status) {
+      const meta = this.store.get(session);
+      if (meta) meta.status = null;
+      return;
+    }
+    const meta = this.getOrCreate(session);
+    meta.status = { text: truncate(status.text, 100), tone: status.tone, ts: Date.now() };
+  }
+
+  setProgress(
+    session: string,
+    progress: { current?: number; total?: number; percent?: number; label?: string } | null,
+  ): void {
+    if (!progress) {
+      const meta = this.store.get(session);
+      if (meta) meta.progress = null;
+      return;
+    }
+    const meta = this.getOrCreate(session);
+    meta.progress = {
+      current: progress.current,
+      total: progress.total,
+      percent: progress.percent,
+      label: progress.label ? truncate(progress.label, 100) : undefined,
+      ts: Date.now(),
+    };
+  }
+
+  appendLog(
+    session: string,
+    entry: { message: string; tone?: MetadataTone; source?: string },
+  ): void {
+    const meta = this.getOrCreate(session);
+    meta.logs.push({
+      message: truncate(entry.message),
+      tone: entry.tone,
+      source: entry.source ? truncate(entry.source, 50) : undefined,
+      ts: Date.now(),
+    });
+    if (meta.logs.length > MAX_LOGS) {
+      meta.logs = meta.logs.slice(meta.logs.length - MAX_LOGS);
+    }
+  }
+
+  clearLogs(session: string): void {
+    const meta = this.store.get(session);
+    if (meta) meta.logs = [];
+  }
+
+  /** Remove metadata for sessions that no longer exist */
+  pruneSessions(validNames: Set<string>): void {
+    for (const name of this.store.keys()) {
+      if (!validNames.has(name)) this.store.delete(name);
+    }
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/pane-scanner.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/pane-scanner.ts
@@ -1,0 +1,327 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { AgentStatus } from "../contracts/agent";
+import type { SidebarPane } from "../contracts/mux";
+import type { ServerContext, PaneAgentPresence } from "./context";
+import { shell } from "./git-info";
+
+const AGENT_TITLE_PATTERNS: Record<string, string[]> = {
+  amp: ["amp"],
+  "claude-code": ["claude"],
+  codex: ["codex"],
+  opencode: ["opencode"],
+};
+
+/** Build parent->children map from a single ps snapshot (avoids per-pane pgrep calls). */
+function buildProcessTree(): { childrenOf: Map<number, number[]>; commOf: Map<number, string> } {
+  const childrenOf = new Map<number, number[]>();
+  const commOf = new Map<number, string>();
+  const psResult = Bun.spawnSync(["ps", "-eo", "pid=,ppid=,comm="], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  for (const line of psResult.stdout.toString().trim().split("\n")) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 3) continue;
+    const pid = Number.parseInt(parts[0], 10);
+    const ppid = Number.parseInt(parts[1], 10);
+    const comm = parts.slice(2).join(" ").toLowerCase();
+    if (Number.isNaN(pid) || Number.isNaN(ppid)) continue;
+    commOf.set(pid, comm);
+    let arr = childrenOf.get(ppid);
+    if (!arr) {
+      arr = [];
+      childrenOf.set(ppid, arr);
+    }
+    arr.push(pid);
+  }
+  return { childrenOf, commOf };
+}
+
+/** Walk up to 3 levels of child processes using a pre-built process tree. */
+function matchProcessTreeFast(
+  pid: number,
+  patterns: string[],
+  tree: ReturnType<typeof buildProcessTree>,
+  depth = 0,
+): boolean {
+  if (depth > 2) return false;
+  const children = tree.childrenOf.get(pid);
+  if (!children) return false;
+  for (const childPid of children) {
+    const comm = tree.commOf.get(childPid);
+    if (comm && patterns.some((pat) => comm.includes(pat))) return true;
+    if (matchProcessTreeFast(childPid, patterns, tree, depth + 1)) return true;
+  }
+  return false;
+}
+
+/** Find child PID matching a name pattern using pre-built process tree. */
+function findChildPidFast(
+  pid: number,
+  name: string,
+  tree: ReturnType<typeof buildProcessTree>,
+  depth = 0,
+): number | undefined {
+  if (depth > 2) return undefined;
+  const children = tree.childrenOf.get(pid);
+  if (!children) return undefined;
+  for (const childPid of children) {
+    const comm = tree.commOf.get(childPid);
+    if (comm?.includes(name)) return childPid;
+    const found = findChildPidFast(childPid, name, tree, depth + 1);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** Resolve threadId/threadName for an amp pane from its title. */
+function resolveAmpPaneInfo(title: string): { threadId?: string; threadName?: string } {
+  if (!title.toLowerCase().startsWith("amp - ")) return {};
+  const rest = title.slice(6);
+  const dashIdx = rest.lastIndexOf(" - ");
+  const threadName = dashIdx > 0 ? rest.slice(0, dashIdx) : rest;
+  return { threadName: threadName || undefined };
+}
+
+/** Resolve threadId/threadName/status for a Claude Code pane via ~/.claude/sessions/<pid>.json + journal. */
+function resolveClaudeCodePaneInfo(
+  panePid: number,
+  tree: ReturnType<typeof buildProcessTree>,
+): { threadId?: string; threadName?: string; status?: AgentStatus } {
+  const agentPid = findChildPidFast(panePid, "claude", tree);
+  if (!agentPid) return {};
+  const sessionsDir = join(homedir(), ".claude", "sessions");
+  try {
+    const data = JSON.parse(readFileSync(join(sessionsDir, `${agentPid}.json`), "utf-8"));
+    const threadId: string | undefined = data.sessionId;
+    if (!threadId) return {};
+    const journalInfo = resolveClaudeCodeJournalInfo(threadId);
+    return { threadId, ...journalInfo };
+  } catch {
+    return {};
+  }
+}
+
+/** Read the JSONL journal to extract thread name and current status. */
+function resolveClaudeCodeJournalInfo(threadId: string): {
+  threadName?: string;
+  status?: AgentStatus;
+} {
+  const projectsDir = join(homedir(), ".claude", "projects");
+  try {
+    const dirs = require("node:fs").readdirSync(projectsDir) as string[];
+    for (const dir of dirs) {
+      const filePath = join(projectsDir, dir, `${threadId}.jsonl`);
+      try {
+        const text = readFileSync(filePath, "utf-8");
+        const lines = text.split("\n").filter(Boolean);
+        let threadName: string | undefined;
+        let lastStatus: AgentStatus = "idle";
+
+        for (const line of lines) {
+          try {
+            const entry = JSON.parse(line);
+            const msg = entry.message;
+            if (!msg?.role) continue;
+
+            if (!threadName && msg.role === "user") {
+              const content = msg.content;
+              let t: string | undefined;
+              if (typeof content === "string") t = content;
+              else if (Array.isArray(content))
+                t = content.find((c: any) => c.type === "text" && c.text)?.text;
+              if (t && !t.startsWith("<") && !t.startsWith("{")) threadName = t.slice(0, 80);
+            }
+
+            if (msg.role === "assistant") {
+              const items = Array.isArray(msg.content) ? msg.content : [];
+              lastStatus = items.some((c: any) => c.type === "tool_use") ? "running" : "done";
+            } else if (msg.role === "user") {
+              lastStatus = "running";
+            }
+          } catch {
+            continue;
+          }
+        }
+
+        return { threadName, status: lastStatus };
+      } catch {
+        continue;
+      }
+    }
+  } catch {}
+  return {};
+}
+
+/** Resolve threadId for a Codex pane via logs_1.sqlite. */
+function resolveCodexPaneInfo(
+  panePid: number,
+  tree: ReturnType<typeof buildProcessTree>,
+): { threadId?: string; threadName?: string } {
+  const agentPid = findChildPidFast(panePid, "codex", tree);
+  if (!agentPid) return {};
+  const dbPath = join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "logs_1.sqlite");
+  let db: any;
+  try {
+    const { Database } = require("bun:sqlite");
+    db = new Database(dbPath, { readonly: true });
+  } catch {
+    return {};
+  }
+  try {
+    const row = db
+      .query(
+        `SELECT thread_id FROM logs WHERE process_uuid LIKE ? AND thread_id IS NOT NULL ORDER BY ts DESC LIMIT 1`,
+      )
+      .get(`pid:${agentPid}:%`);
+    if (row?.thread_id) return { threadId: row.thread_id };
+  } catch {
+  } finally {
+    try {
+      db.close();
+    } catch {}
+  }
+  return {};
+}
+
+/** Scan all panes across all tmux sessions and identify running agents.
+ *  Uses a single `tmux list-panes -a` call for efficiency. */
+function scanAllTmuxPaneAgents(
+  listSidebarPanesByProvider: () => { panes: SidebarPane[] }[],
+): Map<string, Map<string, PaneAgentPresence>> {
+  const result = new Map<string, Map<string, PaneAgentPresence>>();
+
+  const raw = shell([
+    "tmux",
+    "list-panes",
+    "-a",
+    "-F",
+    "#{session_name}|#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}",
+  ]);
+  if (!raw) return result;
+
+  const panes = raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const idx1 = line.indexOf("|");
+      const idx2 = line.indexOf("|", idx1 + 1);
+      const idx3 = line.indexOf("|", idx2 + 1);
+      const idx4 = line.indexOf("|", idx3 + 1);
+      return {
+        session: line.slice(0, idx1),
+        id: line.slice(idx1 + 1, idx2),
+        pid: Number.parseInt(line.slice(idx2 + 1, idx3), 10),
+        cmd: line.slice(idx3 + 1, idx4),
+        title: line.slice(idx4 + 1),
+      };
+    });
+
+  // Exclude sidebar panes
+  const sidebarPaneIds = new Set<string>();
+  for (const { panes: sbPanes } of listSidebarPanesByProvider()) {
+    for (const sb of sbPanes) sidebarPaneIds.add(sb.paneId);
+  }
+
+  const nonSidebar = panes.filter((p) => !sidebarPaneIds.has(p.id));
+  if (nonSidebar.length === 0) return result;
+
+  // Build process tree once for all panes
+  const tree = buildProcessTree();
+  const now = Date.now();
+
+  for (const pane of nonSidebar) {
+    for (const [agentName, patterns] of Object.entries(AGENT_TITLE_PATTERNS)) {
+      if (!matchProcessTreeFast(pane.pid, patterns, tree)) continue;
+
+      let threadId: string | undefined;
+      let threadName: string | undefined;
+      let status: AgentStatus | undefined;
+
+      if (agentName === "amp") {
+        const info = resolveAmpPaneInfo(pane.title);
+        threadName = info.threadName;
+      } else if (agentName === "claude-code") {
+        const info = resolveClaudeCodePaneInfo(pane.pid, tree);
+        threadId = info.threadId;
+        threadName = info.threadName;
+        status = info.status;
+      } else if (agentName === "codex") {
+        const info = resolveCodexPaneInfo(pane.pid, tree);
+        threadId = info.threadId;
+      }
+
+      const key = `${agentName}:pane:${pane.id}`;
+      let sessionAgents = result.get(pane.session);
+      if (!sessionAgents) {
+        sessionAgents = new Map();
+        result.set(pane.session, sessionAgents);
+      }
+      sessionAgents.set(key, {
+        agent: agentName,
+        session: pane.session,
+        paneId: pane.id,
+        threadId,
+        threadName,
+        status,
+        lastSeenTs: now,
+      });
+    }
+  }
+
+  return result;
+}
+
+/** Refresh pane agent cache for all tmux sessions. */
+export function refreshPaneAgents(ctx: ServerContext): void {
+  const hasTmux = ctx.allProviders.some((p) => p.name === "tmux");
+  if (!hasTmux) {
+    if (ctx.paneAgentsBySession.size > 0) {
+      ctx.paneAgentsBySession.clear();
+      ctx.tracker.setPinnedInstancesMulti(new Map());
+      ctx.broadcastState();
+    }
+    return;
+  }
+
+  const nextBySession = scanAllTmuxPaneAgents(ctx.listSidebarPanesByProvider);
+  const allPinnedKeys = new Map<string, string[]>();
+  for (const [session, agents] of nextBySession) {
+    allPinnedKeys.set(session, [...agents.keys()]);
+  }
+
+  // Check if anything changed
+  let changed = ctx.paneAgentsBySession.size !== nextBySession.size;
+  if (!changed) {
+    for (const [session, agents] of nextBySession) {
+      const prev = ctx.paneAgentsBySession.get(session);
+      if (!prev || prev.size !== agents.size) {
+        changed = true;
+        break;
+      }
+      for (const key of agents.keys()) {
+        if (!prev.has(key)) {
+          changed = true;
+          break;
+        }
+      }
+      if (changed) break;
+    }
+  }
+
+  ctx.paneAgentsBySession = nextBySession;
+  ctx.tracker.setPinnedInstancesMulti(allPinnedKeys);
+
+  if (changed) ctx.broadcastState();
+}
+
+const PANE_SCAN_INTERVAL_MS = 3_000;
+
+export function startPaneScan(ctx: ServerContext): ReturnType<typeof setInterval> {
+  return setInterval(() => {
+    if (ctx.clientCount === 0) return;
+    refreshPaneAgents(ctx);
+  }, PANE_SCAN_INTERVAL_MS);
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/port-scanner.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/port-scanner.ts
@@ -1,0 +1,155 @@
+import { debugLog } from "../debug";
+
+// Global port snapshot — refreshed by the port poll timer, read by computeState.
+// Runs lsof + ps once for ALL sessions instead of per-session.
+let portSnapshot = new Map<string, number[]>();
+
+export function refreshPortSnapshot(sessionNames: string[]): boolean {
+  try {
+    // 1. Gather pane PIDs for all sessions in one tmux call per session
+    const panePidsBySession = new Map<string, number[]>();
+    for (const name of sessionNames) {
+      const r = Bun.spawnSync(["tmux", "list-panes", "-s", "-t", name, "-F", "#{pane_pid}"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const pids = r.stdout
+        .toString()
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map(Number)
+        .filter((n) => !Number.isNaN(n));
+      if (pids.length > 0) panePidsBySession.set(name, pids);
+    }
+
+    if (panePidsBySession.size === 0) {
+      portSnapshot = new Map();
+      return false;
+    }
+
+    // 2. Build parent->children map from a single ps call
+    const childrenOf = new Map<number, number[]>();
+    const psResult = Bun.spawnSync(["ps", "-eo", "pid=,ppid="], { stdout: "pipe", stderr: "pipe" });
+    for (const line of psResult.stdout.toString().trim().split("\n")) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 2) continue;
+      const pid = Number.parseInt(parts[0], 10);
+      const ppid = Number.parseInt(parts[1], 10);
+      if (Number.isNaN(pid) || Number.isNaN(ppid)) continue;
+      let arr = childrenOf.get(ppid);
+      if (!arr) {
+        arr = [];
+        childrenOf.set(ppid, arr);
+      }
+      arr.push(pid);
+    }
+
+    // 3. BFS from pane PIDs to get full descendant tree per session
+    const pidToSessions = new Map<number, string[]>();
+    for (const [name, panePids] of panePidsBySession) {
+      const allPids = new Set<number>(panePids);
+      const queue = [...panePids];
+      while (queue.length > 0) {
+        const pid = queue.pop()!;
+        const kids = childrenOf.get(pid);
+        if (!kids) continue;
+        for (const kid of kids) {
+          if (!allPids.has(kid)) {
+            allPids.add(kid);
+            queue.push(kid);
+          }
+        }
+      }
+      for (const pid of allPids) {
+        let arr = pidToSessions.get(pid);
+        if (!arr) {
+          arr = [];
+          pidToSessions.set(pid, arr);
+        }
+        arr.push(name);
+      }
+    }
+
+    // 4. Single lsof call for all listening TCP ports
+    const lsofResult = Bun.spawnSync(["lsof", "-iTCP", "-sTCP:LISTEN", "-nP", "-F", "pn"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (lsofResult.exitCode !== 0) {
+      debugLog("ports", "lsof failed", {
+        exitCode: lsofResult.exitCode,
+        stderr: lsofResult.stderr.toString().slice(0, 200),
+      });
+      return false;
+    }
+
+    // 5. Parse and attribute ports to sessions
+    const sessionPorts = new Map<string, Set<number>>();
+    let currentPid = 0;
+    for (const line of lsofResult.stdout.toString().split("\n")) {
+      if (line.startsWith("p")) {
+        currentPid = Number.parseInt(line.slice(1), 10);
+      } else if (line.startsWith("n")) {
+        const sessions = pidToSessions.get(currentPid);
+        if (!sessions) continue;
+        const match = line.match(/:(\d+)$/);
+        if (!match) continue;
+        const port = Number.parseInt(match[1], 10);
+        if (Number.isNaN(port)) continue;
+        for (const name of sessions) {
+          let set = sessionPorts.get(name);
+          if (!set) {
+            set = new Set();
+            sessionPorts.set(name, set);
+          }
+          set.add(port);
+        }
+      }
+    }
+
+    // 6. Build the new snapshot
+    const next = new Map<string, number[]>();
+    for (const name of sessionNames) {
+      const set = sessionPorts.get(name);
+      next.set(name, set ? [...set].sort((a, b) => a - b) : []);
+    }
+
+    const changed = !mapsEqual(portSnapshot, next);
+    portSnapshot = next;
+    return changed;
+  } catch (err) {
+    debugLog("ports", "refreshPortSnapshot failed", { error: String(err) });
+    return false;
+  }
+}
+
+function mapsEqual(a: Map<string, number[]>, b: Map<string, number[]>): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) {
+    const bv = b.get(k);
+    if (!bv || bv.length !== v.length || v.some((n, i) => n !== bv[i])) return false;
+  }
+  return true;
+}
+
+export function getSessionPorts(sessionName: string): number[] {
+  return portSnapshot.get(sessionName) ?? [];
+}
+
+export function startPortPoll(ctx: {
+  lastState: { sessions: { name: string }[] } | null;
+  clientCount: number;
+  broadcastState: () => void;
+}): ReturnType<typeof setInterval> {
+  // Run initial snapshot immediately so first broadcast has ports
+  if (ctx.lastState) {
+    refreshPortSnapshot(ctx.lastState.sessions.map((s) => s.name));
+  }
+  const PORT_POLL_INTERVAL_MS = 10_000;
+  return setInterval(() => {
+    if (!ctx.lastState || ctx.clientCount === 0) return;
+    const changed = refreshPortSnapshot(ctx.lastState.sessions.map((s) => s.name));
+    if (changed) ctx.broadcastState();
+  }, PORT_POLL_INTERVAL_MS);
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/session-order.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/session-order.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+interface PersistedSessionOrder {
+  order?: unknown;
+  hidden?: unknown;
+}
+
+/**
+ * Maintains custom session ordering for reorder-session commands.
+ * Stores an ordered list of session names. The `apply` method takes
+ * the natural session list and returns it sorted by the custom order.
+ *
+ * When a `persistPath` is provided, the order is loaded from disk on
+ * construction and saved after every `reorder()` call.
+ */
+export class SessionOrder {
+  private order: string[] = [];
+  private hidden = new Set<string>();
+  private readonly persistPath: string | null;
+
+  constructor(persistPath?: string) {
+    this.persistPath = persistPath ?? null;
+    if (this.persistPath) {
+      try {
+        if (existsSync(this.persistPath)) {
+          const raw = readFileSync(this.persistPath, "utf-8");
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            this.order = parsed.filter((n): n is string => typeof n === "string");
+          } else if (parsed && typeof parsed === "object") {
+            const persisted = parsed as PersistedSessionOrder;
+            if (Array.isArray(persisted.order)) {
+              this.order = persisted.order.filter((n): n is string => typeof n === "string");
+            }
+            if (Array.isArray(persisted.hidden)) {
+              this.hidden = new Set(
+                persisted.hidden.filter((n): n is string => typeof n === "string"),
+              );
+            }
+          }
+        }
+      } catch {
+        // Ignore corrupt file — start fresh
+      }
+    }
+  }
+
+  /** Sync with current session names — adds new ones at end, removes stale ones. */
+  sync(names: string[]): void {
+    const nameSet = new Set(names);
+    // Remove sessions that no longer exist
+    this.order = this.order.filter((n) => nameSet.has(n));
+    this.hidden = new Set([...this.hidden].filter((n) => nameSet.has(n)));
+    // Add new sessions at the end
+    for (const n of names) {
+      if (!this.order.includes(n)) {
+        this.order.push(n);
+      }
+    }
+  }
+
+  /** Move a session by delta (-1 = up, 1 = down). */
+  reorder(name: string, delta: -1 | 1): void {
+    const idx = this.order.indexOf(name);
+    if (idx === -1) return;
+    const newIdx = idx + delta;
+    if (newIdx < 0 || newIdx >= this.order.length) return;
+    // Swap
+    [this.order[idx], this.order[newIdx]] = [this.order[newIdx]!, this.order[idx]!];
+    this.save();
+  }
+
+  /** Hide a session from the panel without touching the underlying mux session. */
+  hide(name: string): void {
+    if (!this.order.includes(name) || this.hidden.has(name)) return;
+    this.hidden.add(name);
+    this.save();
+  }
+
+  /** Make a previously hidden session visible again. */
+  show(name: string): void {
+    if (!this.hidden.delete(name)) return;
+    if (!this.order.includes(name)) {
+      this.order.push(name);
+    }
+    this.save();
+  }
+
+  /** Restore all hidden sessions back into the panel. */
+  showAll(): void {
+    if (this.hidden.size === 0) return;
+    this.hidden.clear();
+    this.save();
+  }
+
+  /** Apply the custom order to a list of session names. Returns sorted names. */
+  apply(names: string[]): string[] {
+    const posMap = new Map(this.order.map((n, i) => [n, i]));
+    return names
+      .filter((n) => !this.hidden.has(n))
+      .sort((a, b) => {
+        const pa = posMap.get(a) ?? Infinity;
+        const pb = posMap.get(b) ?? Infinity;
+        return pa - pb;
+      });
+  }
+
+  private save(): void {
+    if (!this.persistPath) return;
+    try {
+      mkdirSync(dirname(this.persistPath), { recursive: true });
+      const serialized =
+        this.hidden.size === 0 ? this.order : { order: this.order, hidden: [...this.hidden] };
+      writeFileSync(this.persistPath, JSON.stringify(serialized) + "\n");
+    } catch {
+      // Best-effort — don't crash if write fails
+    }
+  }
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/sidebar-manager.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/sidebar-manager.ts
@@ -1,0 +1,242 @@
+import { debugLog } from "../debug";
+import { saveConfig } from "../config";
+import { resolveSidebarWidthFromResizeContext, snapshotSidebarWindows } from "./sidebar-width-sync";
+import type { SidebarResizeContext } from "./sidebar-width-sync";
+import type { ServerContext } from "./context";
+
+const SIDEBAR_PANE_CACHE_TTL = 300; // ms
+
+export function listSidebarPanesByProviderUncached(ctx: ServerContext) {
+  return ctx.getProvidersWithSidebar().map((provider) => ({
+    provider,
+    panes: provider.listSidebarPanes(),
+  }));
+}
+
+export function listSidebarPanesByProvider(ctx: ServerContext) {
+  const now = Date.now();
+  if (ctx.sidebarPaneCache && now - ctx.sidebarPaneCacheTs < SIDEBAR_PANE_CACHE_TTL)
+    return ctx.sidebarPaneCache;
+  ctx.sidebarPaneCache = listSidebarPanesByProviderUncached(ctx);
+  ctx.sidebarPaneCacheTs = now;
+  return ctx.sidebarPaneCache;
+}
+
+export function invalidateSidebarPaneCache(ctx: ServerContext): void {
+  ctx.sidebarPaneCache = null;
+  ctx.sidebarPaneCacheTs = 0;
+}
+
+export function scheduleSidebarResize(ctx: ServerContext, resizeCtx?: SidebarResizeContext): void {
+  if (resizeCtx) ctx.pendingSidebarResizeCtx = resizeCtx;
+  resizeSidebars(ctx, resizeCtx);
+  if (ctx.pendingSidebarResize) clearTimeout(ctx.pendingSidebarResize);
+  ctx.pendingSidebarResize = setTimeout(() => {
+    const nextCtx = ctx.pendingSidebarResizeCtx;
+    ctx.pendingSidebarResizeCtx = undefined;
+    ctx.pendingSidebarResize = null;
+    resizeSidebars(ctx, nextCtx);
+  }, 120);
+}
+
+export function toggleSidebar(
+  ctx: ServerContext,
+  toggleCtx?: { session: string; windowId: string },
+): void {
+  const providers = ctx.getProvidersWithSidebar();
+  if (providers.length === 0) {
+    debugLog("toggle", "SKIP — no providers with sidebar methods");
+    return;
+  }
+
+  invalidateSidebarPaneCache(ctx);
+  if (ctx.sidebarVisible) {
+    for (const p of providers) {
+      const panes = p.listSidebarPanes();
+      debugLog("toggle", "OFF — hiding panes", { provider: p.name, count: panes.length });
+      for (const pane of panes) {
+        p.hideSidebar(pane.paneId);
+      }
+    }
+    ctx.sidebarVisible = false;
+  } else {
+    ctx.sidebarVisible = true;
+    for (const p of providers) {
+      const allWindows = p.listActiveWindows();
+      debugLog("toggle", "ON — spawning in active windows", {
+        provider: p.name,
+        count: allWindows.length,
+      });
+      for (const w of allWindows) {
+        ensureSidebarInWindow(ctx, p, { session: w.sessionName, windowId: w.id });
+      }
+    }
+    scheduleSidebarResize(ctx);
+    ctx.server.publish("sidebar", JSON.stringify({ type: "re-identify" }));
+  }
+  debugLog("toggle", "done", { sidebarVisible: ctx.sidebarVisible });
+}
+
+export function ensureSidebarInWindow(
+  ctx: ServerContext,
+  provider?: ReturnType<ServerContext["getProvidersWithSidebar"]>[number],
+  windowCtx?: { session: string; windowId: string },
+): void {
+  const p =
+    provider ??
+    (() => {
+      const providers = ctx.getProvidersWithSidebar();
+      if (windowCtx?.session) {
+        const sessionProvider = ctx.sessionProviders.get(windowCtx.session);
+        return providers.find((pp) => pp === sessionProvider) ?? providers[0];
+      }
+      return providers[0];
+    })();
+  if (!p || !ctx.sidebarVisible) {
+    debugLog("ensure", "SKIP", { hasProvider: !!p, sidebarVisible: ctx.sidebarVisible });
+    return;
+  }
+
+  const curSession = windowCtx?.session ?? ctx.getCurrentSession();
+  if (!curSession) {
+    debugLog("ensure", "SKIP — no current session");
+    return;
+  }
+
+  const windowId = windowCtx?.windowId ?? p.getCurrentWindowId();
+  if (!windowId) {
+    debugLog("ensure", "SKIP — could not get window_id");
+    return;
+  }
+
+  const spawnKey = `${p.name}:${windowId}`;
+  if (ctx.pendingSidebarSpawns.has(spawnKey)) {
+    debugLog("ensure", "SKIP — spawn already in progress", {
+      curSession,
+      windowId,
+      provider: p.name,
+    });
+    return;
+  }
+
+  const allPanesByProvider = listSidebarPanesByProvider(ctx);
+  const providerEntry = allPanesByProvider.find((e) => e.provider === p);
+  const existingPanes = providerEntry?.panes ?? [];
+  const hasInWindow = existingPanes.some((ep) => ep.windowId === windowId);
+  debugLog("ensure", "checking window", {
+    curSession,
+    windowId,
+    existingPanes: existingPanes.length,
+    hasInWindow,
+    paneIds: existingPanes.map((x) => `${x.paneId}@${x.windowId}`),
+  });
+
+  if (!hasInWindow) {
+    invalidateSidebarPaneCache(ctx);
+    ctx.pendingSidebarSpawns.add(spawnKey);
+    debugLog("ensure", "SPAWNING sidebar", {
+      curSession,
+      windowId,
+      sidebarWidth: ctx.sidebarWidth,
+      sidebarPosition: ctx.sidebarPosition,
+      scriptsDir: ctx.scriptsDir,
+    });
+    try {
+      const newPaneId = p.spawnSidebar(
+        curSession,
+        windowId,
+        ctx.sidebarWidth,
+        ctx.sidebarPosition,
+        ctx.scriptsDir,
+      );
+      debugLog("ensure", "spawn result", { newPaneId });
+    } finally {
+      ctx.pendingSidebarSpawns.delete(spawnKey);
+    }
+    scheduleSidebarResize(ctx);
+  }
+}
+
+export function debouncedEnsureSidebar(
+  ctx: ServerContext,
+  windowCtx?: { session: string; windowId: string },
+): void {
+  if (windowCtx) ctx.ensureSidebarPendingCtx = windowCtx;
+  if (ctx.ensureSidebarTimer) clearTimeout(ctx.ensureSidebarTimer);
+  ctx.ensureSidebarTimer = setTimeout(() => {
+    ctx.ensureSidebarTimer = null;
+    const nextCtx = ctx.ensureSidebarPendingCtx;
+    ctx.ensureSidebarPendingCtx = undefined;
+    ensureSidebarInWindow(ctx, undefined, nextCtx);
+  }, 150);
+}
+
+export function quitAll(ctx: ServerContext): void {
+  debugLog("quit", "killing all sidebar panes");
+  for (const p of ctx.getProvidersWithSidebar()) {
+    const panes = p.listSidebarPanes();
+    debugLog("quit", "found panes to kill", { provider: p.name, count: panes.length });
+    for (const pane of panes) {
+      p.killSidebarPane(pane.paneId);
+    }
+  }
+  for (const p of ctx.getProvidersWithSidebar()) {
+    p.cleanupSidebar();
+  }
+  ctx.server.publish("sidebar", JSON.stringify({ type: "quit" }));
+  ctx.sidebarVisible = false;
+  ctx.cleanup();
+  process.exit(0);
+}
+
+export function resizeSidebars(ctx: ServerContext, resizeCtx?: SidebarResizeContext): void {
+  const panesByProvider = listSidebarPanesByProvider(ctx);
+  const allPanes = panesByProvider.flatMap(({ panes }) => panes);
+
+  if (allPanes.length === 0) {
+    ctx.sidebarSnapshots = new Map();
+    return;
+  }
+
+  const nextSidebarWidth = resolveSidebarWidthFromResizeContext({
+    ctx: resizeCtx,
+    panes: allPanes,
+    previousByWindow: ctx.sidebarSnapshots,
+    suppressedByPane: ctx.suppressedSidebarResizeAcks,
+  });
+
+  if (nextSidebarWidth != null && nextSidebarWidth !== ctx.sidebarWidth) {
+    ctx.sidebarWidth = nextSidebarWidth;
+    saveConfig({ sidebarWidth: ctx.sidebarWidth });
+    debugLog("resize", "adopted sidebar width from pane resize", {
+      paneId: resizeCtx?.paneId ?? null,
+      sessionName: resizeCtx?.sessionName ?? null,
+      windowId: resizeCtx?.windowId ?? null,
+      sidebarWidth: ctx.sidebarWidth,
+    });
+    ctx.broadcastState();
+  }
+
+  const now = Date.now();
+  for (const { provider, panes } of panesByProvider) {
+    debugLog("resize", "enforcing width on all panes", {
+      provider: provider.name,
+      sidebarWidth: ctx.sidebarWidth,
+      count: panes.length,
+      triggerPaneId: resizeCtx?.paneId ?? null,
+    });
+    for (const pane of panes) {
+      if (pane.width === ctx.sidebarWidth) continue;
+      ctx.suppressedSidebarResizeAcks.set(pane.paneId, {
+        width: ctx.sidebarWidth,
+        expiresAt: now + 1_000,
+      });
+      provider.resizeSidebarPane(pane.paneId, ctx.sidebarWidth);
+    }
+  }
+
+  if (panesByProvider.some(({ panes }) => panes.some((pane) => pane.width !== ctx.sidebarWidth))) {
+    invalidateSidebarPaneCache(ctx);
+  }
+  ctx.sidebarSnapshots = snapshotSidebarWindows(allPanes);
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/server/sidebar-width-sync.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/server/sidebar-width-sync.ts
@@ -1,0 +1,66 @@
+import type { SidebarPane } from "../contracts/mux";
+
+export interface SidebarResizeContext {
+  paneId?: string;
+  sessionName?: string;
+  windowId?: string;
+  width?: number;
+  windowWidth?: number;
+}
+
+export interface SidebarWindowSnapshot {
+  width?: number;
+  windowWidth?: number;
+}
+
+export interface SidebarResizeSuppression {
+  width: number;
+  expiresAt: number;
+}
+
+export function snapshotSidebarWindows(panes: SidebarPane[]): Map<string, SidebarWindowSnapshot> {
+  const snapshots = new Map<string, SidebarWindowSnapshot>();
+  for (const pane of panes) {
+    snapshots.set(pane.windowId, {
+      width: pane.width,
+      windowWidth: pane.windowWidth,
+    });
+  }
+  return snapshots;
+}
+
+export function resolveSidebarWidthFromResizeContext(params: {
+  ctx?: SidebarResizeContext;
+  panes: SidebarPane[];
+  previousByWindow: Map<string, SidebarWindowSnapshot>;
+  suppressedByPane: Map<string, SidebarResizeSuppression>;
+  now?: number;
+}): number | null {
+  const { ctx, panes, previousByWindow, suppressedByPane, now = Date.now() } = params;
+  if (!ctx?.paneId) return null;
+
+  const pane = panes.find((candidate) => candidate.paneId === ctx.paneId);
+  if (!pane) return null;
+
+  const width = pane.width ?? ctx.width;
+  const windowWidth = pane.windowWidth ?? ctx.windowWidth;
+  if (width == null || windowWidth == null) return null;
+
+  const suppressed = suppressedByPane.get(pane.paneId);
+  if (suppressed) {
+    if (suppressed.width === width && suppressed.expiresAt >= now) {
+      suppressedByPane.delete(pane.paneId);
+      return null;
+    }
+    if (suppressed.expiresAt < now || suppressed.width !== width) {
+      suppressedByPane.delete(pane.paneId);
+    }
+  }
+
+  const previous = previousByWindow.get(pane.windowId);
+  if (!previous || previous.width == null || previous.windowWidth == null) return null;
+  if (previous.windowWidth !== windowWidth) return null;
+  if (previous.width === width) return null;
+
+  return width;
+}

--- a/plugins/tt-agentboard2/packages/runtime/src/shared.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/shared.ts
@@ -1,0 +1,175 @@
+import type { AgentStatus, AgentEvent } from "./contracts/agent";
+
+export const SERVER_PORT = 4201;
+export const SERVER_HOST = "127.0.0.1";
+export const PID_FILE = "/tmp/agentboard2.pid";
+export const SERVER_IDLE_TIMEOUT_MS = 30_000;
+export const STUCK_RUNNING_TIMEOUT_MS = 3 * 60 * 1000;
+
+export interface SessionData {
+  name: string;
+  createdAt: number;
+  dir: string;
+  branch: string;
+  dirty: boolean;
+  isWorktree: boolean;
+  unseen: boolean;
+  panes: number;
+  ports: number[];
+  windows: number;
+  uptime: string;
+  agentState: AgentEvent | null;
+  agents: AgentEvent[];
+  eventTimestamps: number[];
+  metadata?: SessionMetadata | null;
+}
+
+export interface ServerState {
+  type: "state";
+  sessions: SessionData[];
+  focusedSession: string | null;
+  currentSession: string | null;
+  theme: string | undefined;
+  sidebarWidth: number;
+  ts: number;
+}
+
+export interface FocusUpdate {
+  type: "focus";
+  focusedSession: string | null;
+  currentSession: string | null;
+}
+
+export interface ResizeNotify {
+  type: "resize";
+  width: number;
+}
+
+export interface QuitNotify {
+  type: "quit";
+}
+
+export interface YourSession {
+  type: "your-session";
+  name: string;
+  clientTty: string | null;
+}
+
+export interface ReIdentify {
+  type: "re-identify";
+}
+
+export type ServerMessage =
+  | ServerState
+  | FocusUpdate
+  | ResizeNotify
+  | QuitNotify
+  | YourSession
+  | ReIdentify;
+
+// --- Programmatic metadata (agent/script-pushed) ---
+
+export type MetadataTone = "neutral" | "info" | "success" | "warn" | "error";
+
+export interface MetadataStatus {
+  text: string;
+  tone?: MetadataTone;
+  ts: number;
+}
+
+export interface MetadataProgress {
+  current?: number;
+  total?: number;
+  percent?: number;
+  label?: string;
+  ts: number;
+}
+
+export interface MetadataLogEntry {
+  message: string;
+  tone?: MetadataTone;
+  source?: string;
+  ts: number;
+}
+
+export interface SessionMetadata {
+  status: MetadataStatus | null;
+  progress: MetadataProgress | null;
+  logs: MetadataLogEntry[];
+}
+
+export type ClientCommand =
+  | { type: "switch-session"; name: string; clientTty?: string }
+  | { type: "switch-index"; index: number }
+  | { type: "new-session" }
+  | { type: "hide-session"; name: string }
+  | { type: "show-all-sessions" }
+  | { type: "kill-session"; name: string }
+  | { type: "reorder-session"; name: string; delta: -1 | 1 }
+  | { type: "refresh" }
+  | { type: "move-focus"; delta: -1 | 1 }
+  | { type: "focus-session"; name: string }
+  | { type: "mark-seen"; name: string }
+  | { type: "dismiss-agent"; session: string; agent: string; threadId?: string }
+  | { type: "set-theme"; theme: string }
+  | { type: "identify"; clientTty: string }
+  | { type: "report-width"; width: number }
+  | { type: "quit" }
+  | { type: "identify-pane"; paneId: string; sessionName: string }
+  | {
+      type: "focus-agent-pane";
+      session: string;
+      agent: string;
+      threadId?: string;
+      threadName?: string;
+    }
+  | {
+      type: "kill-agent-pane";
+      session: string;
+      agent: string;
+      threadId?: string;
+      threadName?: string;
+    };
+
+// Catppuccin Mocha palette
+export const C = {
+  blue: "#89b4fa",
+  lavender: "#b4befe",
+  pink: "#cba6f7",
+  mauve: "#cba6f7",
+  yellow: "#f9e2af",
+  green: "#a6e3a1",
+  red: "#f38ba8",
+  peach: "#fab387",
+  teal: "#94e2d5",
+  sky: "#89dceb",
+  text: "#cdd6f4",
+  subtext0: "#a6adc8",
+  subtext1: "#bac2de",
+  overlay0: "#6c7086",
+  overlay1: "#7f849c",
+  surface0: "#313244",
+  surface1: "#45475a",
+  surface2: "#585b70",
+  base: "#1e1e2e",
+  mantle: "#181825",
+  crust: "#11111b",
+} as const;
+
+export const STATUS_COLORS: Record<AgentStatus, string> = {
+  idle: C.surface2,
+  running: C.yellow,
+  done: C.green,
+  error: C.red,
+  waiting: C.blue,
+  interrupted: C.peach,
+};
+
+export const STATUS_ICONS: Record<AgentStatus, string> = {
+  idle: "○",
+  running: "●",
+  done: "✓",
+  error: "✗",
+  waiting: "◉",
+  interrupted: "⚠",
+};

--- a/plugins/tt-agentboard2/packages/runtime/src/themes.ts
+++ b/plugins/tt-agentboard2/packages/runtime/src/themes.ts
@@ -1,0 +1,750 @@
+import type { AgentStatus } from "./contracts/agent";
+
+export interface ThemePalette {
+  blue: string;
+  lavender: string;
+  pink: string;
+  mauve: string;
+  yellow: string;
+  green: string;
+  red: string;
+  peach: string;
+  teal: string;
+  sky: string;
+  text: string;
+  subtext0: string;
+  subtext1: string;
+  overlay0: string;
+  overlay1: string;
+  surface0: string;
+  surface1: string;
+  surface2: string;
+  base: string;
+  mantle: string;
+  crust: string;
+}
+
+export interface Theme {
+  palette: ThemePalette;
+  status: Record<AgentStatus, string>;
+  icons: Record<AgentStatus, string>;
+}
+
+// --- Builtin themes ---
+
+const CATPPUCCIN_MOCHA: Theme = {
+  palette: {
+    blue: "#89b4fa",
+    lavender: "#b4befe",
+    pink: "#cba6f7",
+    mauve: "#cba6f7",
+    yellow: "#f9e2af",
+    green: "#a6e3a1",
+    red: "#f38ba8",
+    peach: "#fab387",
+    teal: "#94e2d5",
+    sky: "#89dceb",
+    text: "#cdd6f4",
+    subtext0: "#a6adc8",
+    subtext1: "#bac2de",
+    overlay0: "#6c7086",
+    overlay1: "#7f849c",
+    surface0: "#313244",
+    surface1: "#45475a",
+    surface2: "#585b70",
+    base: "#1e1e2e",
+    mantle: "#181825",
+    crust: "#11111b",
+  },
+  status: {
+    idle: "#585b70",
+    running: "#f9e2af",
+    done: "#a6e3a1",
+    error: "#f38ba8",
+    waiting: "#89b4fa",
+    interrupted: "#fab387",
+  },
+  icons: {
+    idle: "○",
+    running: "●",
+    done: "✓",
+    error: "✗",
+    waiting: "◉",
+    interrupted: "⚠",
+  },
+};
+
+const CATPPUCCIN_LATTE: Theme = {
+  palette: {
+    blue: "#1e66f5",
+    lavender: "#7287fd",
+    pink: "#ea76cb",
+    mauve: "#8839ef",
+    yellow: "#df8e1d",
+    green: "#40a02b",
+    red: "#d20f39",
+    peach: "#fe640b",
+    teal: "#179299",
+    sky: "#04a5e5",
+    text: "#4c4f69",
+    subtext0: "#6c6f85",
+    subtext1: "#5c5f77",
+    overlay0: "#9ca0b0",
+    overlay1: "#8c8fa1",
+    surface0: "#ccd0da",
+    surface1: "#bcc0cc",
+    surface2: "#acb0be",
+    base: "#eff1f5",
+    mantle: "#e6e9ef",
+    crust: "#dce0e8",
+  },
+  status: {
+    idle: "#acb0be",
+    running: "#df8e1d",
+    done: "#40a02b",
+    error: "#d20f39",
+    waiting: "#1e66f5",
+    interrupted: "#fe640b",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const TOKYO_NIGHT: Theme = {
+  palette: {
+    blue: "#7aa2f7",
+    lavender: "#bb9af7",
+    pink: "#bb9af7",
+    mauve: "#bb9af7",
+    yellow: "#e0af68",
+    green: "#9ece6a",
+    red: "#f7768e",
+    peach: "#ff9e64",
+    teal: "#73daca",
+    sky: "#7dcfff",
+    text: "#c0caf5",
+    subtext0: "#a9b1d6",
+    subtext1: "#9aa5ce",
+    overlay0: "#565f89",
+    overlay1: "#414868",
+    surface0: "#24283b",
+    surface1: "#292e42",
+    surface2: "#343a52",
+    base: "#1a1b26",
+    mantle: "#16161e",
+    crust: "#13131a",
+  },
+  status: {
+    idle: "#343a52",
+    running: "#e0af68",
+    done: "#9ece6a",
+    error: "#f7768e",
+    waiting: "#7aa2f7",
+    interrupted: "#ff9e64",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const GRUVBOX_DARK: Theme = {
+  palette: {
+    blue: "#83a598",
+    lavender: "#d3869b",
+    pink: "#d3869b",
+    mauve: "#d3869b",
+    yellow: "#fabd2f",
+    green: "#b8bb26",
+    red: "#fb4934",
+    peach: "#fe8019",
+    teal: "#8ec07c",
+    sky: "#83a598",
+    text: "#ebdbb2",
+    subtext0: "#d5c4a1",
+    subtext1: "#bdae93",
+    overlay0: "#665c54",
+    overlay1: "#7c6f64",
+    surface0: "#3c3836",
+    surface1: "#504945",
+    surface2: "#665c54",
+    base: "#282828",
+    mantle: "#1d2021",
+    crust: "#1b1b1b",
+  },
+  status: {
+    idle: "#665c54",
+    running: "#fabd2f",
+    done: "#b8bb26",
+    error: "#fb4934",
+    waiting: "#83a598",
+    interrupted: "#fe8019",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const NORD: Theme = {
+  palette: {
+    blue: "#81a1c1",
+    lavender: "#b48ead",
+    pink: "#b48ead",
+    mauve: "#b48ead",
+    yellow: "#ebcb8b",
+    green: "#a3be8c",
+    red: "#bf616a",
+    peach: "#d08770",
+    teal: "#8fbcbb",
+    sky: "#88c0d0",
+    text: "#eceff4",
+    subtext0: "#d8dee9",
+    subtext1: "#e5e9f0",
+    overlay0: "#4c566a",
+    overlay1: "#434c5e",
+    surface0: "#3b4252",
+    surface1: "#434c5e",
+    surface2: "#4c566a",
+    base: "#2e3440",
+    mantle: "#272c36",
+    crust: "#242933",
+  },
+  status: {
+    idle: "#4c566a",
+    running: "#ebcb8b",
+    done: "#a3be8c",
+    error: "#bf616a",
+    waiting: "#81a1c1",
+    interrupted: "#d08770",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const DRACULA: Theme = {
+  palette: {
+    blue: "#8be9fd",
+    lavender: "#bd93f9",
+    pink: "#ff79c6",
+    mauve: "#bd93f9",
+    yellow: "#f1fa8c",
+    green: "#50fa7b",
+    red: "#ff5555",
+    peach: "#ffb86c",
+    teal: "#8be9fd",
+    sky: "#8be9fd",
+    text: "#f8f8f2",
+    subtext0: "#bfbfbf",
+    subtext1: "#6272a4",
+    overlay0: "#6272a4",
+    overlay1: "#565761",
+    surface0: "#44475a",
+    surface1: "#44475a",
+    surface2: "#6272a4",
+    base: "#282a36",
+    mantle: "#21222c",
+    crust: "#191a21",
+  },
+  status: {
+    idle: "#6272a4",
+    running: "#f1fa8c",
+    done: "#50fa7b",
+    error: "#ff5555",
+    waiting: "#8be9fd",
+    interrupted: "#ffb86c",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const CATPPUCCIN_FRAPPE: Theme = {
+  palette: {
+    blue: "#8da4e2",
+    lavender: "#babbf1",
+    pink: "#f4b8e4",
+    mauve: "#ca9ee6",
+    yellow: "#e5c890",
+    green: "#a6d189",
+    red: "#e78284",
+    peach: "#ef9f76",
+    teal: "#81c8be",
+    sky: "#99d1db",
+    text: "#c6d0f5",
+    subtext0: "#a5adce",
+    subtext1: "#b5bfe2",
+    overlay0: "#626880",
+    overlay1: "#51576d",
+    surface0: "#414559",
+    surface1: "#51576d",
+    surface2: "#626880",
+    base: "#303446",
+    mantle: "#292c3c",
+    crust: "#232634",
+  },
+  status: {
+    idle: "#626880",
+    running: "#e5c890",
+    done: "#a6d189",
+    error: "#e78284",
+    waiting: "#8da4e2",
+    interrupted: "#ef9f76",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const CATPPUCCIN_MACCHIATO: Theme = {
+  palette: {
+    blue: "#8aadf4",
+    lavender: "#b7bdf8",
+    pink: "#f5bde6",
+    mauve: "#c6a0f6",
+    yellow: "#eed49f",
+    green: "#a6da95",
+    red: "#ed8796",
+    peach: "#f5a97f",
+    teal: "#8bd5ca",
+    sky: "#91d7e3",
+    text: "#cad3f5",
+    subtext0: "#a5adcb",
+    subtext1: "#b8c0e0",
+    overlay0: "#5b6078",
+    overlay1: "#494d64",
+    surface0: "#363a4f",
+    surface1: "#494d64",
+    surface2: "#5b6078",
+    base: "#24273a",
+    mantle: "#1e2030",
+    crust: "#181926",
+  },
+  status: {
+    idle: "#5b6078",
+    running: "#eed49f",
+    done: "#a6da95",
+    error: "#ed8796",
+    waiting: "#8aadf4",
+    interrupted: "#f5a97f",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const GITHUB_DARK: Theme = {
+  palette: {
+    blue: "#58a6ff",
+    lavender: "#bc8cff",
+    pink: "#bc8cff",
+    mauve: "#bc8cff",
+    yellow: "#e3b341",
+    green: "#3fb950",
+    red: "#f85149",
+    peach: "#d29922",
+    teal: "#39c5cf",
+    sky: "#58a6ff",
+    text: "#c9d1d9",
+    subtext0: "#8b949e",
+    subtext1: "#b1bac4",
+    overlay0: "#484f58",
+    overlay1: "#30363d",
+    surface0: "#161b22",
+    surface1: "#21262d",
+    surface2: "#30363d",
+    base: "#0d1117",
+    mantle: "#010409",
+    crust: "#010409",
+  },
+  status: {
+    idle: "#484f58",
+    running: "#e3b341",
+    done: "#3fb950",
+    error: "#f85149",
+    waiting: "#58a6ff",
+    interrupted: "#d29922",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const ONE_DARK: Theme = {
+  palette: {
+    blue: "#61afef",
+    lavender: "#c678dd",
+    pink: "#c678dd",
+    mauve: "#c678dd",
+    yellow: "#e5c07b",
+    green: "#98c379",
+    red: "#e06c75",
+    peach: "#d19a66",
+    teal: "#56b6c2",
+    sky: "#61afef",
+    text: "#abb2bf",
+    subtext0: "#828997",
+    subtext1: "#5c6370",
+    overlay0: "#5c6370",
+    overlay1: "#4b5263",
+    surface0: "#3e4451",
+    surface1: "#4b5263",
+    surface2: "#5c6370",
+    base: "#282c34",
+    mantle: "#21252b",
+    crust: "#1b1f27",
+  },
+  status: {
+    idle: "#5c6370",
+    running: "#e5c07b",
+    done: "#98c379",
+    error: "#e06c75",
+    waiting: "#61afef",
+    interrupted: "#d19a66",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const KANAGAWA: Theme = {
+  palette: {
+    blue: "#7E9CD8",
+    lavender: "#957FB8",
+    pink: "#D27E99",
+    mauve: "#957FB8",
+    yellow: "#D7A657",
+    green: "#98BB6C",
+    red: "#E82424",
+    peach: "#FFA066",
+    teal: "#7AA89F",
+    sky: "#7FB4CA",
+    text: "#DCD7BA",
+    subtext0: "#C8C093",
+    subtext1: "#727169",
+    overlay0: "#727169",
+    overlay1: "#54546D",
+    surface0: "#363646",
+    surface1: "#54546D",
+    surface2: "#727169",
+    base: "#1F1F28",
+    mantle: "#16161D",
+    crust: "#131320",
+  },
+  status: {
+    idle: "#54546D",
+    running: "#D7A657",
+    done: "#98BB6C",
+    error: "#E82424",
+    waiting: "#7E9CD8",
+    interrupted: "#FFA066",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const EVERFOREST: Theme = {
+  palette: {
+    blue: "#7fbbb3",
+    lavender: "#d699b6",
+    pink: "#d699b6",
+    mauve: "#d699b6",
+    yellow: "#dbbc7f",
+    green: "#a7c080",
+    red: "#e67e80",
+    peach: "#e69875",
+    teal: "#83c092",
+    sky: "#7fbbb3",
+    text: "#d3c6aa",
+    subtext0: "#9da9a0",
+    subtext1: "#7a8478",
+    overlay0: "#7a8478",
+    overlay1: "#859289",
+    surface0: "#343f44",
+    surface1: "#3d484d",
+    surface2: "#475258",
+    base: "#2d353b",
+    mantle: "#272e33",
+    crust: "#232a2e",
+  },
+  status: {
+    idle: "#7a8478",
+    running: "#dbbc7f",
+    done: "#a7c080",
+    error: "#e67e80",
+    waiting: "#7fbbb3",
+    interrupted: "#e69875",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const MATERIAL: Theme = {
+  palette: {
+    blue: "#82aaff",
+    lavender: "#c792ea",
+    pink: "#c792ea",
+    mauve: "#c792ea",
+    yellow: "#ffcb6b",
+    green: "#c3e88d",
+    red: "#f07178",
+    peach: "#f78c6c",
+    teal: "#89ddff",
+    sky: "#82aaff",
+    text: "#eeffff",
+    subtext0: "#b0bec5",
+    subtext1: "#546e7a",
+    overlay0: "#546e7a",
+    overlay1: "#37474f",
+    surface0: "#37474f",
+    surface1: "#455a64",
+    surface2: "#546e7a",
+    base: "#263238",
+    mantle: "#1e272c",
+    crust: "#192227",
+  },
+  status: {
+    idle: "#546e7a",
+    running: "#ffcb6b",
+    done: "#c3e88d",
+    error: "#f07178",
+    waiting: "#82aaff",
+    interrupted: "#f78c6c",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const COBALT2: Theme = {
+  palette: {
+    blue: "#0088ff",
+    lavender: "#9a5feb",
+    pink: "#ff9d00",
+    mauve: "#9a5feb",
+    yellow: "#ffc600",
+    green: "#9eff80",
+    red: "#ff0088",
+    peach: "#ff628c",
+    teal: "#2affdf",
+    sky: "#0088ff",
+    text: "#ffffff",
+    subtext0: "#adb7c9",
+    subtext1: "#6688aa",
+    overlay0: "#2d5a7b",
+    overlay1: "#1f4662",
+    surface0: "#1f4662",
+    surface1: "#234b6b",
+    surface2: "#2d5a7b",
+    base: "#193549",
+    mantle: "#122738",
+    crust: "#0e1e2e",
+  },
+  status: {
+    idle: "#2d5a7b",
+    running: "#ffc600",
+    done: "#9eff80",
+    error: "#ff0088",
+    waiting: "#0088ff",
+    interrupted: "#ff628c",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const FLEXOKI: Theme = {
+  palette: {
+    blue: "#4385BE",
+    lavender: "#8B7EC8",
+    pink: "#CE5D97",
+    mauve: "#8B7EC8",
+    yellow: "#D0A215",
+    green: "#879A39",
+    red: "#D14D41",
+    peach: "#DA702C",
+    teal: "#3AA99F",
+    sky: "#4385BE",
+    text: "#CECDC3",
+    subtext0: "#B7B5AC",
+    subtext1: "#878580",
+    overlay0: "#6F6E69",
+    overlay1: "#575653",
+    surface0: "#282726",
+    surface1: "#343331",
+    surface2: "#403E3C",
+    base: "#100F0F",
+    mantle: "#0D0D0C",
+    crust: "#0A0A09",
+  },
+  status: {
+    idle: "#575653",
+    running: "#D0A215",
+    done: "#879A39",
+    error: "#D14D41",
+    waiting: "#4385BE",
+    interrupted: "#DA702C",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const AYU: Theme = {
+  palette: {
+    blue: "#59C2FF",
+    lavender: "#D2A6FF",
+    pink: "#F07178",
+    mauve: "#D2A6FF",
+    yellow: "#E6B450",
+    green: "#7FD962",
+    red: "#D95757",
+    peach: "#FF8F40",
+    teal: "#95E6CB",
+    sky: "#39BAE6",
+    text: "#BFBDB6",
+    subtext0: "#ACB6BF",
+    subtext1: "#565B66",
+    overlay0: "#565B66",
+    overlay1: "#6C7380",
+    surface0: "#0D1017",
+    surface1: "#0F131A",
+    surface2: "#11151C",
+    base: "#0B0E14",
+    mantle: "#090C10",
+    crust: "#070A0E",
+  },
+  status: {
+    idle: "#565B66",
+    running: "#E6B450",
+    done: "#7FD962",
+    error: "#D95757",
+    waiting: "#59C2FF",
+    interrupted: "#FF8F40",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const AURA: Theme = {
+  palette: {
+    blue: "#82e2ff",
+    lavender: "#a277ff",
+    pink: "#f694ff",
+    mauve: "#a277ff",
+    yellow: "#ffca85",
+    green: "#9dff65",
+    red: "#ff6767",
+    peach: "#ffca85",
+    teal: "#61ffca",
+    sky: "#82e2ff",
+    text: "#edecee",
+    subtext0: "#bdbdbd",
+    subtext1: "#6d6d6d",
+    overlay0: "#6d6d6d",
+    overlay1: "#2d2d2d",
+    surface0: "#1a1a24",
+    surface1: "#1f1f2b",
+    surface2: "#2d2d2d",
+    base: "#15141b",
+    mantle: "#110f17",
+    crust: "#0f0f0f",
+  },
+  status: {
+    idle: "#6d6d6d",
+    running: "#ffca85",
+    done: "#61ffca",
+    error: "#ff6767",
+    waiting: "#a277ff",
+    interrupted: "#ffca85",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const MATRIX: Theme = {
+  palette: {
+    blue: "#30b3ff",
+    lavender: "#c770ff",
+    pink: "#c770ff",
+    mauve: "#c770ff",
+    yellow: "#e6ff57",
+    green: "#62ff94",
+    red: "#ff4b4b",
+    peach: "#ffa83d",
+    teal: "#24f6d9",
+    sky: "#30b3ff",
+    text: "#62ff94",
+    subtext0: "#8ca391",
+    subtext1: "#4a6b55",
+    overlay0: "#2e4a37",
+    overlay1: "#1e2a1b",
+    surface0: "#141c12",
+    surface1: "#182218",
+    surface2: "#1e2a1b",
+    base: "#0a0e0a",
+    mantle: "#070a07",
+    crust: "#050705",
+  },
+  status: {
+    idle: "#2e4a37",
+    running: "#e6ff57",
+    done: "#62ff94",
+    error: "#ff4b4b",
+    waiting: "#30b3ff",
+    interrupted: "#ffa83d",
+  },
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+const TRANSPARENT: Theme = {
+  palette: {
+    blue: "#89b4fa",
+    lavender: "#b4befe",
+    pink: "#cba6f7",
+    mauve: "#cba6f7",
+    yellow: "#f9e2af",
+    green: "#a6e3a1",
+    red: "#f38ba8",
+    peach: "#fab387",
+    teal: "#94e2d5",
+    sky: "#89dceb",
+    text: "#cdd6f4",
+    subtext0: "#a6adc8",
+    subtext1: "#bac2de",
+    overlay0: "#6c7086",
+    overlay1: "#7f849c",
+    surface0: "#313244",
+    surface1: "#45475a",
+    surface2: "#585b70",
+    base: "transparent",
+    mantle: "transparent",
+    crust: "transparent",
+  },
+  status: CATPPUCCIN_MOCHA.status,
+  icons: CATPPUCCIN_MOCHA.icons,
+};
+
+export const BUILTIN_THEMES: Record<string, Theme> = {
+  "catppuccin-mocha": CATPPUCCIN_MOCHA,
+  "catppuccin-latte": CATPPUCCIN_LATTE,
+  "catppuccin-frappe": CATPPUCCIN_FRAPPE,
+  "catppuccin-macchiato": CATPPUCCIN_MACCHIATO,
+  "tokyo-night": TOKYO_NIGHT,
+  "gruvbox-dark": GRUVBOX_DARK,
+  nord: NORD,
+  dracula: DRACULA,
+  "github-dark": GITHUB_DARK,
+  "one-dark": ONE_DARK,
+  kanagawa: KANAGAWA,
+  everforest: EVERFOREST,
+  material: MATERIAL,
+  cobalt2: COBALT2,
+  flexoki: FLEXOKI,
+  ayu: AYU,
+  aura: AURA,
+  matrix: MATRIX,
+  transparent: TRANSPARENT,
+};
+
+export const DEFAULT_THEME = "catppuccin-mocha";
+
+/** Partial theme for user overrides — any field can be omitted */
+export type PartialTheme = {
+  palette?: Partial<ThemePalette>;
+  status?: Partial<Record<AgentStatus, string>>;
+  icons?: Partial<Record<AgentStatus, string>>;
+};
+
+/**
+ * Resolve a theme from config.
+ * @param themeConfig — string name of builtin, partial inline object, or undefined for default
+ */
+export function resolveTheme(themeConfig: string | PartialTheme | undefined): Theme {
+  const base = BUILTIN_THEMES[DEFAULT_THEME];
+
+  if (!themeConfig) return base;
+
+  if (typeof themeConfig === "string") {
+    return BUILTIN_THEMES[themeConfig] ?? base;
+  }
+
+  // Merge partial inline theme over default
+  return {
+    palette: { ...base.palette, ...themeConfig.palette },
+    status: { ...base.status, ...themeConfig.status },
+    icons: { ...base.icons, ...themeConfig.icons },
+  };
+}

--- a/plugins/tt-agentboard2/packages/runtime/test/config.test.ts
+++ b/plugins/tt-agentboard2/packages/runtime/test/config.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { loadConfig, saveConfig } from "../src/config";
+
+const TEST_HOME = join(import.meta.dir, ".test-home");
+const CONFIG_DIR = join(TEST_HOME, ".config", "towles-tool", "agentboard2");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+describe("config", () => {
+  beforeEach(() => {
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  describe("loadConfig", () => {
+    it("returns defaults when no config file exists", () => {
+      const config = loadConfig(TEST_HOME);
+      expect(config.plugins).toEqual([]);
+      expect(config.port).toBeUndefined();
+      expect(config.theme).toBeUndefined();
+      expect(config.sidebarWidth).toBeUndefined();
+    });
+
+    it("reads config from disk", () => {
+      mkdirSync(CONFIG_DIR, { recursive: true });
+      writeFileSync(
+        CONFIG_FILE,
+        JSON.stringify({
+          port: 4201,
+          theme: "tokyo-night",
+          sidebarWidth: 30,
+          plugins: ["my-plugin"],
+        }),
+      );
+
+      const config = loadConfig(TEST_HOME);
+      expect(config.port).toBe(4201);
+      expect(config.theme).toBe("tokyo-night");
+      expect(config.sidebarWidth).toBe(30);
+      expect(config.plugins).toEqual(["my-plugin"]);
+    });
+
+    it("handles malformed JSON gracefully", () => {
+      mkdirSync(CONFIG_DIR, { recursive: true });
+      writeFileSync(CONFIG_FILE, "not json {{{");
+
+      const config = loadConfig(TEST_HOME);
+      expect(config.plugins).toEqual([]);
+    });
+  });
+
+  describe("saveConfig", () => {
+    it("creates config directory and file", () => {
+      saveConfig({ theme: "gruvbox-dark" }, TEST_HOME);
+
+      expect(existsSync(CONFIG_FILE)).toBe(true);
+      const saved = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
+      expect(saved.theme).toBe("gruvbox-dark");
+    });
+
+    it("merges with existing config", () => {
+      mkdirSync(CONFIG_DIR, { recursive: true });
+      writeFileSync(
+        CONFIG_FILE,
+        JSON.stringify({
+          theme: "nord",
+          sidebarWidth: 28,
+          plugins: [],
+        }),
+      );
+
+      saveConfig({ sidebarWidth: 32 }, TEST_HOME);
+
+      const saved = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
+      expect(saved.theme).toBe("nord");
+      expect(saved.sidebarWidth).toBe(32);
+    });
+  });
+});

--- a/plugins/tt-agentboard2/packages/runtime/test/tracker.test.ts
+++ b/plugins/tt-agentboard2/packages/runtime/test/tracker.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { AgentTracker, instanceKey } from "../src/agents/tracker";
+import type { AgentEvent } from "../src/contracts/agent";
+
+function makeEvent(overrides: Partial<AgentEvent> = {}): AgentEvent {
+  return {
+    agent: "claude-code",
+    session: "main",
+    status: "running",
+    ts: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("instanceKey", () => {
+  it("returns agent name when no threadId", () => {
+    expect(instanceKey("claude-code")).toBe("claude-code");
+  });
+
+  it("returns agent:threadId when threadId provided", () => {
+    expect(instanceKey("claude-code", "abc123")).toBe("claude-code:abc123");
+  });
+});
+
+describe("AgentTracker", () => {
+  let tracker: AgentTracker;
+
+  beforeEach(() => {
+    tracker = new AgentTracker();
+  });
+
+  describe("applyEvent / getState", () => {
+    it("returns null for unknown session", () => {
+      expect(tracker.getState("unknown")).toBeNull();
+    });
+
+    it("tracks a single agent event", () => {
+      const event = makeEvent({ status: "running" });
+      tracker.applyEvent(event);
+
+      const state = tracker.getState("main");
+      expect(state).not.toBeNull();
+      expect(state!.status).toBe("running");
+      expect(state!.agent).toBe("claude-code");
+    });
+
+    it("returns highest priority agent", () => {
+      tracker.applyEvent(makeEvent({ agent: "amp", status: "idle" }));
+      tracker.applyEvent(makeEvent({ agent: "claude-code", status: "running" }));
+
+      const state = tracker.getState("main");
+      expect(state!.status).toBe("running");
+    });
+  });
+
+  describe("getAgents", () => {
+    it("returns empty array for unknown session", () => {
+      expect(tracker.getAgents("unknown")).toEqual([]);
+    });
+
+    it("returns all agents for a session sorted by ts desc", () => {
+      tracker.applyEvent(makeEvent({ agent: "amp", ts: 100 }));
+      tracker.applyEvent(makeEvent({ agent: "claude-code", ts: 200 }));
+
+      const agents = tracker.getAgents("main");
+      expect(agents).toHaveLength(2);
+      expect(agents[0]!.agent).toBe("claude-code");
+      expect(agents[1]!.agent).toBe("amp");
+    });
+  });
+
+  describe("getEventTimestamps", () => {
+    it("tracks event timestamps per session", () => {
+      tracker.applyEvent(makeEvent({ ts: 100 }));
+      tracker.applyEvent(makeEvent({ ts: 200 }));
+
+      const timestamps = tracker.getEventTimestamps("main");
+      expect(timestamps).toEqual([100, 200]);
+    });
+
+    it("caps at 30 timestamps", () => {
+      for (let i = 0; i < 40; i++) {
+        tracker.applyEvent(makeEvent({ ts: i }));
+      }
+      const timestamps = tracker.getEventTimestamps("main");
+      expect(timestamps).toHaveLength(30);
+      expect(timestamps[0]).toBe(10);
+    });
+  });
+
+  describe("unseen tracking", () => {
+    it("marks terminal status as unseen when session not active", () => {
+      tracker.applyEvent(makeEvent({ status: "done" }));
+      expect(tracker.isUnseen("main")).toBe(true);
+    });
+
+    it("marks seen on focus", () => {
+      tracker.applyEvent(makeEvent({ status: "done" }));
+      tracker.handleFocus("main");
+      expect(tracker.isUnseen("main")).toBe(false);
+    });
+
+    it("markSeen clears unseen flags", () => {
+      tracker.applyEvent(makeEvent({ status: "error" }));
+      expect(tracker.markSeen("main")).toBe(true);
+      expect(tracker.isUnseen("main")).toBe(false);
+    });
+  });
+
+  describe("dismiss", () => {
+    it("removes an agent instance", () => {
+      tracker.applyEvent(makeEvent({ agent: "claude-code" }));
+      const removed = tracker.dismiss("main", "claude-code");
+      expect(removed).toBe(true);
+      expect(tracker.getState("main")).toBeNull();
+    });
+
+    it("returns false for non-existent agent", () => {
+      expect(tracker.dismiss("main", "nonexistent")).toBe(false);
+    });
+  });
+
+  describe("pruneStuck", () => {
+    it("prunes running agents older than timeout", () => {
+      tracker.applyEvent(makeEvent({ status: "running", ts: Date.now() - 10_000 }));
+      tracker.pruneStuck(5_000);
+      expect(tracker.getState("main")).toBeNull();
+    });
+
+    it("does not prune pinned agents", () => {
+      tracker.applyEvent(makeEvent({ status: "running", ts: Date.now() - 10_000 }));
+      tracker.setPinnedInstances("main", ["claude-code"]);
+      tracker.pruneStuck(5_000);
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+  });
+
+  describe("pruneTerminal", () => {
+    it("prunes seen terminal agents after timeout", () => {
+      const event = makeEvent({ status: "done", ts: Date.now() - 6 * 60 * 1000 });
+      tracker.applyEvent(event);
+      tracker.markSeen("main");
+      tracker.pruneTerminal();
+      expect(tracker.getState("main")).toBeNull();
+    });
+
+    it("does not prune unseen terminal agents", () => {
+      tracker.applyEvent(makeEvent({ status: "done", ts: Date.now() - 6 * 60 * 1000 }));
+      // Don't mark seen
+      tracker.pruneTerminal();
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+  });
+
+  describe("multi-thread support", () => {
+    it("tracks multiple threads for the same agent", () => {
+      tracker.applyEvent(makeEvent({ threadId: "t1", status: "running" }));
+      tracker.applyEvent(makeEvent({ threadId: "t2", status: "done" }));
+
+      const agents = tracker.getAgents("main");
+      expect(agents).toHaveLength(2);
+    });
+
+    it("getState returns highest priority across threads", () => {
+      tracker.applyEvent(makeEvent({ threadId: "t1", status: "done" }));
+      tracker.applyEvent(makeEvent({ threadId: "t2", status: "running" }));
+
+      const state = tracker.getState("main");
+      expect(state!.status).toBe("running");
+    });
+  });
+});

--- a/plugins/tt-agentboard2/packages/runtime/tsconfig.json
+++ b/plugins/tt-agentboard2/packages/runtime/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/plugins/tt-agentboard2/scripts/ensure-sidebar.sh
+++ b/plugins/tt-agentboard2/scripts/ensure-sidebar.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# Ensure the current window has a sidebar pane.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/server-common.sh"
+
+ensure_server || exit 0
+
+CTX=$(tmux display-message -p '#{client_tty}|#{session_name}|#{window_id}' 2>/dev/null)
+curl -s -o /dev/null -X POST "http://${HOST}:${PORT}/ensure-sidebar" -d "$CTX"

--- a/plugins/tt-agentboard2/scripts/focus.ts
+++ b/plugins/tt-agentboard2/scripts/focus.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+// Focus the agentboard2 sidebar pane, or toggle it on if missing.
+
+import { ensureServer, serverUrl, tmuxContext, tmuxDisplay } from "./lib/server-common";
+
+function findSidebarPane(windowId: string): string | null {
+  try {
+    const r = Bun.spawnSync(
+      ["tmux", "list-panes", "-t", windowId, "-F", "#{pane_id} #{pane_title}"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    for (const line of r.stdout.toString().trim().split("\n")) {
+      const [paneId, title] = line.split(" ", 2);
+      if (title === "agentboard2-sidebar" && paneId) return paneId;
+    }
+  } catch {}
+  return null;
+}
+
+function selectPaneAndResetKeys(paneId: string): void {
+  Bun.spawnSync(["tmux", "select-pane", "-t", paneId], { stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(["tmux", "switch-client", "-T", "root"], { stdout: "pipe", stderr: "pipe" });
+}
+
+const windowId = tmuxDisplay("#{window_id}");
+if (!windowId) process.exit(0);
+
+// If sidebar already exists, just focus it
+const existing = findSidebarPane(windowId);
+if (existing) {
+  selectPaneAndResetKeys(existing);
+  process.exit(0);
+}
+
+// Otherwise, ensure server + toggle sidebar on
+if (!(await ensureServer())) process.exit(0);
+
+const ctx = tmuxContext();
+await fetch(serverUrl("/toggle"), { method: "POST", body: ctx }).catch(() => {});
+
+// Wait for sidebar pane to appear
+for (let i = 0; i < 20; i++) {
+  const paneId = findSidebarPane(windowId);
+  if (paneId) {
+    selectPaneAndResetKeys(paneId);
+    process.exit(0);
+  }
+  await Bun.sleep(50);
+}
+
+Bun.spawnSync(["tmux", "switch-client", "-T", "root"], { stdout: "pipe", stderr: "pipe" });

--- a/plugins/tt-agentboard2/scripts/lib/server-common.ts
+++ b/plugins/tt-agentboard2/scripts/lib/server-common.ts
@@ -1,0 +1,72 @@
+import { SERVER_PORT, SERVER_HOST, SERVER_ERR_LOG } from "@tt-agentboard2/runtime";
+
+const PORT = Number(process.env.AGENTBOARD2_PORT) || SERVER_PORT;
+const HOST = process.env.AGENTBOARD2_HOST || SERVER_HOST;
+
+export function resolvePluginDir(): string {
+  if (process.env.AGENTBOARD2_DIR) return process.env.AGENTBOARD2_DIR;
+
+  // Try reading from tmux environment
+  try {
+    const r = Bun.spawnSync(["tmux", "show-environment", "-g", "AGENTBOARD2_DIR"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const line = r.stdout.toString().trim();
+    const eq = line.indexOf("=");
+    if (eq > 0) return line.slice(eq + 1);
+  } catch {}
+
+  // Fallback: walk up from scripts/lib/
+  return new URL("../../", import.meta.url).pathname;
+}
+
+export async function serverAlive(): Promise<boolean> {
+  try {
+    const res = await fetch(`http://${HOST}:${PORT}/`, { signal: AbortSignal.timeout(200) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureServer(): Promise<boolean> {
+  if (await serverAlive()) return true;
+
+  const pluginDir = resolvePluginDir();
+  const serverEntry = `${pluginDir}/apps/server/src/main.ts`;
+
+  const proc = Bun.spawn([process.execPath, "run", serverEntry], {
+    stdio: ["ignore", "ignore", Bun.file(SERVER_ERR_LOG)],
+    cwd: pluginDir,
+    env: { ...process.env, AGENTBOARD2_DIR: pluginDir },
+  });
+  proc.unref();
+
+  for (let i = 0; i < 30; i++) {
+    await Bun.sleep(100);
+    if (await serverAlive()) return true;
+  }
+
+  return false;
+}
+
+export function serverUrl(path: string): string {
+  return `http://${HOST}:${PORT}${path}`;
+}
+
+export function tmuxDisplay(fmt: string): string {
+  try {
+    const r = Bun.spawnSync(["tmux", "display-message", "-p", fmt], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return r.stdout.toString().trim();
+  } catch {
+    return "";
+  }
+}
+
+export function tmuxContext(): string {
+  return tmuxDisplay("#{client_tty}|#{session_name}|#{window_id}");
+}

--- a/plugins/tt-agentboard2/scripts/start.ts
+++ b/plugins/tt-agentboard2/scripts/start.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+// Start agentboard2: launch the server, then open tmux with the plugin loaded.
+
+import { ensureServer, resolvePluginDir } from "./lib/server-common";
+import { join, basename } from "node:path";
+
+const pluginDir = resolvePluginDir();
+const pluginEntry = join(pluginDir, "agentboard2.tmux");
+const sessionName = process.argv[2] || basename(process.cwd());
+
+// 1. Boot the server (spawns in background if not already running)
+const alive = await ensureServer();
+if (!alive) {
+  console.error("Failed to start agentboard2 server. Check /tmp/agentboard2-server-err.log");
+  process.exit(1);
+}
+
+// 2. Check if already inside tmux
+if (process.env.TMUX) {
+  // Already in tmux — just source the plugin to register hooks/keybindings
+  console.log("Already inside tmux. Loading agentboard2 plugin…");
+  Bun.spawnSync(["bash", pluginEntry], {
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { ...process.env, AGENTBOARD2_DIR: pluginDir },
+  });
+  process.exit(0);
+}
+
+// 3. Check if target session already exists
+const checkSession = Bun.spawnSync(["tmux", "has-session", "-t", sessionName], {
+  stdout: "pipe",
+  stderr: "pipe",
+});
+
+if (checkSession.exitCode === 0) {
+  // Session exists — attach and source the plugin
+  console.log(`Attaching to existing tmux session "${sessionName}"…`);
+  Bun.spawnSync(["tmux", "attach-session", "-t", sessionName], {
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  });
+} else {
+  // Create new session (detached), source plugin, then attach
+  Bun.spawnSync(["tmux", "new-session", "-d", "-s", sessionName], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, AGENTBOARD2_DIR: pluginDir },
+  });
+
+  // Source the plugin inside the new session to register hooks + keybindings
+  Bun.spawnSync(["bash", pluginEntry], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, AGENTBOARD2_DIR: pluginDir },
+  });
+
+  // Attach
+  Bun.spawnSync(["tmux", "attach-session", "-t", sessionName], {
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  });
+}

--- a/plugins/tt-agentboard2/scripts/toggle.ts
+++ b/plugins/tt-agentboard2/scripts/toggle.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bun
+// Toggle the agentboard2 sidebar via the server.
+
+import { ensureServer, serverUrl, tmuxContext } from "./lib/server-common";
+
+if (!(await ensureServer())) process.exit(0);
+
+const ctx = tmuxContext();
+await fetch(serverUrl("/toggle"), { method: "POST", body: ctx }).catch(() => {});
+
+// Reset tmux key table
+Bun.spawnSync(["tmux", "switch-client", "-T", "root"], { stdout: "pipe", stderr: "pipe" });

--- a/plugins/tt-agentboard2/tsconfig.json
+++ b/plugins/tt-agentboard2/tsconfig.json
@@ -8,10 +8,12 @@
     "strict": true,
     "strictNullChecks": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
-    "skipDefaultLibCheck": true,
     "skipLibCheck": true,
-    "types": ["node"]
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": ["@types/bun"]
   },
-  "exclude": ["plugins/tt-agentboard", "plugins/tt-agentboard2"]
+  "include": ["apps/**/*.ts", "apps/**/*.tsx", "packages/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 1.7.0
       promptfoo:
         specifier: ^0.121.2
-        version: 0.121.2(@types/better-sqlite3@7.6.13)(@types/json-schema@7.0.15)(@types/node@22.16.3)(pg@8.20.0)(playwright-core@1.58.2)(socks@2.8.7)
+        version: 0.121.2(@types/better-sqlite3@7.6.13)(@types/json-schema@7.0.15)(@types/node@22.16.3)(bun-types@1.3.11)(pg@8.20.0)(playwright-core@1.58.2)(socks@2.8.7)
       simple-git-hooks:
         specifier: ^2.13.0
         version: 2.13.0
@@ -106,7 +106,7 @@ importers:
         version: 14.2.1(vue@3.5.31(typescript@5.8.3))
       '@vueuse/nuxt':
         specifier: ^14.2.1
-        version: 14.2.1(magicast@0.5.2)(nuxt@4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.31(typescript@5.8.3))
+        version: 14.2.1(magicast@0.5.2)(nuxt@4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.31(typescript@5.8.3))
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -115,7 +115,7 @@ importers:
         version: 3.4.2
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3))
@@ -167,13 +167,85 @@ importers:
         version: 0.31.10
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)
+        version: 0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)
       happy-dom:
         specifier: ^20.8.7
         version: 20.8.8
       vitest:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.16.3)(happy-dom@20.8.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  plugins/tt-agentboard2:
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.11
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
+  plugins/tt-agentboard2/apps/server:
+    dependencies:
+      '@tt-agentboard2/mux-tmux':
+        specifier: workspace:*
+        version: link:../../packages/mux-tmux
+      '@tt-agentboard2/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.11
+      typescript:
+        specifier: ^5
+        version: 5.8.3
+
+  plugins/tt-agentboard2/apps/tui:
+    dependencies:
+      '@opentui/core':
+        specifier: ^0.1.88
+        version: 0.1.93(stage-js@1.0.1)(typescript@5.8.3)(web-tree-sitter@0.25.10)
+      '@opentui/solid':
+        specifier: ^0.1.88
+        version: 0.1.93(solid-js@1.9.12)(stage-js@1.0.1)(typescript@5.8.3)(web-tree-sitter@0.25.10)
+      '@tt-agentboard2/mux-tmux':
+        specifier: workspace:*
+        version: link:../../packages/mux-tmux
+      '@tt-agentboard2/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+      solid-js:
+        specifier: ^1.9.11
+        version: 1.9.12
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.11
+      typescript:
+        specifier: ^5
+        version: 5.8.3
+
+  plugins/tt-agentboard2/packages/mux-tmux:
+    dependencies:
+      '@tt-agentboard2/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.11
+      typescript:
+        specifier: ^5
+        version: 5.8.3
+
+  plugins/tt-agentboard2/packages/runtime:
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.11
+      typescript:
+        specifier: ^5
+        version: 5.8.3
 
 packages:
 
@@ -206,6 +278,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@anthropic-ai/claude-agent-sdk@0.2.76':
     resolution: {integrity: sha512-HZxvnT8ZWkzCnQygaYCA0dl8RSUzuVbxE1YG4ecy6vh4nQbTT36CxUxBy+QVdR12pPQluncC0mCOLhI2918Eaw==}
@@ -549,6 +625,10 @@ packages:
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/core@7.28.0':
+    resolution: {integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
@@ -577,6 +657,10 @@ packages:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.18.6':
+    resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -640,8 +724,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-typescript@7.28.6':
     resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.27.1':
+    resolution: {integrity: sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -765,6 +861,9 @@ packages:
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
+
+  '@dimforge/rapier2d-simd-compat@0.17.3':
+    resolution: {integrity: sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1897,6 +1996,118 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@jimp/core@1.6.0':
+    resolution: {integrity: sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==}
+    engines: {node: '>=18'}
+
+  '@jimp/diff@1.6.0':
+    resolution: {integrity: sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==}
+    engines: {node: '>=18'}
+
+  '@jimp/file-ops@1.6.0':
+    resolution: {integrity: sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-bmp@1.6.0':
+    resolution: {integrity: sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-gif@1.6.0':
+    resolution: {integrity: sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-jpeg@1.6.0':
+    resolution: {integrity: sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-png@1.6.0':
+    resolution: {integrity: sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-tiff@1.6.0':
+    resolution: {integrity: sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-blit@1.6.0':
+    resolution: {integrity: sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-blur@1.6.0':
+    resolution: {integrity: sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-circle@1.6.0':
+    resolution: {integrity: sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-color@1.6.0':
+    resolution: {integrity: sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-contain@1.6.0':
+    resolution: {integrity: sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-cover@1.6.0':
+    resolution: {integrity: sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-crop@1.6.0':
+    resolution: {integrity: sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-displace@1.6.0':
+    resolution: {integrity: sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-dither@1.6.0':
+    resolution: {integrity: sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-fisheye@1.6.0':
+    resolution: {integrity: sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-flip@1.6.0':
+    resolution: {integrity: sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-hash@1.6.0':
+    resolution: {integrity: sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-mask@1.6.0':
+    resolution: {integrity: sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-print@1.6.0':
+    resolution: {integrity: sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-quantize@1.6.0':
+    resolution: {integrity: sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-resize@1.6.0':
+    resolution: {integrity: sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-rotate@1.6.0':
+    resolution: {integrity: sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-threshold@1.6.0':
+    resolution: {integrity: sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==}
+    engines: {node: '>=18'}
+
+  '@jimp/types@1.6.0':
+    resolution: {integrity: sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==}
+    engines: {node: '>=18'}
+
+  '@jimp/utils@1.6.0':
+    resolution: {integrity: sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==}
+    engines: {node: '>=18'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2314,6 +2525,46 @@ packages:
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
+
+  '@opentui/core-darwin-arm64@0.1.93':
+    resolution: {integrity: sha512-4I2mwhXLqRNUv7tu88hA6cBGaGpLZXkAa8W0VqBiGDV+Tx337x4T+vbQ7G57OwKXT787oTrEOF9rOOrGLov6qw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.1.93':
+    resolution: {integrity: sha512-jvYMgcg47a5qLhSv1DnQiafEWBQ1UukGutmsYV1TvNuhWtuDXYLVy2AhKIHPzbB9JNrV0IpjbxUC8QnJaP3n8g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opentui/core-linux-arm64@0.1.93':
+    resolution: {integrity: sha512-bvFqRcPftmg14iYmMc3d63XC9rhe4yF7pJRApH6klLBKp27WX/LU0iSO4mvyX7qhy65gcmyy4Sj9dl5jNJ+vlA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opentui/core-linux-x64@0.1.93':
+    resolution: {integrity: sha512-/wJXhwtNxdcpshrRl1KouyGE54ODAHxRQgBHtnlM/F4bB8cjzOlq2Yc+5cv5DxRz4Q0nQZFCPefwpg2U6ZwNdA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opentui/core-win32-arm64@0.1.93':
+    resolution: {integrity: sha512-g3PQobfM2yFPSzkBKRKFp8FgTG4ulWyJcU+GYXjyYmxQIT+ZbOU7UfR//ImRq3/FxUAfUC/MhC6WwjqccjEqBw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@opentui/core-win32-x64@0.1.93':
+    resolution: {integrity: sha512-Spllte2W7q+WfB1zVHgHilVJNp+jpp77PkkxTWyMQNvT7vJNt9LABMNjGTGiJBBMkAuKvO0GgFNKxrda7tFKrQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentui/core@0.1.93':
+    resolution: {integrity: sha512-HlTM16ZiBKN0mPBNMHSILkSrbzNku6Pg/ovIpVVkEPqLeWeSC2bfZS4Uhc0Ej1sckVVVoU9HKBJanfHvpP+pMg==}
+    peerDependencies:
+      web-tree-sitter: 0.25.10
+
+  '@opentui/solid@0.1.93':
+    resolution: {integrity: sha512-Qx+4qoLSjnRGoo/YY4sZJMyXj09Y5kaAMpVO+65Ax58MMj4TjABN4bOOiRT2KV7sKOMTjxiAgXAIaBuqBBJ0Qg==}
+    peerDependencies:
+      solid-js: 1.9.11
 
   '@oxc-minify/binding-android-arm-eabi@0.117.0':
     resolution: {integrity: sha512-5Hf2KsGRjxp3HnPU/mse7cQJa5tWfMFUPZQcgSMVsv2JZnGFFOIDzA0Oja2KDD+VPJqMpEJKc2dCHAGZgJxsGg==}
@@ -3614,6 +3865,9 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/bun@1.3.11':
+    resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3640,6 +3894,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@16.9.1':
+    resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
@@ -3917,6 +4174,9 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
+
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
@@ -4026,6 +4286,9 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
+  any-base@1.1.0:
+    resolution: {integrity: sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -4107,6 +4370,10 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  await-to-js@3.0.0:
+    resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
+    engines: {node: '>=6.0.0'}
+
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
@@ -4116,6 +4383,23 @@ packages:
       react-native-b4a: '*'
     peerDependenciesMeta:
       react-native-b4a:
+        optional: true
+
+  babel-plugin-jsx-dom-expressions@0.40.6:
+    resolution: {integrity: sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  babel-plugin-module-resolver@5.0.2:
+    resolution: {integrity: sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==}
+
+  babel-preset-solid@1.9.10:
+    resolution: {integrity: sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      solid-js: ^1.9.10
+    peerDependenciesMeta:
+      solid-js:
         optional: true
 
   balanced-match@1.0.2:
@@ -4223,6 +4507,9 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  bmp-ts@1.0.9:
+    resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -4280,6 +4567,37 @@ packages:
     resolution: {integrity: sha512-VzJhB4iyZ04w99HreEvXJY/lxzApnE/PRbcFY4cKnOUSRVbRbAf0AIU0DeavrkffW+mclJlkmnQYn9NdwcBk1g==}
     engines: {node: '>=18'}
     hasBin: true
+
+  bun-ffi-structs@0.1.2:
+    resolution: {integrity: sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==}
+    peerDependencies:
+      typescript: ^5
+
+  bun-types@1.3.11:
+    resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
+
+  bun-webgpu-darwin-arm64@0.1.6:
+    resolution: {integrity: sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  bun-webgpu-darwin-x64@0.1.6:
+    resolution: {integrity: sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng==}
+    cpu: [x64]
+    os: [darwin]
+
+  bun-webgpu-linux-x64@0.1.6:
+    resolution: {integrity: sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA==}
+    cpu: [x64]
+    os: [linux]
+
+  bun-webgpu-win32-x64@0.1.6:
+    resolution: {integrity: sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg==}
+    cpu: [x64]
+    os: [win32]
+
+  bun-webgpu@0.1.5:
+    resolution: {integrity: sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -4833,6 +5151,10 @@ packages:
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
+  diff@8.0.2:
+    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+    engines: {node: '>=0.3.1'}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -5201,6 +5523,9 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  exif-parser@0.1.12:
+    resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -5310,6 +5635,10 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-type@16.5.4:
+    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
+    engines: {node: '>=10'}
+
   file-type@21.3.2:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
     engines: {node: '>=20'}
@@ -5327,6 +5656,13 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-babel-config@2.1.2:
+    resolution: {integrity: sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==}
+
+  find-up@3.0.0:
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
+    engines: {node: '>=6'}
 
   flatbuffers@25.9.23:
     resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
@@ -5478,6 +5814,9 @@ packages:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
 
+  gifwrap@0.10.1:
+    resolution: {integrity: sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==}
+
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
@@ -5508,6 +5847,11 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  glob@9.3.5:
+    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
+    engines: {node: '>=16 || 14 >=14.17'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
@@ -5608,6 +5952,9 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-entities@2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -5674,6 +6021,9 @@ packages:
 
   image-meta@0.2.2:
     resolution: {integrity: sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==}
+
+  image-q@4.0.0:
+    resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
 
   impound@1.1.5:
     resolution: {integrity: sha512-5AUn+QE0UofqNHu5f2Skf6Svukdg4ehOIq8O0EtqIx4jta0CDZYBPqpIHt0zrlUTiFVYlLpeH39DoikXBjPKpA==}
@@ -5909,6 +6259,10 @@ packages:
   javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
 
+  jimp@1.6.0:
+    resolution: {integrity: sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==}
+    engines: {node: '>=18'}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -5922,6 +6276,9 @@ packages:
 
   jose@6.2.1:
     resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
 
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
@@ -6104,6 +6461,10 @@ packages:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
 
+  locate-path@3.0.0:
+    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
+    engines: {node: '>=6'}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
@@ -6186,6 +6547,11 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -6262,6 +6628,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
     engines: {node: '>=16'}
@@ -6294,12 +6665,20 @@ packages:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
+  minimatch@8.0.7:
+    resolution: {integrity: sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@4.2.8:
+    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
+    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -6575,6 +6954,9 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  omggif@1.0.10:
+    resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
+
   on-change@6.0.2:
     resolution: {integrity: sha512-08+12qcOVEA0fS9g/VxKS27HaT94nRutUT77J2dr8zv/unzXopvhBuF8tNLWsoLQ5IgrQ6eptGeGqUYat82U1w==}
     engines: {node: '>=20'}
@@ -6694,6 +7076,14 @@ packages:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@3.0.0:
+    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
+    engines: {node: '>=6'}
+
   p-queue-compat@1.0.225:
     resolution: {integrity: sha512-SdfGSQSJJpD7ZR+dJEjjn9GuuBizHPLW/yarJpXnmrHRruzrq7YM8OqsikSrKeoPv+Pi1YXw9IIBSIg5WveQHA==}
     engines: {node: '>=12'}
@@ -6714,6 +7104,10 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
     engines: {node: '>= 14'}
@@ -6728,9 +7122,24 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  parse-bmfont-ascii@1.0.6:
+    resolution: {integrity: sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==}
+
+  parse-bmfont-binary@1.0.6:
+    resolution: {integrity: sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==}
+
+  parse-bmfont-xml@1.1.6:
+    resolution: {integrity: sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==}
+
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -6742,6 +7151,10 @@ packages:
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-exists@3.0.0:
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
 
   path-expression-matcher@1.1.3:
     resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
@@ -6790,6 +7203,10 @@ packages:
   pdfjs-dist@5.4.296:
     resolution: {integrity: sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==}
     engines: {node: '>=20.16.0 || >=22.3.0'}
+
+  peek-readable@4.1.0:
+    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
+    engines: {node: '>=8'}
 
   pem@1.14.8:
     resolution: {integrity: sha512-ZpbOf4dj9/fQg5tQzTqv4jSKJQsK7tPl0pm4/pvPcZVjZcJg7TMfr3PBk6gJH97lnpJDu4e4v8UUqEz5daipCg==}
@@ -6870,6 +7287,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pixelmatch@5.3.0:
+    resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
+    hasBin: true
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -6879,6 +7300,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  pkg-up@3.1.0:
+    resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
+    engines: {node: '>=8'}
+
+  planck@1.4.3:
+    resolution: {integrity: sha512-B+lHKhRSeg7vZOfEyEzyQVu7nx8JHcX3QgnAcHXrPW0j04XYKX5eXSiUrxH2Z5QR8OoqvjD6zKIaPMdMYAd0uA==}
+    engines: {node: '>=24.0'}
+    peerDependencies:
+      stage-js: ^1.0.0-alpha.12
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
@@ -6904,6 +7335,14 @@ packages:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
@@ -7336,6 +7775,10 @@ packages:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  readable-web-to-node-stream@3.0.4:
+    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
+    engines: {node: '>=8'}
+
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
@@ -7382,6 +7825,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@4.1.8:
+    resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -7483,6 +7929,9 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  s-js@0.4.9:
+    resolution: {integrity: sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -7545,6 +7994,12 @@ packages:
   serialize-javascript@7.0.5:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
+
+  seroval-plugins@1.5.1:
+    resolution: {integrity: sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
 
   seroval@1.5.1:
     resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
@@ -7625,6 +8080,10 @@ packages:
   simple-git@3.33.0:
     resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
 
+  simple-xml-to-json@1.2.4:
+    resolution: {integrity: sha512-3MY16e0ocMHL7N1ufpdObURGyX+lCo0T/A+y6VCwosLdH1HSda4QZl1Sdt/O+2qWp48WFi26XEp5rF0LoaL0Dg==}
+    engines: {node: '>=20.12.2'}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -7670,6 +8129,9 @@ packages:
   socks@2.8.7:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  solid-js@1.9.12:
+    resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
   sortablejs@1.14.0:
     resolution: {integrity: sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==}
@@ -7722,6 +8184,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stage-js@1.0.1:
+    resolution: {integrity: sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw==}
+    engines: {node: '>=18.0'}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -7806,6 +8272,10 @@ packages:
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
+
+  strtok3@6.3.0:
+    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
+    engines: {node: '>=10'}
 
   structured-clone-es@2.0.0:
     resolution: {integrity: sha512-5UuAHmBLXYPCl22xWJrFuGmIhBKQzxISPVz6E7nmTmTcAOpUzlbjKJsRrCE4vADmMQ0dzeCnlWn9XufnAGf76Q==}
@@ -7920,6 +8390,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  three@0.177.0:
+    resolution: {integrity: sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==}
+
   tiny-emitter@2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
 
@@ -7932,6 +8405,9 @@ packages:
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -7970,6 +8446,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  token-types@4.2.1:
+    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
+    engines: {node: '>=10'}
 
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
@@ -8228,6 +8708,9 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
+  utif2@4.1.0:
+    resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -8475,6 +8958,14 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -8597,6 +9088,17 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-parse-from-string@1.0.1:
+    resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
+
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -8669,6 +9171,9 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.0.5:
     resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
 
@@ -8710,6 +9215,11 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@anthropic-ai/claude-agent-sdk@0.2.76(zod@4.3.6)':
     dependencies:
@@ -9709,6 +10219,26 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
+  '@babel/core@7.28.0':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/core@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -9749,6 +10279,19 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -9771,10 +10314,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.18.6':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9792,6 +10348,15 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -9824,15 +10389,44 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -9842,6 +10436,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.27.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.28.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9953,6 +10558,9 @@ snapshots:
       '@so-ric/colorspace': 1.1.6
       enabled: 2.0.0
       kuler: 2.0.0
+
+  '@dimforge/rapier2d-simd-compat@0.17.3':
+    optional: true
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -10660,6 +11268,195 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  '@jimp/core@1.6.0':
+    dependencies:
+      '@jimp/file-ops': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      await-to-js: 3.0.0
+      exif-parser: 0.1.12
+      file-type: 16.5.4
+      mime: 3.0.0
+
+  '@jimp/diff@1.6.0':
+    dependencies:
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      pixelmatch: 5.3.0
+
+  '@jimp/file-ops@1.6.0': {}
+
+  '@jimp/js-bmp@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      bmp-ts: 1.0.9
+
+  '@jimp/js-gif@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      gifwrap: 0.10.1
+      omggif: 1.0.10
+
+  '@jimp/js-jpeg@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      jpeg-js: 0.4.4
+
+  '@jimp/js-png@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      pngjs: 7.0.0
+
+  '@jimp/js-tiff@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      utif2: 4.1.0
+
+  '@jimp/plugin-blit@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-blur@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/utils': 1.6.0
+
+  '@jimp/plugin-circle@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-color@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      tinycolor2: 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-contain@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/plugin-blit': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-cover@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/plugin-crop': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-crop@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-displace@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-dither@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+
+  '@jimp/plugin-fisheye@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-flip@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-hash@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/js-bmp': 1.6.0
+      '@jimp/js-jpeg': 1.6.0
+      '@jimp/js-png': 1.6.0
+      '@jimp/js-tiff': 1.6.0
+      '@jimp/plugin-color': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      any-base: 1.1.0
+
+  '@jimp/plugin-mask@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-print@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/js-jpeg': 1.6.0
+      '@jimp/js-png': 1.6.0
+      '@jimp/plugin-blit': 1.6.0
+      '@jimp/types': 1.6.0
+      parse-bmfont-ascii: 1.0.6
+      parse-bmfont-binary: 1.0.6
+      parse-bmfont-xml: 1.1.6
+      simple-xml-to-json: 1.2.4
+      zod: 3.25.76
+
+  '@jimp/plugin-quantize@1.6.0':
+    dependencies:
+      image-q: 4.0.0
+      zod: 3.25.76
+
+  '@jimp/plugin-resize@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-rotate@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/plugin-crop': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-threshold@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/plugin-color': 1.6.0
+      '@jimp/plugin-hash': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/types@1.6.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@jimp/utils@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      tinycolor2: 1.6.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -10969,7 +11766,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.2(77e7b2854dac39de7d0cef2ca1851c8a)':
+  '@nuxt/nitro-server@4.4.2(1247b362c4e8fa4c38b1d55e54a29e7b)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -10987,8 +11784,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))
-      nuxt: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      nitropack: 2.13.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))
+      nuxt: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10997,7 +11794,7 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unctx: 2.5.0
-      unstorage: 1.17.4(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(ioredis@5.10.1)
+      unstorage: 1.17.4(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(ioredis@5.10.1)
       vue: 3.5.31(typescript@5.8.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -11098,7 +11895,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/vite-builder@4.4.2(dd839b50674035c9ad8b6a16b9710716)':
+  '@nuxt/vite-builder@4.4.2(e10e33fa6d4d6fa8883e8a49ad7169be)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.0)
@@ -11116,7 +11913,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -11375,6 +12172,63 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentui/core-darwin-arm64@0.1.93':
+    optional: true
+
+  '@opentui/core-darwin-x64@0.1.93':
+    optional: true
+
+  '@opentui/core-linux-arm64@0.1.93':
+    optional: true
+
+  '@opentui/core-linux-x64@0.1.93':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.1.93':
+    optional: true
+
+  '@opentui/core-win32-x64@0.1.93':
+    optional: true
+
+  '@opentui/core@0.1.93(stage-js@1.0.1)(typescript@5.8.3)(web-tree-sitter@0.25.10)':
+    dependencies:
+      bun-ffi-structs: 0.1.2(typescript@5.8.3)
+      diff: 8.0.2
+      jimp: 1.6.0
+      marked: 17.0.1
+      web-tree-sitter: 0.25.10
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@dimforge/rapier2d-simd-compat': 0.17.3
+      '@opentui/core-darwin-arm64': 0.1.93
+      '@opentui/core-darwin-x64': 0.1.93
+      '@opentui/core-linux-arm64': 0.1.93
+      '@opentui/core-linux-x64': 0.1.93
+      '@opentui/core-win32-arm64': 0.1.93
+      '@opentui/core-win32-x64': 0.1.93
+      bun-webgpu: 0.1.5
+      planck: 1.4.3(stage-js@1.0.1)
+      three: 0.177.0
+    transitivePeerDependencies:
+      - stage-js
+      - typescript
+
+  '@opentui/solid@0.1.93(solid-js@1.9.12)(stage-js@1.0.1)(typescript@5.8.3)(web-tree-sitter@0.25.10)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
+      '@opentui/core': 0.1.93(stage-js@1.0.1)(typescript@5.8.3)(web-tree-sitter@0.25.10)
+      babel-plugin-module-resolver: 5.0.2
+      babel-preset-solid: 1.9.10(@babel/core@7.28.0)(solid-js@1.9.12)
+      entities: 7.0.1
+      s-js: 0.4.9
+      solid-js: 1.9.12
+    transitivePeerDependencies:
+      - stage-js
+      - supports-color
+      - typescript
+      - web-tree-sitter
 
   '@oxc-minify/binding-android-arm-eabi@0.117.0':
     optional: true
@@ -12480,8 +13334,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@tokenizer/token@0.3.0':
-    optional: true
+  '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -12493,6 +13346,10 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.16.3
+
+  '@types/bun@1.3.11':
+    dependencies:
+      bun-types: 1.3.11
 
   '@types/chai@5.2.3':
     dependencies:
@@ -12520,6 +13377,8 @@ snapshots:
 
   '@types/ms@2.1.0':
     optional: true
+
+  '@types/node@16.9.1': {}
 
   '@types/node@18.19.130':
     dependencies:
@@ -12887,13 +13746,13 @@ snapshots:
 
   '@vueuse/metadata@14.2.1': {}
 
-  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.31(typescript@5.8.3))':
+  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.31(typescript@5.8.3))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.8.3))
       '@vueuse/metadata': 14.2.1
       local-pkg: 1.1.2
-      nuxt: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       vue: 3.5.31(typescript@5.8.3)
     transitivePeerDependencies:
       - magicast
@@ -12901,6 +13760,9 @@ snapshots:
   '@vueuse/shared@14.2.1(vue@3.5.31(typescript@5.8.3))':
     dependencies:
       vue: 3.5.31(typescript@5.8.3)
+
+  '@webgpu/types@0.1.69':
+    optional: true
 
   '@xmldom/xmldom@0.8.11':
     optional: true
@@ -12987,6 +13849,8 @@ snapshots:
   ansis@3.17.0: {}
 
   ansis@4.2.0: {}
+
+  any-base@1.1.0: {}
 
   any-promise@1.3.0: {}
 
@@ -13090,6 +13954,8 @@ snapshots:
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
+  await-to-js@3.0.0: {}
+
   axios@1.13.6(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -13100,6 +13966,30 @@ snapshots:
     optional: true
 
   b4a@1.8.0: {}
+
+  babel-plugin-jsx-dom-expressions@0.40.6(@babel/core@7.28.0):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.0)
+      '@babel/types': 7.29.0
+      html-entities: 2.3.3
+      parse5: 7.3.0
+
+  babel-plugin-module-resolver@5.0.2:
+    dependencies:
+      find-babel-config: 2.1.2
+      glob: 9.3.5
+      pkg-up: 3.1.0
+      reselect: 4.1.8
+      resolve: 1.22.11
+
+  babel-preset-solid@1.9.10(@babel/core@7.28.0)(solid-js@1.9.12):
+    dependencies:
+      '@babel/core': 7.28.0
+      babel-plugin-jsx-dom-expressions: 0.40.6(@babel/core@7.28.0)
+    optionalDependencies:
+      solid-js: 1.9.12
 
   balanced-match@1.0.2: {}
 
@@ -13184,6 +14074,8 @@ snapshots:
   bluebird@3.7.2:
     optional: true
 
+  bmp-ts@1.0.9: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -13265,6 +14157,36 @@ snapshots:
       yaml: 2.8.3
     transitivePeerDependencies:
       - magicast
+
+  bun-ffi-structs@0.1.2(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
+  bun-types@1.3.11:
+    dependencies:
+      '@types/node': 22.16.3
+
+  bun-webgpu-darwin-arm64@0.1.6:
+    optional: true
+
+  bun-webgpu-darwin-x64@0.1.6:
+    optional: true
+
+  bun-webgpu-linux-x64@0.1.6:
+    optional: true
+
+  bun-webgpu-win32-x64@0.1.6:
+    optional: true
+
+  bun-webgpu@0.1.5:
+    dependencies:
+      '@webgpu/types': 0.1.69
+    optionalDependencies:
+      bun-webgpu-darwin-arm64: 0.1.6
+      bun-webgpu-darwin-x64: 0.1.6
+      bun-webgpu-linux-x64: 0.1.6
+      bun-webgpu-win32-x64: 0.1.6
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -13689,10 +14611,10 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)):
+  db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)):
     optionalDependencies:
       better-sqlite3: 12.8.0
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)
 
   debounce@3.0.0: {}
 
@@ -13779,6 +14701,8 @@ snapshots:
 
   didyoumean@1.2.2: {}
 
+  diff@8.0.2: {}
+
   diff@8.0.4: {}
 
   dlv@1.1.3: {}
@@ -13819,11 +14743,12 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0):
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.8.0
+      bun-types: 1.3.11
       pg: 8.20.0
 
   dunder-proto@1.0.1:
@@ -14176,6 +15101,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  exif-parser@0.1.12: {}
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
@@ -14299,6 +15226,12 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-type@16.5.4:
+    dependencies:
+      readable-web-to-node-stream: 3.0.4
+      strtok3: 6.3.0
+      token-types: 4.2.1
+
   file-type@21.3.2:
     dependencies:
       '@tokenizer/inflate': 0.4.1
@@ -14329,6 +15262,14 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-babel-config@2.1.2:
+    dependencies:
+      json5: 2.2.3
+
+  find-up@3.0.0:
+    dependencies:
+      locate-path: 3.0.0
 
   flatbuffers@25.9.23:
     optional: true
@@ -14488,6 +15429,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  gifwrap@0.10.1:
+    dependencies:
+      image-q: 4.0.0
+      omggif: 1.0.10
+
   giget@2.0.0:
     dependencies:
       citty: 0.1.6
@@ -14532,6 +15478,13 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  glob@9.3.5:
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 8.0.7
+      minipass: 4.2.8
+      path-scurry: 1.11.1
 
   global-agent@3.0.0:
     dependencies:
@@ -14660,6 +15613,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-entities@2.3.3: {}
+
   html-escaper@2.0.2: {}
 
   http-assert@1.5.0:
@@ -14748,6 +15703,10 @@ snapshots:
   ignore@7.0.5: {}
 
   image-meta@0.2.2: {}
+
+  image-q@4.0.0:
+    dependencies:
+      '@types/node': 16.9.1
 
   impound@1.1.5:
     dependencies:
@@ -14976,6 +15935,36 @@ snapshots:
 
   javascript-natural-sort@0.7.1: {}
 
+  jimp@1.6.0:
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/diff': 1.6.0
+      '@jimp/js-bmp': 1.6.0
+      '@jimp/js-gif': 1.6.0
+      '@jimp/js-jpeg': 1.6.0
+      '@jimp/js-png': 1.6.0
+      '@jimp/js-tiff': 1.6.0
+      '@jimp/plugin-blit': 1.6.0
+      '@jimp/plugin-blur': 1.6.0
+      '@jimp/plugin-circle': 1.6.0
+      '@jimp/plugin-color': 1.6.0
+      '@jimp/plugin-contain': 1.6.0
+      '@jimp/plugin-cover': 1.6.0
+      '@jimp/plugin-crop': 1.6.0
+      '@jimp/plugin-displace': 1.6.0
+      '@jimp/plugin-dither': 1.6.0
+      '@jimp/plugin-fisheye': 1.6.0
+      '@jimp/plugin-flip': 1.6.0
+      '@jimp/plugin-hash': 1.6.0
+      '@jimp/plugin-mask': 1.6.0
+      '@jimp/plugin-print': 1.6.0
+      '@jimp/plugin-quantize': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/plugin-rotate': 1.6.0
+      '@jimp/plugin-threshold': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
@@ -14987,6 +15976,8 @@ snapshots:
       node-rsa: 1.1.1
 
   jose@6.2.1: {}
+
+  jpeg-js@0.4.4: {}
 
   js-beautify@1.15.4:
     dependencies:
@@ -15237,6 +16228,11 @@ snapshots:
       pkg-types: 2.3.0
       quansync: 0.2.11
 
+  locate-path@3.0.0:
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+
   lodash.defaults@4.2.0: {}
 
   lodash.includes@4.3.0:
@@ -15324,6 +16320,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  marked@17.0.1: {}
+
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
@@ -15395,6 +16393,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@3.0.0: {}
+
   mime@4.1.0: {}
 
   mimic-fn@2.1.0: {}
@@ -15417,11 +16417,17 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minimatch@8.0.7:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minipass@4.2.8: {}
 
   minipass@7.1.3: {}
 
@@ -15553,7 +16559,7 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.34.9
 
-  nitropack@2.13.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)):
+  nitropack@2.13.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.0)
@@ -15574,7 +16580,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))
+      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -15620,7 +16626,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.0.2
       unplugin-utils: 0.3.1
-      unstorage: 1.17.4(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(ioredis@5.10.1)
+      unstorage: 1.17.4(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(ioredis@5.10.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.0
@@ -15727,16 +16733,16 @@ snapshots:
     optionalDependencies:
       chokidar: 5.0.0
 
-  nuxt@4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
+  nuxt@4.4.2(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(oxlint@1.7.0)(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.8.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@22.16.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@5.8.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(77e7b2854dac39de7d0cef2ca1851c8a)
+      '@nuxt/nitro-server': 4.4.2(1247b362c4e8fa4c38b1d55e54a29e7b)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(dd839b50674035c9ad8b6a16b9710716)
+      '@nuxt/vite-builder': 4.4.2(e10e33fa6d4d6fa8883e8a49ad7169be)
       '@unhead/vue': 2.1.12(vue@3.5.31(typescript@5.8.3))
       '@vue/shared': 3.5.31
       c12: 3.3.3(magicast@0.5.2)
@@ -15891,6 +16897,8 @@ snapshots:
   ofetch@2.0.0-alpha.3: {}
 
   ohash@2.0.11: {}
+
+  omggif@1.0.10: {}
 
   on-change@6.0.2: {}
 
@@ -16097,6 +17105,14 @@ snapshots:
   p-finally@1.0.0:
     optional: true
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@3.0.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-queue-compat@1.0.225:
     dependencies:
       eventemitter3: 5.0.4
@@ -16123,6 +17139,8 @@ snapshots:
       p-finally: 1.0.0
     optional: true
 
+  p-try@2.2.0: {}
+
   pac-proxy-agent@7.2.0:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
@@ -16145,7 +17163,22 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@1.0.11: {}
+
+  parse-bmfont-ascii@1.0.6: {}
+
+  parse-bmfont-binary@1.0.6: {}
+
+  parse-bmfont-xml@1.1.6:
+    dependencies:
+      xml-parse-from-string: 1.0.1
+      xml2js: 0.5.0
+
   parse-ms@4.0.0: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.0:
     dependencies:
@@ -16154,6 +17187,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   patch-console@2.0.0: {}
+
+  path-exists@3.0.0: {}
 
   path-expression-matcher@1.1.3: {}
 
@@ -16193,6 +17228,8 @@ snapshots:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.80
     optional: true
+
+  peek-readable@4.1.0: {}
 
   pem@1.14.8:
     dependencies:
@@ -16268,6 +17305,10 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pixelmatch@5.3.0:
+    dependencies:
+      pngjs: 6.0.0
+
   pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
@@ -16281,6 +17322,15 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  pkg-up@3.1.0:
+    dependencies:
+      find-up: 3.0.0
+
+  planck@1.4.3(stage-js@1.0.1):
+    dependencies:
+      stage-js: 1.0.1
+    optional: true
 
   platform@1.3.6:
     optional: true
@@ -16304,6 +17354,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
     optional: true
+
+  pngjs@6.0.0: {}
+
+  pngjs@7.0.0: {}
 
   portfinder@1.0.38:
     dependencies:
@@ -16563,7 +17617,7 @@ snapshots:
 
   process@0.11.10: {}
 
-  promptfoo@0.121.2(@types/better-sqlite3@7.6.13)(@types/json-schema@7.0.15)(@types/node@22.16.3)(pg@8.20.0)(playwright-core@1.58.2)(socks@2.8.7):
+  promptfoo@0.121.2(@types/better-sqlite3@7.6.13)(@types/json-schema@7.0.15)(@types/node@22.16.3)(bun-types@1.3.11)(pg@8.20.0)(playwright-core@1.58.2)(socks@2.8.7):
     dependencies:
       '@anthropic-ai/sdk': 0.78.0(zod@4.3.6)
       '@apidevtools/json-schema-ref-parser': 15.3.1(@types/json-schema@7.0.15)
@@ -16604,7 +17658,7 @@ snapshots:
       debounce: 3.0.0
       dedent: 1.7.2
       dotenv: 17.3.1
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)
       execa: 9.6.1
       express: 5.2.1
       exsolve: 1.0.8
@@ -16943,6 +17997,10 @@ snapshots:
       process: 0.11.10
       string_decoder: 1.3.0
 
+  readable-web-to-node-stream@3.0.4:
+    dependencies:
+      readable-stream: 4.7.0
+
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.6
@@ -16986,6 +18044,8 @@ snapshots:
 
   requires-port@1.0.0:
     optional: true
+
+  reselect@4.1.8: {}
 
   resolve-from@5.0.0: {}
 
@@ -17141,6 +18201,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  s-js@0.4.9: {}
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -17198,6 +18260,10 @@ snapshots:
     optional: true
 
   serialize-javascript@7.0.5: {}
+
+  seroval-plugins@1.5.1(seroval@1.5.1):
+    dependencies:
+      seroval: 1.5.1
 
   seroval@1.5.1: {}
 
@@ -17321,6 +18387,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  simple-xml-to-json@1.2.4: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -17394,6 +18462,12 @@ snapshots:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
 
+  solid-js@1.9.12:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.1
+      seroval-plugins: 1.5.1(seroval@1.5.1)
+
   sortablejs@1.14.0: {}
 
   source-map-js@1.2.1: {}
@@ -17431,6 +18505,9 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
+
+  stage-js@1.0.1:
+    optional: true
 
   standard-as-callback@2.1.0: {}
 
@@ -17515,6 +18592,11 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
     optional: true
+
+  strtok3@6.3.0:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      peek-readable: 4.1.0
 
   structured-clone-es@2.0.0: {}
 
@@ -17683,6 +18765,9 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  three@0.177.0:
+    optional: true
+
   tiny-emitter@2.1.0: {}
 
   tiny-invariant@1.3.3: {}
@@ -17690,6 +18775,8 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyclip@0.1.12: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -17720,6 +18807,11 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  token-types@4.2.1:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   token-types@6.1.2:
     dependencies:
@@ -17894,7 +18986,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.3
 
-  unstorage@1.17.4(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0)))(ioredis@5.10.1):
+  unstorage@1.17.4(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)))(ioredis@5.10.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -17907,7 +18999,7 @@ snapshots:
     optionalDependencies:
       '@azure/identity': 4.13.0
       '@azure/storage-blob': 12.31.0
-      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(pg@8.20.0))
+      db0: 0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0))
       ioredis: 5.10.1
 
   untun@0.1.3:
@@ -17957,6 +19049,10 @@ snapshots:
     optional: true
 
   url-template@2.0.8: {}
+
+  utif2@4.1.0:
+    dependencies:
+      pako: 1.0.11
 
   util-deprecate@1.0.2: {}
 
@@ -18218,6 +19314,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  web-tree-sitter@0.25.10: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0:
@@ -18331,6 +19429,15 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
+  xml-parse-from-string@1.0.1: {}
+
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
   xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
@@ -18399,6 +19506,8 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.0.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - "plugins/tt-agentboard"
+  - "plugins/tt-agentboard2"
+  - "plugins/tt-agentboard2/apps/*"
+  - "plugins/tt-agentboard2/packages/*"

--- a/src/commands/agentboard2.ts
+++ b/src/commands/agentboard2.ts
@@ -1,0 +1,280 @@
+import { Args } from "@oclif/core";
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import consola from "consola";
+import { colors } from "consola/utils";
+import { BaseCommand } from "./base.js";
+
+const PLUGIN_DIR = resolve(import.meta.dirname, "../../plugins/tt-agentboard2");
+
+// Keybinding defaults
+const DEFAULT_KEY = "a";
+const TMUX_BINDINGS = { toggle: "t", focus: "s" } as const;
+const RUN_SHELL_LINE = `run-shell '${PLUGIN_DIR}/agentboard2.tmux'`;
+const MARKER = "# agentboard2";
+
+function findTmuxConf(): string | null {
+  const candidates = [
+    resolve(process.env.HOME ?? "~", ".tmux.conf"),
+    resolve(process.env.HOME ?? "~", ".config/tmux/tmux.conf"),
+  ];
+  for (const path of candidates) {
+    try {
+      const real = existsSync(path) ? path : null;
+      if (real) return real;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export default class Agentboard2 extends BaseCommand {
+  static override aliases = ["ag2"];
+  static override description = "AgentBoard2 — opensessions-style tmux TUI sidebar";
+
+  static override examples = [
+    {
+      description: "Install agentboard2 into tmux",
+      command: "<%= config.bin %> agentboard2 setup",
+    },
+    {
+      description: "Uninstall from tmux",
+      command: "<%= config.bin %> agentboard2 uninstall",
+    },
+    {
+      description: "Launch the server",
+      command: "<%= config.bin %> agentboard2 server",
+    },
+    {
+      description: "Launch the TUI directly",
+      command: "<%= config.bin %> agentboard2 tui",
+    },
+  ];
+
+  static override args = {
+    subcommand: Args.string({
+      description: "Subcommand: setup, uninstall, server, tui, keys",
+      required: false,
+      options: ["setup", "uninstall", "server", "tui", "start", "keys"],
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(Agentboard2);
+
+    switch (args.subcommand) {
+      case "setup":
+        this.setup();
+        break;
+      case "uninstall":
+        this.uninstall();
+        break;
+      case "server":
+        this.startServer();
+        break;
+      case "tui":
+        this.startTui();
+        break;
+      case "start":
+        // For backwards compat, start = tui
+        this.startTui();
+        break;
+      case "keys":
+        this.showKeys();
+        break;
+      default:
+        this.showKeys();
+        break;
+    }
+  }
+
+  private ensureDeps(): void {
+    // Check bun is installed
+    try {
+      execSync("bun --version", { stdio: "pipe" });
+    } catch {
+      this.error("bun is required but not found. Install: https://bun.sh");
+    }
+
+    // Install deps if needed for runtime package
+    const runtimeNodeModules = resolve(PLUGIN_DIR, "packages/runtime/node_modules");
+    if (!existsSync(runtimeNodeModules)) {
+      consola.info("Installing agentboard2 dependencies...");
+      execSync("pnpm install", { cwd: PLUGIN_DIR, stdio: "inherit" });
+    }
+  }
+
+  private setup(): void {
+    this.ensureDeps();
+
+    // Find tmux.conf
+    const confPath = findTmuxConf();
+    if (!confPath) {
+      consola.warn("No tmux.conf found. Add this line manually:");
+      consola.info(colors.cyan(`  ${RUN_SHELL_LINE}`));
+      return;
+    }
+
+    // If it's a symlink, resolve to the real file for editing
+    let editPath = confPath;
+    try {
+      editPath = realpathSync(confPath);
+    } catch {
+      // keep confPath
+    }
+
+    // Check if already installed
+    const content = readFileSync(editPath, "utf8");
+    if (content.includes("agentboard2.tmux")) {
+      consola.success("Already installed in tmux.conf");
+      this.reloadTmux();
+      return;
+    }
+
+    // Add run-shell line before TPM init
+    const tpmLine = "run '~/.config/tmux/plugins/tpm/tpm'";
+    const altTpmLine = "run-shell '~/.tmux/plugins/tpm/tpm'";
+    const insertLines = `\n${MARKER}\n${RUN_SHELL_LINE}\n`;
+
+    let newContent: string;
+    if (content.includes(tpmLine)) {
+      newContent = content.replace(tpmLine, `${insertLines}\n${tpmLine}`);
+    } else if (content.includes(altTpmLine)) {
+      newContent = content.replace(altTpmLine, `${insertLines}\n${altTpmLine}`);
+    } else {
+      // No TPM found, append to end
+      newContent = content + insertLines;
+    }
+
+    writeFileSync(editPath, newContent);
+    consola.success(`Added agentboard2 to ${editPath}`);
+
+    this.reloadTmux();
+    this.showKeys();
+  }
+
+  private uninstall(): void {
+    const confPath = findTmuxConf();
+    if (!confPath) {
+      consola.info("No tmux.conf found.");
+      return;
+    }
+
+    let editPath = confPath;
+    try {
+      editPath = realpathSync(confPath);
+    } catch {
+      // keep confPath
+    }
+
+    const content = readFileSync(editPath, "utf8");
+    if (!content.includes("agentboard2")) {
+      consola.info("agentboard2 not found in tmux.conf");
+      return;
+    }
+
+    // Remove the marker line and run-shell line
+    const newContent = content
+      .split("\n")
+      .filter((line) => !line.includes("agentboard2"))
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n");
+
+    writeFileSync(editPath, newContent);
+    consola.success("Removed agentboard2 from tmux.conf");
+    this.reloadTmux();
+  }
+
+  // Foreground command — blocks until server exits (Ctrl+C to stop)
+  private startServer(): void {
+    this.ensureDeps();
+
+    const serverEntry = resolve(PLUGIN_DIR, "apps/server/src/main.ts");
+    consola.info("Starting agentboard2 server (foreground, Ctrl+C to stop)...");
+
+    execSync(`bun run ${serverEntry}`, {
+      stdio: "inherit",
+      cwd: PLUGIN_DIR,
+      env: {
+        ...process.env,
+        AGENTBOARD2_DIR: PLUGIN_DIR,
+      },
+    });
+  }
+
+  // Foreground command — blocks until TUI exits
+  private startTui(): void {
+    this.ensureDeps();
+
+    const tuiEntry = resolve(PLUGIN_DIR, "apps/tui/src/index.tsx");
+
+    execSync(`bun run ${tuiEntry}`, {
+      stdio: "inherit",
+      cwd: resolve(PLUGIN_DIR, "apps/tui"),
+      env: {
+        ...process.env,
+        AGENTBOARD2_DIR: PLUGIN_DIR,
+      },
+    });
+  }
+
+  private showKeys(): void {
+    // Get tmux prefix and agentboard2 key from tmux
+    let prefix = "C-a";
+    let key = DEFAULT_KEY;
+    try {
+      prefix = execSync("tmux show-option -gv prefix", {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      const ab2Key = execSync(
+        `tmux show-option -gv @agentboard2-key 2>/dev/null || echo ${DEFAULT_KEY}`,
+        {
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      ).trim();
+      if (ab2Key) key = ab2Key;
+    } catch {
+      // use defaults
+    }
+
+    const { toggle, focus } = TMUX_BINDINGS;
+    consola.box(
+      [
+        `${colors.bold("AgentBoard2 Keybindings")}\n`,
+        `${colors.cyan(`tmux (prefix = ${prefix}, C = Ctrl):`)}`,
+        `  ${prefix} ${key} ${toggle}     toggle sidebar`,
+        `  ${prefix} ${key} ${focus}     focus sidebar`,
+        `  ${prefix} ${key} 1-9   jump to session\n`,
+        `${colors.cyan("In sidebar:")}`,
+        `  Tab         cycle sessions`,
+        `  j / ↓       move down`,
+        `  k / ↑       move up`,
+        `  Enter / l   switch to selected session`,
+        `  1-9         jump to session`,
+        `  d           hide session`,
+        `  x           kill session`,
+        `  t           theme picker`,
+        `  r           refresh`,
+        `  q           quit`,
+      ].join("\n"),
+    );
+  }
+
+  private reloadTmux(): void {
+    try {
+      execSync(
+        "tmux source-file ~/.config/tmux/tmux.conf 2>/dev/null || tmux source-file ~/.tmux.conf 2>/dev/null",
+        {
+          stdio: "pipe",
+        },
+      );
+      consola.success("tmux config reloaded");
+    } catch {
+      consola.info("Reload tmux manually: tmux source-file ~/.config/tmux/tmux.conf");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `plugins/tt-agentboard2/` — terminal-native tmux sidebar TUI replacing the Nuxt web UI (agentboard v1)
- Bun monorepo with `@tt-agentboard2/runtime`, `@tt-agentboard2/mux-tmux`, server, and TUI apps
- Session management, agent monitoring (Claude Code, Codex, AMP, OpenCode), themes, and keyboard-driven navigation

## Security hardening (from code review)
- Fixed command injection in `getGitInfo()` (replaced `sh -c` string interpolation with safe array-based git calls)
- Fixed tmux hook injection via `#{q:...}` shell-escaping for session names
- Added tone field validation in HTTP endpoints
- Removed duplicate `/notify` endpoint
- Fixed idle shutdown race condition
- Added DI for `TmuxProvider` (testable via constructor injection)
- Fixed hardcoded `/usr/sbin/lsof` path
- Gated debug logging behind `AGENTBOARD2_DEBUG` env var
- Cross-platform `open` command (`xdg-open` on Linux)
- Fixed workspace resolution for scripts

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (only expected `no-console` warnings remain)
- [ ] Manual: `tt agentboard2 setup` + toggle sidebar with `prefix a t`
- [ ] Manual: test with session named `test'$(echo pwned)` to verify hook injection fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)