### PR TITLE
refactor: consolidate DIVIDER constant into constants.ts

### DIFF
--- a/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
+++ b/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
@@ -9,6 +9,7 @@ import {
   UNSEEN_ICON,
   BOLD,
   DIM,
+  DIVIDER,
   SPARK_BLOCKS,
   TONE_ICONS,
   toneColor,
@@ -135,7 +136,7 @@ export function DetailPanel(props: DetailPanelProps) {
             fg: props.isResizing ? P().blue : props.isResizeHover ? P().overlay1 : P().surface2,
           }}
         >
-          {"─".repeat(200)}
+          {DIVIDER}
         </text>
       </box>
 

--- a/packages/agentboard/apps/tui/src/constants.ts
+++ b/packages/agentboard/apps/tui/src/constants.ts
@@ -8,6 +8,7 @@ export const UNSEEN_ICON = "●";
 export const BOLD = TextAttributes.BOLD;
 export const DIM = TextAttributes.DIM;
 export const SPARK_BLOCKS = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+export const DIVIDER = "─".repeat(200);
 
 export const THEME_NAMES = Object.keys(BUILTIN_THEMES);
 export const DEFAULT_DETAIL_PANEL_HEIGHT = 10;

--- a/packages/agentboard/apps/tui/src/index.tsx
+++ b/packages/agentboard/apps/tui/src/index.tsx
@@ -29,6 +29,7 @@ import { TmuxClient } from "@tt-agentboard/mux-tmux";
 import { SessionCard } from "./components/SessionCard";
 import { DetailPanel } from "./components/DetailPanel";
 import { StatusBar } from "./components/StatusBar";
+import { DIVIDER } from "./constants";
 
 // Detect tmux context (tmux only)
 type MuxContext = { type: "tmux"; sdk: TmuxClient; paneId: string } | { type: "none" };
@@ -47,7 +48,6 @@ const BOLD = TextAttributes.BOLD;
 const DIM = TextAttributes.DIM;
 const DEFAULT_DETAIL_PANEL_HEIGHT = 10;
 const MIN_DETAIL_PANEL_HEIGHT = 4;
-const DIVIDER = "─".repeat(200);
 const RESIZE_DEBUG_LOG = "/tmp/agentboard-tui-resize.log";
 
 const TUI_DEBUG = !!process.env.TT_AGENTBOARD_DEBUG;


### PR DESCRIPTION
## Summary
- Add `DIVIDER` constant to `constants.ts`
- Import in `index.tsx` instead of local definition
- Import in `DetailPanel.tsx` instead of inline `"─".repeat(200)`

## Test plan
- [x] `bun run build` passes for agentboard TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)