### PR TITLE
feat: improve agentboard key hints and clean up dead code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ tsconfig.tsbuildinfo
 # promptfoo cache/output
 .promptfoo/
 
+# superpowers skill plans/docs
+docs/superpowers/
+
 # auto-claude artifacts
 .auto-claude/
 .auto-claude/**/prompt-*.md

--- a/packages/agentboard/apps/tui/src/index.tsx
+++ b/packages/agentboard/apps/tui/src/index.tsx
@@ -830,28 +830,31 @@ function App() {
 
 // --- Help Overlay ---
 
+const HELP_KEYS: [string, string][] = [
+  ["j/k ↑↓", "Move focus"],
+  ["Enter", "Switch to session"],
+  ["1-9", "Jump to session"],
+  ["Tab", "Cycle sessions"],
+  ["n", "New session"],
+  ["e", "Open in editor"],
+  ["d", "Hide session"],
+  ["x", "Kill session"],
+  ["r", "Refresh"],
+  ["u", "Show all sessions"],
+  ["→/l", "Select panel"],
+  ["←/h/Esc", "Back to sessions"],
+  ["Alt+↑↓", "Reorder sessions"],
+  ["q", "Quit"],
+];
+
+const HELP_COLS = 2;
+const HELP_ROWS = Math.ceil(HELP_KEYS.length / HELP_COLS);
+const HELP_COLUMNS = Array.from({ length: HELP_COLS }, (_, c) =>
+  HELP_KEYS.slice(c * HELP_ROWS, (c + 1) * HELP_ROWS),
+);
+
 function HelpOverlay(props: { palette: Accessor<Theme["palette"]>; onClose: () => void }) {
   const P = () => props.palette();
-  const keys: [string, string][] = [
-    ["j/k ↑↓", "Move focus"],
-    ["Enter", "Switch to session"],
-    ["1-9", "Jump to session"],
-    ["Tab", "Cycle sessions"],
-    ["n", "New session"],
-    ["e", "Open in editor"],
-    ["d", "Hide session"],
-    ["x", "Kill session"],
-    ["r", "Refresh"],
-    ["u", "Show all sessions"],
-    ["→/l", "Select panel"],
-    ["←/h/Esc", "Back to sessions"],
-    ["Alt+↑↓", "Reorder sessions"],
-    ["q", "Quit"],
-  ];
-
-  const COLS = 2;
-  const rows = Math.ceil(keys.length / COLS);
-  const columns = Array.from({ length: COLS }, (_, c) => keys.slice(c * rows, (c + 1) * rows));
 
   return (
     <box
@@ -880,7 +883,7 @@ function HelpOverlay(props: { palette: Accessor<Theme["palette"]>; onClose: () =
           <text style={{ fg: P().surface2 }}>{DIVIDER}</text>
         </box>
         <box flexDirection="row">
-          <For each={columns}>
+          <For each={HELP_COLUMNS}>
             {(col) => (
               <box flexDirection="column" flexGrow={1}>
                 <For each={col}>

--- a/packages/agentboard/apps/tui/src/index.tsx
+++ b/packages/agentboard/apps/tui/src/index.tsx
@@ -458,6 +458,9 @@ function App() {
             }
           } else if (msg.type === "re-identify") {
             reIdentify();
+          } else if (msg.type === "quit") {
+            if (ws) ws.close();
+            renderer.destroy();
           }
         });
 
@@ -473,17 +476,6 @@ function App() {
     };
 
     onCleanup(() => socket.close());
-
-    // Listen for quit messages from server
-    socket.addEventListener("message", (event) => {
-      try {
-        const msg = JSON.parse(event.data as string);
-        if (msg.type === "quit") {
-          if (ws) ws.close();
-          renderer.destroy();
-        }
-      } catch {}
-    });
   });
 
   const hasRunning = createMemo(() => sessions.some((s) => s.agentState?.status === "running"));
@@ -610,9 +602,6 @@ function App() {
       }
       case "r":
         send({ type: "refresh" });
-        break;
-      case "t":
-        // reserved — was theme picker
         break;
       case "u":
         send({ type: "show-all-sessions" });
@@ -855,7 +844,6 @@ const HELP_COLUMNS = Array.from({ length: HELP_COLS }, (_, c) =>
 
 function HelpOverlay(props: { palette: Accessor<Theme["palette"]>; onClose: () => void }) {
   const P = () => props.palette();
-
   return (
     <box
       position="absolute"

--- a/packages/agentboard/apps/tui/src/index.tsx
+++ b/packages/agentboard/apps/tui/src/index.tsx
@@ -770,7 +770,7 @@ function App() {
             hints={[
               ["⇥", "cycle"],
               ["⏎", "go"],
-              ["→", "detail"],
+              ["→", "select"],
               ["n", "new"],
               ["e", "edit"],
               ["d", "hide"],
@@ -843,11 +843,15 @@ function HelpOverlay(props: { palette: Accessor<Theme["palette"]>; onClose: () =
     ["x", "Kill session"],
     ["r", "Refresh"],
     ["u", "Show all sessions"],
-    ["→/l", "Detail panel"],
+    ["→/l", "Select panel"],
     ["←/h/Esc", "Back to sessions"],
     ["Alt+↑↓", "Reorder sessions"],
     ["q", "Quit"],
   ];
+
+  const COLS = 2;
+  const rows = Math.ceil(keys.length / COLS);
+  const columns = Array.from({ length: COLS }, (_, c) => keys.slice(c * rows, (c + 1) * rows));
 
   return (
     <box
@@ -867,7 +871,7 @@ function HelpOverlay(props: { palette: Accessor<Theme["palette"]>; onClose: () =
         backgroundColor={P().mantle}
         padding={1}
         flexDirection="column"
-        width={30}
+        width={56}
       >
         <text>
           <span style={{ fg: P().blue, attributes: BOLD }}>Keybindings</span>
@@ -875,20 +879,28 @@ function HelpOverlay(props: { palette: Accessor<Theme["palette"]>; onClose: () =
         <box height={1}>
           <text style={{ fg: P().surface2 }}>{DIVIDER}</text>
         </box>
-        <For each={keys}>
-          {([key, desc]) => (
-            <box flexDirection="row" paddingLeft={1}>
-              <box width={12} flexShrink={0}>
-                <text>
-                  <span style={{ fg: P().sky }}>{key}</span>
-                </text>
+        <box flexDirection="row">
+          <For each={columns}>
+            {(col) => (
+              <box flexDirection="column" flexGrow={1}>
+                <For each={col}>
+                  {([key, desc]) => (
+                    <box flexDirection="row" paddingLeft={1}>
+                      <box width={12} flexShrink={0}>
+                        <text>
+                          <span style={{ fg: P().sky }}>{key}</span>
+                        </text>
+                      </box>
+                      <text truncate>
+                        <span style={{ fg: P().subtext0 }}>{desc}</span>
+                      </text>
+                    </box>
+                  )}
+                </For>
               </box>
-              <text truncate>
-                <span style={{ fg: P().subtext0 }}>{desc}</span>
-              </text>
-            </box>
-          )}
-        </For>
+            )}
+          </For>
+        </box>
         <box height={1}>
           <text style={{ fg: P().surface2 }}>{DIVIDER}</text>
         </box>

--- a/packages/agentboard/packages/runtime/src/server/launcher.ts
+++ b/packages/agentboard/packages/runtime/src/server/launcher.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { connect } from "node:net";
 import { SERVER_PORT, SERVER_HOST, PID_FILE } from "../shared";
 import { SERVER_ERR_LOG } from "../debug";
@@ -37,6 +37,10 @@ export async function ensureServer(): Promise<void> {
     if (!Number.isNaN(pid) && isProcessAlive(pid) && (await isPortOpen(SERVER_HOST, SERVER_PORT))) {
       return;
     }
+    // Stale PID file — remove before spawning a new server
+    try {
+      unlinkSync(PID_FILE);
+    } catch {}
   }
 
   const proc = Bun.spawn(["tt", "agentboard", "server"], {

--- a/packages/agentboard/packages/runtime/src/server/launcher.ts
+++ b/packages/agentboard/packages/runtime/src/server/launcher.ts
@@ -49,12 +49,12 @@ export async function ensureServer(): Promise<void> {
     }
   }
 
-  const dir = resolveAgentboardDir();
-  const serverPath = resolveServerEntryPath(dir);
+  const agentboardDir = resolveAgentboardDir();
+  const serverPath = resolveServerEntryPath(agentboardDir);
 
   const proc = Bun.spawn([process.execPath, "run", serverPath], {
     stdio: ["ignore", "ignore", Bun.file(SERVER_ERR_LOG)],
-    cwd: dir,
+    cwd: agentboardDir,
   });
   proc.unref();
 

--- a/packages/agentboard/packages/runtime/src/server/launcher.ts
+++ b/packages/agentboard/packages/runtime/src/server/launcher.ts
@@ -33,13 +33,12 @@ async function isPortOpen(host: string, port: number, timeoutMs = 200): Promise<
 }
 
 function resolveAgentboardDir(): string {
-  if (process.env.TT_AGENTBOARD_DIR) return process.env.TT_AGENTBOARD_DIR;
-  // Walk up from packages/runtime/src/server/ to the plugin root
+  // Walk up from packages/runtime/src/server/ to the agentboard root
   return new URL("../../../..", import.meta.url).pathname;
 }
 
-function resolveServerEntryPath(pluginDir: string): string {
-  return join(pluginDir, "apps", "server", "src", "main.ts");
+function resolveServerEntryPath(dir: string): string {
+  return join(dir, "apps", "server", "src", "main.ts");
 }
 
 export async function ensureServer(): Promise<void> {
@@ -50,13 +49,12 @@ export async function ensureServer(): Promise<void> {
     }
   }
 
-  const pluginDir = resolveAgentboardDir();
-  const serverPath = resolveServerEntryPath(pluginDir);
+  const dir = resolveAgentboardDir();
+  const serverPath = resolveServerEntryPath(dir);
 
   const proc = Bun.spawn([process.execPath, "run", serverPath], {
     stdio: ["ignore", "ignore", Bun.file(SERVER_ERR_LOG)],
-    cwd: pluginDir,
-    env: { ...process.env, TT_AGENTBOARD_DIR: pluginDir },
+    cwd: dir,
   });
   proc.unref();
 

--- a/packages/agentboard/packages/runtime/src/server/launcher.ts
+++ b/packages/agentboard/packages/runtime/src/server/launcher.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
 import { connect } from "node:net";
 import { SERVER_PORT, SERVER_HOST, PID_FILE } from "../shared";
 import { SERVER_ERR_LOG } from "../debug";
@@ -32,15 +31,6 @@ async function isPortOpen(host: string, port: number, timeoutMs = 200): Promise<
   });
 }
 
-function resolveAgentboardDir(): string {
-  // Walk up from packages/runtime/src/server/ to the agentboard root
-  return new URL("../../../..", import.meta.url).pathname;
-}
-
-function resolveServerEntryPath(dir: string): string {
-  return join(dir, "apps", "server", "src", "main.ts");
-}
-
 export async function ensureServer(): Promise<void> {
   if (existsSync(PID_FILE)) {
     const pid = Number.parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
@@ -49,12 +39,8 @@ export async function ensureServer(): Promise<void> {
     }
   }
 
-  const agentboardDir = resolveAgentboardDir();
-  const serverPath = resolveServerEntryPath(agentboardDir);
-
-  const proc = Bun.spawn([process.execPath, "run", serverPath], {
+  const proc = Bun.spawn(["tt", "agentboard", "server"], {
     stdio: ["ignore", "ignore", Bun.file(SERVER_ERR_LOG)],
-    cwd: agentboardDir,
   });
   proc.unref();
 

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -9,8 +9,6 @@ import { debugArg } from "./shared.js";
 const SERVER_HOST = "127.0.0.1";
 const SERVER_PORT = 4201;
 
-const AGENTBOARD_DIR = resolve(import.meta.dirname, "../../packages/agentboard");
-
 // Keybinding defaults
 const DEFAULT_KEY = "a";
 const TMUX_BINDINGS = { toggle: "t", focus: "s" } as const;
@@ -30,16 +28,11 @@ function findTmuxConf(): string | null {
   return null;
 }
 
-function ensureDeps(): void {
+function ensureBun(): void {
   try {
     execSync("bun --version", { stdio: "pipe" });
   } catch {
     consola.error("bun is required but not found. Install: https://bun.sh");
-    process.exit(1);
-  }
-
-  if (!existsSync(AGENTBOARD_DIR)) {
-    consola.error(`Agentboard directory not found: ${AGENTBOARD_DIR}`);
     process.exit(1);
   }
 }
@@ -102,7 +95,7 @@ function showKeys(): void {
 }
 
 function setup(): void {
-  ensureDeps();
+  ensureBun();
 
   const confPath = findTmuxConf();
   if (!confPath) {
@@ -177,14 +170,15 @@ function uninstall(): void {
 }
 
 function startServer(): void {
-  ensureDeps();
+  ensureBun();
 
-  const serverEntry = resolve(AGENTBOARD_DIR, "apps/server/src/main.ts");
+  const agentboardDir = resolve(import.meta.dirname, "../../packages/agentboard");
+  const serverEntry = resolve(agentboardDir, "apps/server/src/main.ts");
   consola.info("Starting agentboard server (foreground, Ctrl+C to stop)...");
 
   execSync(`bun run ${serverEntry}`, {
     stdio: "inherit",
-    cwd: AGENTBOARD_DIR,
+    cwd: agentboardDir,
   });
 }
 
@@ -202,11 +196,9 @@ async function serverAlive(): Promise<boolean> {
 async function ensureServerUp(): Promise<boolean> {
   if (await serverAlive()) return true;
 
-  const serverEntry = resolve(AGENTBOARD_DIR, "apps/server/src/main.ts");
   consola.info("Starting agentboard server...");
-  const child = spawn("bun", ["run", serverEntry], {
+  const child = spawn("tt", ["agentboard", "server"], {
     stdio: "ignore",
-    cwd: AGENTBOARD_DIR,
     detached: true,
   });
   child.unref();
@@ -367,7 +359,7 @@ async function runFocus(): Promise<void> {
 }
 
 async function restart(): Promise<void> {
-  ensureDeps();
+  ensureBun();
 
   // 1. Kill stash sessions left over from hidden sidebars
   try {
@@ -426,13 +418,14 @@ async function restart(): Promise<void> {
 }
 
 function startTui(): void {
-  ensureDeps();
+  ensureBun();
 
-  const tuiEntry = resolve(AGENTBOARD_DIR, "apps/tui/src/index.tsx");
+  const agentboardDir = resolve(import.meta.dirname, "../../packages/agentboard");
+  const tuiEntry = resolve(agentboardDir, "apps/tui/src/index.tsx");
 
   execSync(`bun run ${tuiEntry}`, {
     stdio: "inherit",
-    cwd: resolve(AGENTBOARD_DIR, "apps/tui"),
+    cwd: resolve(agentboardDir, "apps/tui"),
   });
 }
 

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -18,12 +18,7 @@ const MARKER = "# agentboard";
 function findTmuxConf(): string | null {
   const candidates = [resolve(process.env.HOME ?? "~", ".config/tmux/tmux.conf")];
   for (const path of candidates) {
-    try {
-      const real = existsSync(path) ? path : null;
-      if (real) return real;
-    } catch {
-      continue;
-    }
+    if (existsSync(path)) return path;
   }
   return null;
 }
@@ -95,8 +90,6 @@ function showKeys(): void {
 }
 
 function setup(): void {
-  ensureBun();
-
   const confPath = findTmuxConf();
   if (!confPath) {
     consola.warn("No tmux.conf found. Add this line manually:");
@@ -453,8 +446,6 @@ export default defineCommand({
         startServer();
         break;
       case "tui":
-        startTui();
-        break;
       case "start":
         startTui();
         break;

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -9,7 +9,9 @@ import { debugArg } from "./shared.js";
 const SERVER_HOST = "127.0.0.1";
 const SERVER_PORT = 4201;
 
-const PLUGIN_DIR = resolve(import.meta.dirname, "../../packages/agentboard");
+function agentboardDir(): string {
+  return resolve(import.meta.dirname, "../../packages/agentboard");
+}
 
 // Keybinding defaults
 const DEFAULT_KEY = "a";
@@ -38,18 +40,10 @@ function ensureDeps(): void {
     process.exit(1);
   }
 
-  if (!existsSync(PLUGIN_DIR)) {
-    consola.error(`Agentboard plugin directory not found: ${PLUGIN_DIR}`);
-    consola.error(
-      "If installed globally, ensure the 'plugins' directory is included in the package.",
-    );
+  const dir = agentboardDir();
+  if (!existsSync(dir)) {
+    consola.error(`Agentboard directory not found: ${dir}`);
     process.exit(1);
-  }
-
-  const runtimeNodeModules = resolve(PLUGIN_DIR, "packages/runtime/node_modules");
-  if (!existsSync(runtimeNodeModules)) {
-    consola.info("Installing agentboard dependencies...");
-    execSync("bun install", { cwd: PLUGIN_DIR, stdio: "inherit" });
   }
 }
 
@@ -188,16 +182,13 @@ function uninstall(): void {
 function startServer(): void {
   ensureDeps();
 
-  const serverEntry = resolve(PLUGIN_DIR, "apps/server/src/main.ts");
+  const dir = agentboardDir();
+  const serverEntry = resolve(dir, "apps/server/src/main.ts");
   consola.info("Starting agentboard server (foreground, Ctrl+C to stop)...");
 
   execSync(`bun run ${serverEntry}`, {
     stdio: "inherit",
-    cwd: PLUGIN_DIR,
-    env: {
-      ...process.env,
-      AGENTBOARD_DIR: PLUGIN_DIR,
-    },
+    cwd: dir,
   });
 }
 
@@ -215,13 +206,13 @@ async function serverAlive(): Promise<boolean> {
 async function ensureServerUp(): Promise<boolean> {
   if (await serverAlive()) return true;
 
-  const serverEntry = resolve(PLUGIN_DIR, "apps/server/src/main.ts");
+  const dir = agentboardDir();
+  const serverEntry = resolve(dir, "apps/server/src/main.ts");
   consola.info("Starting agentboard server...");
   const child = spawn("bun", ["run", serverEntry], {
     stdio: "ignore",
-    cwd: PLUGIN_DIR,
+    cwd: dir,
     detached: true,
-    env: { ...process.env, AGENTBOARD_DIR: PLUGIN_DIR },
   });
   child.unref();
 
@@ -442,15 +433,12 @@ async function restart(): Promise<void> {
 function startTui(): void {
   ensureDeps();
 
-  const tuiEntry = resolve(PLUGIN_DIR, "apps/tui/src/index.tsx");
+  const dir = agentboardDir();
+  const tuiEntry = resolve(dir, "apps/tui/src/index.tsx");
 
   execSync(`bun run ${tuiEntry}`, {
     stdio: "inherit",
-    cwd: resolve(PLUGIN_DIR, "apps/tui"),
-    env: {
-      ...process.env,
-      AGENTBOARD_DIR: PLUGIN_DIR,
-    },
+    cwd: resolve(dir, "apps/tui"),
   });
 }
 

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -9,9 +9,7 @@ import { debugArg } from "./shared.js";
 const SERVER_HOST = "127.0.0.1";
 const SERVER_PORT = 4201;
 
-function agentboardDir(): string {
-  return resolve(import.meta.dirname, "../../packages/agentboard");
-}
+const AGENTBOARD_DIR = resolve(import.meta.dirname, "../../packages/agentboard");
 
 // Keybinding defaults
 const DEFAULT_KEY = "a";
@@ -40,7 +38,7 @@ function ensureDeps(): void {
     process.exit(1);
   }
 
-  const dir = agentboardDir();
+  const dir = AGENTBOARD_DIR;
   if (!existsSync(dir)) {
     consola.error(`Agentboard directory not found: ${dir}`);
     process.exit(1);
@@ -182,7 +180,7 @@ function uninstall(): void {
 function startServer(): void {
   ensureDeps();
 
-  const dir = agentboardDir();
+  const dir = AGENTBOARD_DIR;
   const serverEntry = resolve(dir, "apps/server/src/main.ts");
   consola.info("Starting agentboard server (foreground, Ctrl+C to stop)...");
 
@@ -206,7 +204,7 @@ async function serverAlive(): Promise<boolean> {
 async function ensureServerUp(): Promise<boolean> {
   if (await serverAlive()) return true;
 
-  const dir = agentboardDir();
+  const dir = AGENTBOARD_DIR;
   const serverEntry = resolve(dir, "apps/server/src/main.ts");
   consola.info("Starting agentboard server...");
   const child = spawn("bun", ["run", serverEntry], {
@@ -433,7 +431,7 @@ async function restart(): Promise<void> {
 function startTui(): void {
   ensureDeps();
 
-  const dir = agentboardDir();
+  const dir = AGENTBOARD_DIR;
   const tuiEntry = resolve(dir, "apps/tui/src/index.tsx");
 
   execSync(`bun run ${tuiEntry}`, {

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -38,9 +38,8 @@ function ensureDeps(): void {
     process.exit(1);
   }
 
-  const dir = AGENTBOARD_DIR;
-  if (!existsSync(dir)) {
-    consola.error(`Agentboard directory not found: ${dir}`);
+  if (!existsSync(AGENTBOARD_DIR)) {
+    consola.error(`Agentboard directory not found: ${AGENTBOARD_DIR}`);
     process.exit(1);
   }
 }
@@ -180,13 +179,12 @@ function uninstall(): void {
 function startServer(): void {
   ensureDeps();
 
-  const dir = AGENTBOARD_DIR;
-  const serverEntry = resolve(dir, "apps/server/src/main.ts");
+  const serverEntry = resolve(AGENTBOARD_DIR, "apps/server/src/main.ts");
   consola.info("Starting agentboard server (foreground, Ctrl+C to stop)...");
 
   execSync(`bun run ${serverEntry}`, {
     stdio: "inherit",
-    cwd: dir,
+    cwd: AGENTBOARD_DIR,
   });
 }
 
@@ -204,12 +202,11 @@ async function serverAlive(): Promise<boolean> {
 async function ensureServerUp(): Promise<boolean> {
   if (await serverAlive()) return true;
 
-  const dir = AGENTBOARD_DIR;
-  const serverEntry = resolve(dir, "apps/server/src/main.ts");
+  const serverEntry = resolve(AGENTBOARD_DIR, "apps/server/src/main.ts");
   consola.info("Starting agentboard server...");
   const child = spawn("bun", ["run", serverEntry], {
     stdio: "ignore",
-    cwd: dir,
+    cwd: AGENTBOARD_DIR,
     detached: true,
   });
   child.unref();
@@ -431,12 +428,11 @@ async function restart(): Promise<void> {
 function startTui(): void {
   ensureDeps();
 
-  const dir = AGENTBOARD_DIR;
-  const tuiEntry = resolve(dir, "apps/tui/src/index.tsx");
+  const tuiEntry = resolve(AGENTBOARD_DIR, "apps/tui/src/index.tsx");
 
   execSync(`bun run ${tuiEntry}`, {
     stdio: "inherit",
-    cwd: resolve(dir, "apps/tui"),
+    cwd: resolve(AGENTBOARD_DIR, "apps/tui"),
   });
 }
 


### PR DESCRIPTION
## Summary
- Rename "detail" to "select" in key hints and add 2-column help overlay
- Remove unnecessary env vars (TT_AGENTBOARD_DIR, PLUGIN_DIR, AGENTBOARD_DIR)
- Use `tt` CLI for background server spawning instead of direct path resolution
- Clean up dead code, stale PID file handling, and split message handler

## Test plan
- [x] Verify agentboard TUI launches correctly
- [x] Key hints display properly in 2-column layout
- [x] Server spawning works via `tt` CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)