### PR TITLE
feat: add config validate and schema subcommands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { version } from "../package.json";
 export const main = defineCommand({
   meta: { name: "tt", version, description: "towles-tool — personal CLI utilities" },
   subCommands: {
-    config: () => import("./commands/config.js").then((m) => m.default),
+    config: () => import("./commands/config/index.js").then((m) => m.default),
     doctor: () => import("./commands/doctor.js").then((m) => m.default),
     install: () => import("./commands/install.js").then((m) => m.default),
     agentboard: () => import("./commands/agentboard.js").then((m) => m.default),

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -1,9 +1,0 @@
-import { describe, it, expect } from "vitest";
-import { runCommand } from "citty";
-
-describe("config command", () => {
-  it("runs config without throwing", async () => {
-    const { default: configCmd } = await import("./config.js");
-    await expect(runCommand(configCmd, { rawArgs: [] })).resolves.toBeDefined();
-  });
-});

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFile, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runCommand } from "citty";
+
+describe("config show", () => {
+  it("runs without throwing", async () => {
+    const { default: showCmd } = await import("./show.js");
+    await expect(runCommand(showCmd, { rawArgs: [] })).resolves.toBeDefined();
+  });
+});
+
+describe("config validate", () => {
+  let dir: string;
+
+  async function writeTempFile(content: string): Promise<string> {
+    dir = await mkdtemp(join(tmpdir(), "tt-config-test-"));
+    const filePath = join(dir, "settings.json");
+    await writeFile(filePath, content, "utf-8");
+    return filePath;
+  }
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("reports valid config as ok", async () => {
+    const filePath = await writeTempFile(JSON.stringify({ preferredEditor: "vim" }));
+    const { default: validateCmd } = await import("./validate.js");
+
+    process.exitCode = 0;
+    await runCommand(validateCmd, { rawArgs: ["--path", filePath] });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("reports invalid JSON", async () => {
+    const filePath = await writeTempFile("not json {{{");
+    const { default: validateCmd } = await import("./validate.js");
+
+    process.exitCode = 0;
+    await runCommand(validateCmd, { rawArgs: ["--path", filePath] });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports schema validation errors", async () => {
+    const filePath = await writeTempFile(JSON.stringify({ preferredEditor: 123 }));
+    const { default: validateCmd } = await import("./validate.js");
+
+    process.exitCode = 0;
+    await runCommand(validateCmd, { rawArgs: ["--path", filePath] });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports missing file", async () => {
+    const { default: validateCmd } = await import("./validate.js");
+
+    process.exitCode = 0;
+    await runCommand(validateCmd, { rawArgs: ["--path", "/tmp/nonexistent-tt-settings.json"] });
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("config schema", () => {
+  it("outputs valid JSON schema", async () => {
+    const { default: schemaCmd } = await import("./schema.js");
+
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await runCommand(schemaCmd, { rawArgs: [] });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    const schema = JSON.parse(output);
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toBeDefined();
+    expect(schema.properties.preferredEditor).toBeDefined();
+  });
+});

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,0 +1,10 @@
+import { defineCommand } from "citty";
+
+export default defineCommand({
+  meta: { name: "config", description: "Configuration management commands" },
+  subCommands: {
+    show: () => import("./show.js").then((m) => m.default),
+    validate: () => import("./validate.js").then((m) => m.default),
+    schema: () => import("./schema.js").then((m) => m.default),
+  },
+});

--- a/src/commands/config/schema.ts
+++ b/src/commands/config/schema.ts
@@ -1,0 +1,19 @@
+import { defineCommand } from "citty";
+import { z } from "zod/v4";
+import { UserSettingsRawSchema } from "../../config/settings.js";
+
+export default defineCommand({
+  meta: { name: "schema", description: "Export JSON Schema for the settings file" },
+  args: {
+    pretty: {
+      type: "boolean",
+      description: "Pretty-print the JSON output",
+      default: true,
+    },
+  },
+  async run({ args }) {
+    const jsonSchema = z.toJSONSchema(UserSettingsRawSchema, { target: "draft-2020-12" });
+    const indent = args.pretty ? 2 : undefined;
+    process.stdout.write(JSON.stringify(jsonSchema, null, indent) + "\n");
+  },
+});

--- a/src/commands/config/show.ts
+++ b/src/commands/config/show.ts
@@ -1,9 +1,9 @@
 import { defineCommand } from "citty";
 import consola from "consola";
-import { withSettings, debugArg } from "./shared.js";
+import { withSettings, debugArg } from "../shared.js";
 
 export default defineCommand({
-  meta: { name: "config", description: "Display current configuration settings" },
+  meta: { name: "show", description: "Display current configuration settings" },
   args: { debug: debugArg },
   async run({ args }) {
     const { settingsFile, settings } = await withSettings(args.debug);

--- a/src/commands/config/validate.ts
+++ b/src/commands/config/validate.ts
@@ -1,0 +1,51 @@
+import { readFile } from "node:fs/promises";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { colors } from "consola/utils";
+import { UserSettingsSchema, USER_SETTINGS_PATH } from "../../config/settings.js";
+import { debugArg } from "../shared.js";
+
+export default defineCommand({
+  meta: { name: "validate", description: "Validate settings file against the config schema" },
+  args: {
+    debug: debugArg,
+    path: {
+      type: "string",
+      description: "Path to settings file (defaults to standard location)",
+    },
+  },
+  async run({ args }) {
+    const filePath = args.path ?? USER_SETTINGS_PATH;
+
+    let raw: string;
+    try {
+      raw = await readFile(filePath, "utf-8");
+    } catch {
+      consola.error(`Settings file not found: ${filePath}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      consola.error(`Invalid JSON in ${filePath}: ${(e as Error).message}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = UserSettingsSchema.safeParse(parsed);
+
+    if (result.success) {
+      consola.log(`${colors.green("✓")} ${filePath} is valid`);
+    } else {
+      consola.log(`${colors.red("✗")} ${filePath} has validation errors:\n`);
+      for (const issue of result.error.issues) {
+        const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+        consola.log(`  ${colors.red("•")} ${colors.bold(path)}: ${issue.message}`);
+      }
+      process.exitCode = 1;
+    }
+  },
+});

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -58,6 +58,13 @@ export const UserSettingsSchema = z.object({
   ),
 });
 
+/** Schema without transforms — safe for JSON Schema export */
+export const UserSettingsRawSchema = z.object({
+  preferredEditor: z.string().default("code"),
+  journalSettings: JournalSettingsSchema.optional(),
+  agentboard: AgentboardSettingsSchema.optional(),
+});
+
 type UserSettings = z.infer<typeof UserSettingsSchema>;
 
 export interface SettingsFile {


### PR DESCRIPTION
## Summary
- Split `tt config` into subcommands: `show`, `validate`, `schema`
- `tt config validate [--path FILE]` — validates settings against Zod schema
- `tt config schema` — exports JSON Schema via `z.toJSONSchema()` for editor integrations
- Added `UserSettingsRawSchema` (transform-free) for clean schema export
- 6 tests covering show, validate (valid/invalid/missing), and schema output

## Test plan
- [x] `bun test -- config` passes
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)