### PR TITLE
Replace tinyexec dependency with Bun.spawn built-in

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
         "neverthrow": "^8.2.0",
         "picocolors": "^1.1.1",
         "prompts": "^2.4.2",
-        "tinyexec": "^0.3.2",
         "zod": "^4.0.5",
       },
       "devDependencies": {
@@ -877,7 +876,7 @@
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
-    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+    "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
@@ -987,13 +986,9 @@
 
     "babel-plugin-jsx-dom-expressions/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
-    "bumpp/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
-
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
 
     "nypm/citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
-
-    "nypm/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -1002,8 +997,6 @@
     "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
-
-    "vitest/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "babel-plugin-jsx-dom-expressions/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "neverthrow": "^8.2.0",
     "picocolors": "^1.1.1",
     "prompts": "^2.4.2",
-    "tinyexec": "^0.3.2",
     "zod": "^4.0.5"
   },
   "devDependencies": {

--- a/packages/shared/src/git/exec.ts
+++ b/packages/shared/src/git/exec.ts
@@ -1,3 +1,30 @@
+export interface XResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface XOptions {
+  throwOnError?: boolean;
+  nodeOptions?: { cwd?: string };
+}
+
+/**
+ * Run a command and return stdout, stderr, and exitCode.
+ * Drop-in replacement for tinyexec's `x()`.
+ */
+export async function run(cmd: string, args: string[] = [], options?: XOptions): Promise<XResult> {
+  const cwd = options?.nodeOptions?.cwd ?? process.cwd();
+  const proc = Bun.spawn([cmd, ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  if (options?.throwOnError && exitCode !== 0) {
+    throw new Error(`Command failed (exit ${exitCode}): ${cmd} ${args.join(" ")}\n${stderr}`);
+  }
+  return { stdout, stderr, exitCode };
+}
+
 export async function exec(cmd: string, args: string[]): Promise<string> {
   const proc = Bun.spawn([cmd, ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
   const exitCode = await proc.exited;

--- a/packages/shared/src/git/exec.ts
+++ b/packages/shared/src/git/exec.ts
@@ -6,19 +6,17 @@ export interface XResult {
 
 export interface XOptions {
   throwOnError?: boolean;
-  nodeOptions?: { cwd?: string };
+  cwd?: string;
 }
 
-/**
- * Run a command and return stdout, stderr, and exitCode.
- * Drop-in replacement for tinyexec's `x()`.
- */
 export async function run(cmd: string, args: string[] = [], options?: XOptions): Promise<XResult> {
-  const cwd = options?.nodeOptions?.cwd ?? process.cwd();
+  const cwd = options?.cwd ?? process.cwd();
   const proc = Bun.spawn([cmd, ...args], { cwd, stdout: "pipe", stderr: "pipe" });
   const exitCode = await proc.exited;
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
   if (options?.throwOnError && exitCode !== 0) {
     throw new Error(`Command failed (exit ${exitCode}): ${cmd} ${args.join(" ")}\n${stderr}`);
   }
@@ -26,24 +24,16 @@ export async function run(cmd: string, args: string[] = [], options?: XOptions):
 }
 
 export async function exec(cmd: string, args: string[]): Promise<string> {
-  const proc = Bun.spawn([cmd, ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
-  const exitCode = await proc.exited;
-  const stdout = await new Response(proc.stdout).text();
-  if (exitCode !== 0) {
-    const stderr = await new Response(proc.stderr).text();
-    throw new Error(`Command failed: ${cmd} ${args.join(" ")}\n${stderr}`);
-  }
-  return stdout.trim();
+  const result = await run(cmd, args, { throwOnError: true });
+  return result.stdout.trim();
 }
 
 export async function execSafe(
   cmd: string,
   args: string[],
 ): Promise<{ stdout: string; ok: boolean }> {
-  const proc = Bun.spawn([cmd, ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
-  const exitCode = await proc.exited;
-  const stdout = await new Response(proc.stdout).text();
-  return { stdout: stdout.trim(), ok: exitCode === 0 };
+  const result = await run(cmd, args);
+  return { stdout: result.stdout.trim(), ok: result.exitCode === 0 };
 }
 
 export async function git(args: string[]): Promise<string> {

--- a/packages/shared/src/git/gh-cli-wrapper.ts
+++ b/packages/shared/src/git/gh-cli-wrapper.ts
@@ -1,24 +1,11 @@
-import { exec, execSafe } from "./exec.js";
-
-export interface ExecOutput {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
+import { exec, execSafe, run as defaultX } from "./exec.js";
+import type { XResult } from "./exec.js";
 
 export type XFn = (
   cmd: string,
   args?: string[],
   opts?: Record<string, unknown>,
-) => PromiseLike<ExecOutput>;
-
-async function defaultX(cmd: string, args: string[] = []): Promise<ExecOutput> {
-  const proc = Bun.spawn([cmd, ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
-  const exitCode = await proc.exited;
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
-  return { stdout, stderr, exitCode };
-}
+) => PromiseLike<XResult>;
 
 export async function isGithubCliInstalled(execFn: XFn = defaultX): Promise<boolean> {
   try {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,7 +1,8 @@
 export { ensureDir, fileExists, readFile, writeFile } from "./fs.js";
 export { getTerminalColumns, limitText, printWithHexColor } from "./render.js";
 export { formatDate, generateJournalFilename, getMondayOfWeek, getWeekInfo } from "./date-utils.js";
-export { exec, execSafe, git } from "./git/exec.js";
+export { exec, execSafe, git, run } from "./git/exec.js";
+export type { XResult, XOptions } from "./git/exec.js";
 export { gh, ghRaw, getIssues, isGithubCliInstalled } from "./git/gh-cli-wrapper.js";
 export type { Issue, XFn } from "./git/gh-cli-wrapper.js";
 export { createBranchNameFromIssue } from "./git/branch-name.js";

--- a/src/commands/auto-claude/config.ts
+++ b/src/commands/auto-claude/config.ts
@@ -1,5 +1,5 @@
 import consola from "consola";
-import { x } from "tinyexec";
+import { run } from "@towles/shared";
 import { z } from "zod/v4";
 
 export const AutoClaudeConfigSchema = z.object({
@@ -25,7 +25,7 @@ export async function initConfig(
   // Auto-detect repo
   let repo = overrides.repo;
   if (!repo) {
-    const result = await x(
+    const result = await run(
       "gh",
       ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
       {
@@ -41,7 +41,7 @@ export async function initConfig(
   let mainBranch = overrides.mainBranch;
   if (!mainBranch) {
     try {
-      const result = await x("git", ["symbolic-ref", "refs/remotes/origin/HEAD"], {
+      const result = await run("git", ["symbolic-ref", "refs/remotes/origin/HEAD"], {
         nodeOptions: { cwd: process.cwd() },
         throwOnError: true,
       });

--- a/src/commands/auto-claude/config.ts
+++ b/src/commands/auto-claude/config.ts
@@ -28,10 +28,7 @@ export async function initConfig(
     const result = await run(
       "gh",
       ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-      {
-        nodeOptions: { cwd: process.cwd() },
-        throwOnError: true,
-      },
+      { throwOnError: true },
     );
     repo = result.stdout.trim();
   }
@@ -42,7 +39,6 @@ export async function initConfig(
   if (!mainBranch) {
     try {
       const result = await run("git", ["symbolic-ref", "refs/remotes/origin/HEAD"], {
-        nodeOptions: { cwd: process.cwd() },
         throwOnError: true,
       });
       mainBranch = result.stdout.trim().replace("refs/remotes/origin/", "");

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { defineCommand } from "citty";
 import consola from "consola";
-import { x } from "tinyexec";
+import { run } from "@towles/shared";
 import { colors } from "consola/utils";
 import { debugArg } from "./shared.js";
 
@@ -20,7 +20,7 @@ async function checkCommand(
   optional = false,
 ): Promise<CheckResult> {
   try {
-    const result = await x(name, args);
+    const result = await run(name, args);
     const output = result.stdout + result.stderr;
     const match = output.match(versionPattern);
     return {
@@ -41,7 +41,7 @@ async function checkCommand(
 
 async function checkGhAuth(): Promise<{ ok: boolean }> {
   try {
-    const result = await x("gh", ["auth", "status"]);
+    const result = await run("gh", ["auth", "status"]);
     return { ok: result.exitCode === 0 };
   } catch {
     consola.debug("GitHub CLI auth check failed");
@@ -118,7 +118,7 @@ async function checkClaudePlugins(): Promise<
   ];
 
   try {
-    const result = await x("claude", ["plugin", "list", "--json"]);
+    const result = await run("claude", ["plugin", "list", "--json"]);
     const plugins: { id: string }[] = JSON.parse(result.stdout);
     const installedIds = new Set(plugins.map((p) => p.id));
 

--- a/src/commands/gh/branch-clean.ts
+++ b/src/commands/gh/branch-clean.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
 import { colors } from "consola/utils";
 import consola from "consola";
-import { x } from "tinyexec";
+import { run } from "@towles/shared";
 
 import { debugArg } from "../shared.js";
 
@@ -34,11 +34,11 @@ export default defineCommand({
     const baseBranch = args.base;
 
     // Get current branch
-    const currentResult = await x("git", ["branch", "--show-current"]);
+    const currentResult = await run("git", ["branch", "--show-current"]);
     const currentBranch = currentResult.stdout.trim();
 
     // Get merged branches
-    const mergedResult = await x("git", ["branch", "--merged", baseBranch]);
+    const mergedResult = await run("git", ["branch", "--merged", baseBranch]);
     const allMerged = mergedResult.stdout
       .split("\n")
       .map((b) => b.trim().replace(/^\* /, ""))
@@ -81,7 +81,7 @@ export default defineCommand({
 
     for (const branch of toDelete) {
       try {
-        await x("git", ["branch", "-d", branch]);
+        await run("git", ["branch", "-d", branch]);
         consola.log(colors.green(`✓ Deleted ${branch}`));
         deleted++;
       } catch {

--- a/src/commands/gh/pr.ts
+++ b/src/commands/gh/pr.ts
@@ -1,10 +1,9 @@
 import { defineCommand } from "citty";
-import { x } from "tinyexec";
+import { run, isGithubCliInstalled } from "@towles/shared";
 import consola from "consola";
 import { colors } from "consola/utils";
 
 import { debugArg } from "../shared.js";
-import { isGithubCliInstalled } from "@towles/shared";
 
 function generatePrContent(branch: string, commits: string[]): { title: string; body: string } {
   // Extract issue number from branch name if present (e.g., feature/123-some-feature)
@@ -85,7 +84,7 @@ export default defineCommand({
     }
 
     // Get current branch
-    const branchResult = await x("git", ["branch", "--show-current"]);
+    const branchResult = await run("git", ["branch", "--show-current"]);
     const currentBranch = branchResult.stdout.trim();
 
     if (!currentBranch) {
@@ -102,7 +101,7 @@ export default defineCommand({
     consola.info(`Base branch: ${colors.cyan(args.base)}`);
 
     // Get commits between base and current branch
-    const logResult = await x("git", ["log", `${args.base}..HEAD`, "--pretty=format:%s"]);
+    const logResult = await run("git", ["log", `${args.base}..HEAD`, "--pretty=format:%s"]);
 
     const commits = logResult.stdout.trim().split("\n").filter(Boolean);
 
@@ -135,12 +134,12 @@ export default defineCommand({
     }
 
     // Push branch if needed
-    const statusResult = await x("git", ["status", "-sb"]);
+    const statusResult = await run("git", ["status", "-sb"]);
     const needsPush = !statusResult.stdout.includes("origin/");
 
     if (needsPush) {
       consola.info("Pushing branch to remote...");
-      await x("git", ["push", "-u", "origin", currentBranch]);
+      await run("git", ["push", "-u", "origin", currentBranch]);
     }
 
     // Create PR
@@ -150,7 +149,7 @@ export default defineCommand({
       prArgs.push("--draft");
     }
 
-    const prResult = await x("gh", prArgs);
+    const prResult = await run("gh", prArgs);
     const prUrl = prResult.stdout.trim();
 
     consola.success(`PR created: ${colors.cyan(prUrl)}`);

--- a/src/commands/graph/index.ts
+++ b/src/commands/graph/index.ts
@@ -3,7 +3,7 @@ import { DateTime } from "luxon";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { x } from "tinyexec";
+import { run } from "@towles/shared";
 import consola from "consola";
 
 import { debugArg } from "../shared.js";
@@ -132,7 +132,7 @@ export default defineCommand({
     } else if (args.open) {
       consola.info("\n📈 Opening treemap...");
       const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
-      await x(openCmd, [outputPath]);
+      await run(openCmd, [outputPath]);
     }
   },
 });

--- a/src/commands/graph/server.ts
+++ b/src/commands/graph/server.ts
@@ -1,5 +1,5 @@
 import * as http from "node:http";
-import { x } from "tinyexec";
+import { run } from "@towles/shared";
 
 /**
  * Start a local HTTP server to serve the generated HTML.
@@ -54,7 +54,7 @@ export async function startServer(
  */
 export function openInBrowser(url: string): void {
   const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
-  x(openCmd, [url]);
+  run(openCmd, [url]);
 }
 
 /**

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -64,7 +64,7 @@ export default defineCommand({
 });
 
 async function ensureClaudePlugins(): Promise<void> {
-  const { x } = await import("tinyexec");
+  const { run } = await import("@towles/shared");
 
   const requiredPlugins = [
     {
@@ -81,7 +81,7 @@ async function ensureClaudePlugins(): Promise<void> {
 
   let installedIds = new Set<string>();
   try {
-    const result = await x("claude", ["plugin", "list", "--json"]);
+    const result = await run("claude", ["plugin", "list", "--json"]);
     const plugins: { id: string }[] = JSON.parse(result.stdout);
     installedIds = new Set(plugins.map((p) => p.id));
   } catch {
@@ -91,7 +91,7 @@ async function ensureClaudePlugins(): Promise<void> {
   for (const plugin of requiredPlugins) {
     if (plugin.marketplaceUrl && !installedIds.has(plugin.id)) {
       try {
-        await x("claude", ["plugin", "marketplace", "add", plugin.marketplaceUrl]);
+        await run("claude", ["plugin", "marketplace", "add", plugin.marketplaceUrl]);
         consola.log(colors.dim(`  Added marketplace: ${plugin.marketplace}`));
       } catch {
         // marketplace may already be added
@@ -111,7 +111,7 @@ async function ensureClaudePlugins(): Promise<void> {
     });
 
     if (answer) {
-      const result = await x("claude", ["plugin", "install", plugin.id, "--scope", "user"]);
+      const result = await run("claude", ["plugin", "install", plugin.id, "--scope", "user"]);
       if (result.exitCode === 0) {
         consola.log(colors.green(`✓ ${plugin.name} installed`));
       } else {


### PR DESCRIPTION
## Summary

- Add `run()` helper to `@towles/shared` as a drop-in replacement for tinyexec's `x()`, backed by `Bun.spawn`
- Replace all tinyexec imports across 7 source files with `run` from `@towles/shared`
- Remove `tinyexec` from dependencies
- Deduplicate `defaultX` in `gh-cli-wrapper.ts` by reusing the new shared `run()`

## Test plan

- [x] `bun typecheck` passes
- [x] `bun test` passes (294/294)
- [x] No remaining tinyexec references in src/

🤖 Generated with [Claude Code](https://claude.com/claude-code)