### PR TITLE
Replace strip-ansi dependency with Bun.stripANSI built-in

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
         "neverthrow": "^8.2.0",
         "picocolors": "^1.1.1",
         "prompts": "^2.4.2",
-        "strip-ansi": "^7.1.0",
         "tinyexec": "^0.3.2",
         "zod": "^4.0.5",
       },
@@ -98,7 +97,6 @@
       "version": "0.1.0",
       "dependencies": {
         "consola": "^3.4.2",
-        "strip-ansi": "^7.1.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -531,8 +529,6 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
     "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
@@ -868,8 +864,6 @@
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
-
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "neverthrow": "^8.2.0",
     "picocolors": "^1.1.1",
     "prompts": "^2.4.2",
-    "strip-ansi": "^7.1.0",
     "tinyexec": "^0.3.2",
     "zod": "^4.0.5"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,8 +6,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
-    "consola": "^3.4.2",
-    "strip-ansi": "^7.1.0"
+    "consola": "^3.4.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/packages/shared/src/git/gh-cli-wrapper.ts
+++ b/packages/shared/src/git/gh-cli-wrapper.ts
@@ -1,5 +1,3 @@
-import stripAnsi from "strip-ansi";
-
 import { exec, execSafe } from "./exec.js";
 
 export interface ExecOutput {
@@ -77,7 +75,7 @@ export async function getIssues({
   }
 
   const result = await execFn("gh", args);
-  const stripped = stripAnsi(result.stdout);
+  const stripped = Bun.stripANSI(result.stdout);
 
   try {
     return JSON.parse(stripped) as Issue[];

--- a/src/commands/gh/branch.test.ts
+++ b/src/commands/gh/branch.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import stripAnsi from "strip-ansi";
 import type { Issue } from "@towles/shared";
 import { buildIssueChoices, computeColumnLayout } from "./branch";
 
@@ -92,13 +91,13 @@ describe("buildIssueChoices", () => {
 
   it("includes issue title text in description", () => {
     const choices = buildIssueChoices(issues, layout);
-    const desc = stripAnsi(choices[0].description!);
+    const desc = Bun.stripANSI(choices[0].description!);
     expect(desc).toContain("Short bug");
   });
 
   it("includes label names in description", () => {
     const choices = buildIssueChoices(issues, layout);
-    const desc = stripAnsi(choices[1].description!);
+    const desc = Bun.stripANSI(choices[1].description!);
     expect(desc).toContain("enhancement");
     expect(desc).toContain("priority");
   });
@@ -106,7 +105,7 @@ describe("buildIssueChoices", () => {
   it("handles issues with no labels", () => {
     const choices = buildIssueChoices(issues, layout);
     // Issue #7 has no labels — description should still contain the title
-    const desc = stripAnsi(choices[2].description!);
+    const desc = Bun.stripANSI(choices[2].description!);
     expect(desc).toContain("Docs update");
   });
 


### PR DESCRIPTION
Removes the strip-ansi (and transitive ansi-regex) package in favor of
Bun's native Bun.stripANSI function, reducing external dependencies.

https://claude.ai/code/session_01AhTqqb8zcXeh6brMeq9Rk3