### PR TITLE
cleanup: remove unused re-exports from shell.ts

### DIFF
--- a/src/commands/auto-claude/shell.ts
+++ b/src/commands/auto-claude/shell.ts
@@ -1,5 +1,3 @@
-export { execSafe, gh, ghRaw, git } from "@towles/shared";
-
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/commands/auto-claude/utils-execution.test.ts
+++ b/src/commands/auto-claude/utils-execution.test.ts
@@ -28,20 +28,20 @@ describe("shell helpers (real execution)", () => {
   });
 
   it("execSafe returns ok:true for a successful command", async () => {
-    const { execSafe } = await import("./shell");
+    const { execSafe } = await import("@towles/shared");
     const result = await execSafe("echo", ["hello"]);
     expect(result.ok).toBe(true);
     expect(result.stdout).toBe("hello");
   });
 
   it("execSafe returns ok:false for a failing command", async () => {
-    const { execSafe } = await import("./shell");
+    const { execSafe } = await import("@towles/shared");
     const result = await execSafe("git", ["checkout", "nonexistent-branch-xyz"]);
     expect(result.ok).toBe(false);
   });
 
   it("git() runs real git commands", async () => {
-    const { git } = await import("./shell");
+    const { git } = await import("@towles/shared");
     const status = await git(["status", "--porcelain"]);
     expect(typeof status).toBe("string");
   });
@@ -67,7 +67,7 @@ describe("ensureBranch (real git)", () => {
 
   it("creates a new branch from main when branch doesn't exist", async () => {
     const { ensureBranch } = await import("./utils");
-    const { git } = await import("./shell");
+    const { git } = await import("@towles/shared");
 
     await ensureBranch("feature/42-new-branch");
 
@@ -77,7 +77,7 @@ describe("ensureBranch (real git)", () => {
 
   it("checks out an existing local branch", async () => {
     const { ensureBranch } = await import("./utils");
-    const { git } = await import("./shell");
+    const { git } = await import("@towles/shared");
 
     execSync("git checkout -b feature/existing-branch", { cwd: repo.dir, stdio: "ignore" });
     execSync("git checkout main", { cwd: repo.dir, stdio: "ignore" });
@@ -90,7 +90,7 @@ describe("ensureBranch (real git)", () => {
 
   it("can checkout after branch creation", async () => {
     const { ensureBranch } = await import("./utils");
-    const { git } = await import("./shell");
+    const { git } = await import("@towles/shared");
 
     await ensureBranch("feature/99-test-checkout");
     const branch1 = await git(["branch", "--show-current"]);


### PR DESCRIPTION
## Summary
- Remove dead `execSafe, gh, ghRaw, git` re-exports from `src/commands/auto-claude/shell.ts`
- All callers import these directly from `@towles/shared`
- Keep the `sleep` function which is still used
- Update `utils-execution.test.ts` to import from `@towles/shared` directly

## Test plan
- [x] Verified no imports reference these re-exports from shell.ts
- [x] Typecheck passes with no errors
- [x] All 131 auto-claude tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)