### PR TITLE
fix: remove unnecessary as any cast in DetailPanel

### DIFF
--- a/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
+++ b/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
@@ -289,7 +289,7 @@ function AgentListItem(props: AgentListItemProps) {
       flexShrink={0}
       onMouseDown={(event) => {
         // Don't trigger focus if clicking the dismiss button
-        if ((event.target as any)?.id === "dismiss") return;
+        if (event.target?.id === "dismiss") return;
         appendFileSync(
           TUI_AGENT_CLICK_LOG,
           `[${new Date().toISOString()}] clicked agent=${props.agent.agent} thread=${props.agent.threadName ?? "?"}\n`,


### PR DESCRIPTION
## Summary
- Remove `as any` cast on `event.target` in `DetailPanel.tsx` — `Renderable` already has `get id(): string`

## Test plan
- [x] `bun run build` passes for agentboard TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)