### PR TITLE
feat: add journal search command

### DIFF
--- a/src/commands/journal/index.ts
+++ b/src/commands/journal/index.ts
@@ -6,5 +6,6 @@ export default defineCommand({
     "daily-notes": () => import("./daily-notes.js").then((m) => m.default),
     note: () => import("./note.js").then((m) => m.default),
     meeting: () => import("./meeting.js").then((m) => m.default),
+    search: () => import("./search.js").then((m) => m.default),
   },
 });

--- a/src/commands/journal/search.test.ts
+++ b/src/commands/journal/search.test.ts
@@ -1,0 +1,158 @@
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  collectMarkdownFiles,
+  inferTypeFromPath,
+  extractDateFromFilename,
+  searchJournalFiles,
+  parseDateRange,
+} from "./search.js";
+import { JOURNAL_TYPES } from "../../types/journal.js";
+
+describe("journal search", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = path.join(tmpdir(), `journal-search-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("collectMarkdownFiles", () => {
+    it("collects .md files recursively", () => {
+      mkdirSync(path.join(tmpDir, "sub"), { recursive: true });
+      writeFileSync(path.join(tmpDir, "a.md"), "hello");
+      writeFileSync(path.join(tmpDir, "b.txt"), "ignored");
+      writeFileSync(path.join(tmpDir, "sub", "c.md"), "nested");
+
+      const files = collectMarkdownFiles(tmpDir);
+      expect(files).toHaveLength(2);
+      expect(files.some((f) => f.endsWith("a.md"))).toBe(true);
+      expect(files.some((f) => f.endsWith("c.md"))).toBe(true);
+    });
+
+    it("returns empty for nonexistent directory", () => {
+      expect(collectMarkdownFiles("/nonexistent-dir-12345")).toEqual([]);
+    });
+  });
+
+  describe("inferTypeFromPath", () => {
+    it("detects daily-notes", () => {
+      expect(inferTypeFromPath("/journal/2026/01/daily-notes/file.md")).toBe(
+        JOURNAL_TYPES.DAILY_NOTES,
+      );
+    });
+
+    it("detects meeting", () => {
+      expect(inferTypeFromPath("/journal/2026/01/meetings/standup.md")).toBe(
+        JOURNAL_TYPES.MEETING,
+      );
+    });
+
+    it("detects note", () => {
+      expect(inferTypeFromPath("/journal/2026/01/notes/idea.md")).toBe(JOURNAL_TYPES.NOTE);
+    });
+
+    it("returns null for unknown", () => {
+      expect(inferTypeFromPath("/journal/2026/01/other/file.md")).toBeNull();
+    });
+  });
+
+  describe("extractDateFromFilename", () => {
+    it("extracts date from standard filename", () => {
+      const date = extractDateFromFilename("/path/2026-03-15-standup.md");
+      expect(date).not.toBeNull();
+      expect(date!.getFullYear()).toBe(2026);
+      expect(date!.getMonth()).toBe(2); // 0-indexed
+      expect(date!.getDate()).toBe(15);
+    });
+
+    it("returns null when no date pattern", () => {
+      expect(extractDateFromFilename("/path/readme.md")).toBeNull();
+    });
+  });
+
+  describe("searchJournalFiles", () => {
+    it("finds matching lines with context", () => {
+      const file = path.join(tmpDir, "2026-01-10-test.md");
+      writeFileSync(file, "line one\nline two\nfind me here\nline four\nline five");
+
+      const matches = searchJournalFiles([file], { query: "find me" });
+      expect(matches).toHaveLength(1);
+      expect(matches[0].lineNumber).toBe(3);
+      expect(matches[0].line).toBe("find me here");
+      expect(matches[0].context).toHaveLength(5); // 2 before + match + 2 after
+    });
+
+    it("is case-insensitive", () => {
+      const file = path.join(tmpDir, "2026-01-10-test.md");
+      writeFileSync(file, "Hello World\nfoo bar");
+
+      const matches = searchJournalFiles([file], { query: "hello" });
+      expect(matches).toHaveLength(1);
+    });
+
+    it("filters by type", () => {
+      const dailyDir = path.join(tmpDir, "daily-notes");
+      const notesDir = path.join(tmpDir, "notes");
+      mkdirSync(dailyDir, { recursive: true });
+      mkdirSync(notesDir, { recursive: true });
+
+      const dailyFile = path.join(dailyDir, "2026-01-10-daily.md");
+      const noteFile = path.join(notesDir, "2026-01-10-idea.md");
+      writeFileSync(dailyFile, "keyword here");
+      writeFileSync(noteFile, "keyword here too");
+
+      const matches = searchJournalFiles([dailyFile, noteFile], {
+        query: "keyword",
+        type: JOURNAL_TYPES.DAILY_NOTES,
+      });
+      expect(matches).toHaveLength(1);
+      expect(matches[0].filePath).toBe(dailyFile);
+    });
+
+    it("filters by date range", () => {
+      const oldFile = path.join(tmpDir, "2025-06-01-old.md");
+      const newFile = path.join(tmpDir, "2026-02-15-new.md");
+      writeFileSync(oldFile, "keyword");
+      writeFileSync(newFile, "keyword");
+
+      const matches = searchJournalFiles([oldFile, newFile], {
+        query: "keyword",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 11, 31),
+      });
+      expect(matches).toHaveLength(1);
+      expect(matches[0].filePath).toBe(newFile);
+    });
+
+    it("returns empty when no matches", () => {
+      const file = path.join(tmpDir, "2026-01-10-test.md");
+      writeFileSync(file, "nothing relevant");
+
+      const matches = searchJournalFiles([file], { query: "xyznotfound" });
+      expect(matches).toHaveLength(0);
+    });
+  });
+
+  describe("parseDateRange", () => {
+    it("parses valid range", () => {
+      const { startDate, endDate } = parseDateRange("2026-01-01..2026-03-01");
+      expect(startDate.getFullYear()).toBe(2026);
+      expect(endDate.getMonth()).toBe(2); // March = 2 (0-indexed)
+    });
+
+    it("throws on invalid format", () => {
+      expect(() => parseDateRange("invalid")).toThrow("Invalid date range format");
+    });
+
+    it("throws TypeError on invalid dates", () => {
+      expect(() => parseDateRange("notadate..alsonot")).toThrow(TypeError);
+    });
+  });
+});

--- a/src/commands/journal/search.ts
+++ b/src/commands/journal/search.ts
@@ -1,0 +1,257 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { colors } from "consola/utils";
+import { withSettings, debugArg } from "../shared.js";
+import type { JournalType } from "../../types/journal.js";
+import { JOURNAL_TYPES } from "../../types/journal.js";
+
+export interface SearchMatch {
+  filePath: string;
+  lineNumber: number;
+  line: string;
+  context: string[];
+}
+
+export interface SearchOptions {
+  query: string;
+  type?: JournalType;
+  startDate?: Date;
+  endDate?: Date;
+  contextLines?: number;
+}
+
+/**
+ * Recursively collect all .md files under a directory.
+ */
+export function collectMarkdownFiles(dir: string): string[] {
+  const results: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      results.push(...collectMarkdownFiles(full));
+    } else if (entry.endsWith(".md")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Determine journal type from a file path based on directory names.
+ */
+export function inferTypeFromPath(filePath: string): JournalType | null {
+  const lower = filePath.toLowerCase();
+  if (lower.includes("/daily-notes/") || lower.includes("daily-notes")) {
+    return JOURNAL_TYPES.DAILY_NOTES;
+  }
+  if (lower.includes("/meetings/") || lower.includes("/meeting/")) {
+    return JOURNAL_TYPES.MEETING;
+  }
+  if (lower.includes("/notes/") || lower.includes("/note/")) {
+    return JOURNAL_TYPES.NOTE;
+  }
+  return null;
+}
+
+/**
+ * Extract a date from a filename like `2026-03-15-*.md`.
+ * Returns null if no date pattern is found.
+ */
+export function extractDateFromFilename(filePath: string): Date | null {
+  const basename = path.basename(filePath);
+  const match = basename.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return null;
+  const [, year, month, day] = match;
+  return new Date(Number(year), Number(month) - 1, Number(day));
+}
+
+/**
+ * Search journal files for a query string, returning matches with context.
+ */
+export function searchJournalFiles(
+  files: string[],
+  options: SearchOptions,
+): SearchMatch[] {
+  const { query, type, startDate, endDate, contextLines = 2 } = options;
+  const lowerQuery = query.toLowerCase();
+  const matches: SearchMatch[] = [];
+
+  for (const filePath of files) {
+    // Filter by type
+    if (type) {
+      const fileType = inferTypeFromPath(filePath);
+      if (fileType !== type) continue;
+    }
+
+    // Filter by date range
+    if (startDate || endDate) {
+      const fileDate = extractDateFromFilename(filePath);
+      if (fileDate) {
+        if (startDate && fileDate < startDate) continue;
+        if (endDate && fileDate > endDate) continue;
+      }
+    }
+
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].toLowerCase().includes(lowerQuery)) {
+        const ctxStart = Math.max(0, i - contextLines);
+        const ctxEnd = Math.min(lines.length - 1, i + contextLines);
+        const context: string[] = [];
+        for (let j = ctxStart; j <= ctxEnd; j++) {
+          const prefix = j === i ? ">" : " ";
+          context.push(`${prefix} ${j + 1}: ${lines[j]}`);
+        }
+        matches.push({
+          filePath,
+          lineNumber: i + 1,
+          line: lines[i],
+          context,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Parse a date range string like `2026-01-01..2026-03-01`.
+ */
+export function parseDateRange(range: string): { startDate: Date; endDate: Date } {
+  const parts = range.split("..");
+  if (parts.length !== 2) {
+    throw new Error(`Invalid date range format: "${range}". Expected: YYYY-MM-DD..YYYY-MM-DD`);
+  }
+  const [startStr, endStr] = parts;
+  const startDate = new Date(startStr);
+  const endDate = new Date(endStr);
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+    throw new TypeError(`Invalid dates in range: "${range}". Expected: YYYY-MM-DD..YYYY-MM-DD`);
+  }
+  return { startDate, endDate };
+}
+
+const VALID_TYPES = new Set<string>([
+  JOURNAL_TYPES.DAILY_NOTES,
+  JOURNAL_TYPES.MEETING,
+  JOURNAL_TYPES.NOTE,
+]);
+
+export default defineCommand({
+  meta: {
+    name: "search",
+    description: "Search journal entries for matching text",
+  },
+  args: {
+    debug: debugArg,
+    query: {
+      type: "positional",
+      required: true,
+      description: "Text to search for",
+    },
+    type: {
+      type: "string",
+      alias: "t",
+      description: "Filter by entry type: daily-notes, meeting, note",
+    },
+    range: {
+      type: "string",
+      alias: "r",
+      description: "Filter by date range: YYYY-MM-DD..YYYY-MM-DD",
+    },
+  },
+  async run({ args }) {
+    const { settings } = await withSettings(args.debug);
+
+    try {
+      const baseFolder = settings.journalSettings.baseFolder;
+      const journalDir = path.join(baseFolder, "journal");
+
+      // Validate --type
+      let typeFilter: JournalType | undefined;
+      if (args.type) {
+        if (!VALID_TYPES.has(args.type)) {
+          consola.error(
+            `Invalid type "${args.type}". Must be one of: ${[...VALID_TYPES].join(", ")}`,
+          );
+          process.exit(1);
+        }
+        typeFilter = args.type as JournalType;
+      }
+
+      // Parse --range
+      let startDate: Date | undefined;
+      let endDate: Date | undefined;
+      if (args.range) {
+        const parsed = parseDateRange(args.range);
+        startDate = parsed.startDate;
+        endDate = parsed.endDate;
+      }
+
+      const files = collectMarkdownFiles(journalDir);
+      if (files.length === 0) {
+        consola.info(`No journal files found in ${colors.cyan(journalDir)}`);
+        return;
+      }
+
+      const matches = searchJournalFiles(files, {
+        query: args.query,
+        type: typeFilter,
+        startDate,
+        endDate,
+      });
+
+      if (matches.length === 0) {
+        consola.info(`No matches found for "${colors.cyan(args.query)}"`);
+        return;
+      }
+
+      consola.info(`Found ${colors.green(String(matches.length))} match(es) for "${colors.cyan(args.query)}":\n`);
+
+      // Group matches by file
+      const byFile = new Map<string, SearchMatch[]>();
+      for (const m of matches) {
+        const existing = byFile.get(m.filePath) ?? [];
+        existing.push(m);
+        byFile.set(m.filePath, existing);
+      }
+
+      for (const [filePath, fileMatches] of byFile) {
+        const relative = path.relative(baseFolder, filePath);
+        console.log(colors.bold(colors.cyan(relative)));
+        for (const m of fileMatches) {
+          for (const line of m.context) {
+            console.log(line);
+          }
+          console.log("");
+        }
+      }
+    } catch (error) {
+      consola.error(`Search failed:`, error);
+      process.exit(1);
+    }
+  },
+});


### PR DESCRIPTION
## Summary
- New `tt journal search <query>` command to grep journal entries with context
- `--type` flag to filter by entry type (daily-notes, meeting, note)
- `--range` flag to filter by date range (YYYY-MM-DD..YYYY-MM-DD)
- 16 tests covering all pure functions

## Test plan
- [x] `bun test -- journal` passes
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)