### PR TITLE
fix: remove as any casts in graph commands

### DIFF
--- a/src/commands/graph/analyzer.test.ts
+++ b/src/commands/graph/analyzer.test.ts
@@ -166,8 +166,8 @@ describe("extractSessionLabel", () => {
   });
 
   it("falls back to gitBranch", () => {
-    const entries = [makeEntry({ type: "user" }) as any];
-    (entries[0] as any).gitBranch = "feat/new-feature";
+    const entries = [makeEntry({ type: "user" })];
+    entries[0].gitBranch = "feat/new-feature";
     expect(extractSessionLabel(entries, "abc12345")).toBe("feat/new-feature");
   });
 
@@ -209,8 +209,8 @@ describe("extractSessionLabel", () => {
   });
 
   it("uses slug fallback for short labels after cleanup", () => {
-    const entries = [makeEntry() as any];
-    (entries[0] as any).slug = "my-slug";
+    const entries = [makeEntry()];
+    entries[0].slug = "my-slug";
     expect(extractSessionLabel(entries, "abc12345")).toBe("my-slug");
   });
 });

--- a/src/commands/graph/index.ts
+++ b/src/commands/graph/index.ts
@@ -8,6 +8,7 @@ import consola from "consola";
 
 import { debugArg } from "../shared.js";
 import { buildAllSessionsTreemap, buildSessionTreemap } from "./treemap.js";
+import type { BarChartData } from "./types.js";
 import { buildBarChartData, findRecentSessions, findSessionPath } from "./sessions.js";
 import { generateTreemapHtml } from "./render.js";
 import { openInBrowser, startServer, waitForShutdown } from "./server.js";
@@ -66,7 +67,7 @@ export default defineCommand({
 
     const sessionId = args.session;
     let treemapData;
-    let barChartData = { days: [] as any[] };
+    let barChartData: BarChartData = { days: [] };
 
     if (!sessionId) {
       // All sessions mode

--- a/src/commands/graph/labels.ts
+++ b/src/commands/graph/labels.ts
@@ -11,11 +11,11 @@ export function extractSessionLabel(entries: JournalEntry[], sessionId: string):
 
   for (const entry of entries) {
     // Extract metadata from any entry
-    if (!gitBranch && (entry as any).gitBranch) {
-      gitBranch = (entry as any).gitBranch;
+    if (!gitBranch && entry.gitBranch) {
+      gitBranch = entry.gitBranch;
     }
-    if (!slug && (entry as any).slug) {
-      slug = (entry as any).slug;
+    if (!slug && entry.slug) {
+      slug = entry.slug;
     }
 
     if (!entry.message) continue;

--- a/src/commands/graph/types.ts
+++ b/src/commands/graph/types.ts
@@ -23,6 +23,8 @@ export interface JournalEntry {
     content?: ContentBlock[] | string;
   };
   uuid?: string;
+  gitBranch?: string;
+  slug?: string;
 }
 
 export interface ToolData {


### PR DESCRIPTION
## Summary
- Add `gitBranch` and `slug` optional fields to `JournalEntry` type
- Remove `as any` casts in `labels.ts` and `analyzer.test.ts`
- Use `BarChartData` type annotation instead of `as any[]` in `index.ts`

## Test plan
- [x] Typecheck shows no new errors
- [x] `bun test -- graph` passes (88 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)