### PR TITLE
fix: add version to CLI --version output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 import { defineCommand } from "citty";
+import { version } from "../package.json";
 
 export const main = defineCommand({
-  meta: { name: "tt", description: "towles-tool — personal CLI utilities" },
+  meta: { name: "tt", version, description: "towles-tool — personal CLI utilities" },
   subCommands: {
     config: () => import("./commands/config.js").then((m) => m.default),
     doctor: () => import("./commands/doctor.js").then((m) => m.default),


### PR DESCRIPTION
## Summary
- Add `version` from `package.json` to citty's `meta` object so `tt --version` outputs the version number instead of showing help text with "No version specified" error.

## Test plan
- [x] `bun run dev -- --version` outputs `0.0.108`

🤖 Generated with [Claude Code](https://claude.com/claude-code)