### PR TITLE
feat: add JSON/CSV output formats to graph command

### DIFF
--- a/src/commands/graph/format.test.ts
+++ b/src/commands/graph/format.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { formatCsv, formatJson } from "./format";
+import type { SessionRow } from "./format";
+
+// ── formatJson ──
+
+describe("formatJson", () => {
+  it("returns valid JSON for empty array", () => {
+    const result = formatJson([]);
+    expect(JSON.parse(result)).toEqual([]);
+  });
+
+  it("serializes session rows with all fields", () => {
+    const rows: SessionRow[] = [
+      {
+        sessionPath: "/home/user/.claude/projects/test/abc123.jsonl",
+        project: "my-project",
+        model: "Opus",
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+        cost: 0.0525,
+        date: "2025-06-15",
+      },
+    ];
+    const parsed = JSON.parse(formatJson(rows));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].sessionPath).toBe("/home/user/.claude/projects/test/abc123.jsonl");
+    expect(parsed[0].project).toBe("my-project");
+    expect(parsed[0].model).toBe("Opus");
+    expect(parsed[0].inputTokens).toBe(1000);
+    expect(parsed[0].outputTokens).toBe(500);
+    expect(parsed[0].totalTokens).toBe(1500);
+    expect(parsed[0].cost).toBe(0.0525);
+    expect(parsed[0].date).toBe("2025-06-15");
+  });
+
+  it("serializes multiple rows", () => {
+    const rows: SessionRow[] = [
+      {
+        sessionPath: "/a.jsonl",
+        project: "proj-a",
+        model: "Opus",
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        cost: 0.005,
+        date: "2025-06-15",
+      },
+      {
+        sessionPath: "/b.jsonl",
+        project: "proj-b",
+        model: "Sonnet",
+        inputTokens: 200,
+        outputTokens: 100,
+        totalTokens: 300,
+        cost: 0.002,
+        date: "2025-06-16",
+      },
+    ];
+    const parsed = JSON.parse(formatJson(rows));
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].project).toBe("proj-a");
+    expect(parsed[1].project).toBe("proj-b");
+  });
+});
+
+// ── formatCsv ──
+
+describe("formatCsv", () => {
+  it("returns header only for empty array", () => {
+    const result = formatCsv([]);
+    expect(result).toBe(
+      "session_path,project,model,input_tokens,output_tokens,total_tokens,cost,date",
+    );
+  });
+
+  it("formats rows with proper CSV quoting", () => {
+    const rows: SessionRow[] = [
+      {
+        sessionPath: "/home/user/.claude/projects/test/abc123.jsonl",
+        project: "my-project",
+        model: "Opus",
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+        cost: 0.0525,
+        date: "2025-06-15",
+      },
+    ];
+    const lines = formatCsv(rows).split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe(
+      "session_path,project,model,input_tokens,output_tokens,total_tokens,cost,date",
+    );
+    expect(lines[1]).toContain('"my-project"');
+    expect(lines[1]).toContain("1000");
+    expect(lines[1]).toContain("500");
+    expect(lines[1]).toContain("1500");
+    expect(lines[1]).toContain("0.0525");
+    expect(lines[1]).toContain("2025-06-15");
+  });
+
+  it("formats multiple rows", () => {
+    const rows: SessionRow[] = [
+      {
+        sessionPath: "/a.jsonl",
+        project: "proj-a",
+        model: "Opus",
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        cost: 0.005,
+        date: "2025-06-15",
+      },
+      {
+        sessionPath: "/b.jsonl",
+        project: "proj-b",
+        model: "Sonnet",
+        inputTokens: 200,
+        outputTokens: 100,
+        totalTokens: 300,
+        cost: 0.002,
+        date: "2025-06-16",
+      },
+    ];
+    const lines = formatCsv(rows).split("\n");
+    expect(lines).toHaveLength(3);
+  });
+});

--- a/src/commands/graph/format.ts
+++ b/src/commands/graph/format.ts
@@ -1,0 +1,94 @@
+import { analyzeSession, extractProjectName, getPrimaryModel } from "./analyzer.js";
+import { parseJsonl } from "./parser.js";
+import type { SessionResult } from "./types.js";
+
+export type OutputFormat = "html" | "json" | "csv";
+
+export interface SessionRow {
+  sessionPath: string;
+  project: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cost: number;
+  date: string;
+}
+
+// Approximate pricing per million tokens (as of 2025)
+const COST_PER_MILLION: Record<string, { input: number; output: number }> = {
+  opus: { input: 15, output: 75 },
+  sonnet: { input: 3, output: 15 },
+  haiku: { input: 0.8, output: 4 },
+};
+
+function estimateCost(analysis: {
+  opusTokens: number;
+  sonnetTokens: number;
+  haikuTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+}): number {
+  const total = analysis.opusTokens + analysis.sonnetTokens + analysis.haikuTokens;
+  if (total === 0) return 0;
+
+  // Distribute input/output proportionally across models
+  let cost = 0;
+  for (const [model, tokens] of [
+    ["opus", analysis.opusTokens],
+    ["sonnet", analysis.sonnetTokens],
+    ["haiku", analysis.haikuTokens],
+  ] as const) {
+    if (tokens === 0) continue;
+    const fraction = tokens / total;
+    const inputShare = analysis.inputTokens * fraction;
+    const outputShare = analysis.outputTokens * fraction;
+    const rates = COST_PER_MILLION[model];
+    cost += (inputShare * rates.input + outputShare * rates.output) / 1_000_000;
+  }
+
+  return Math.round(cost * 10000) / 10000; // 4 decimal places
+}
+
+/**
+ * Build flat session rows from session results by parsing and analyzing each session.
+ */
+export function buildSessionRows(sessions: SessionResult[]): SessionRow[] {
+  return sessions.map((session) => {
+    const entries = parseJsonl(session.path);
+    const analysis = analyzeSession(entries);
+    const model = getPrimaryModel(analysis);
+    const project = extractProjectName(session.project);
+    const cost = estimateCost(analysis);
+
+    return {
+      sessionPath: session.path,
+      project,
+      model,
+      inputTokens: analysis.inputTokens,
+      outputTokens: analysis.outputTokens,
+      totalTokens: analysis.inputTokens + analysis.outputTokens,
+      cost,
+      date: session.date,
+    };
+  });
+}
+
+/**
+ * Format session rows as JSON string.
+ */
+export function formatJson(rows: SessionRow[]): string {
+  return JSON.stringify(rows, null, 2);
+}
+
+/**
+ * Format session rows as CSV string.
+ */
+export function formatCsv(rows: SessionRow[]): string {
+  const header = "session_path,project,model,input_tokens,output_tokens,total_tokens,cost,date";
+  const lines = rows.map(
+    (r) =>
+      `"${r.sessionPath}","${r.project}",${r.model},${r.inputTokens},${r.outputTokens},${r.totalTokens},${r.cost},${r.date}`,
+  );
+  return [header, ...lines].join("\n");
+}

--- a/src/commands/graph/index.ts
+++ b/src/commands/graph/index.ts
@@ -10,6 +10,8 @@ import { debugArg } from "../shared.js";
 import { buildAllSessionsTreemap, buildSessionTreemap } from "./treemap.js";
 import type { BarChartData } from "./types.js";
 import { buildBarChartData, findRecentSessions, findSessionPath } from "./sessions.js";
+import { buildSessionRows, formatCsv, formatJson } from "./format.js";
+import type { OutputFormat } from "./format.js";
 import { generateTreemapHtml } from "./render.js";
 import { openInBrowser, startServer, waitForShutdown } from "./server.js";
 import { parseJsonl } from "./parser.js";
@@ -21,7 +23,9 @@ export { buildBarChartData, findRecentSessions, findSessionPath } from "./sessio
 export { calculateCutoffMs, filterByDays, parseJsonl } from "./parser.js";
 export { extractSessionLabel } from "./labels.js";
 export { generateTreemapHtml } from "./render.js";
+export { buildSessionRows, formatCsv, formatJson } from "./format.js";
 export type { BarChartData, BarChartDay, ProjectBar, SessionResult, TreemapNode } from "./types.js";
+export type { OutputFormat, SessionRow } from "./format.js";
 
 export default defineCommand({
   meta: { name: "graph", description: "Generate interactive HTML treemap from session token data" },
@@ -54,10 +58,22 @@ export default defineCommand({
       description: "Filter to sessions from last N days (0=no limit, default: 7)",
       default: "7",
     },
+    format: {
+      type: "string" as const,
+      alias: "f",
+      description: "Output format: html (default), json, csv",
+      default: "html",
+    },
   },
   async run({ args }) {
     const port = Number(args.port);
     const days = Number(args.days);
+    const format = args.format as OutputFormat;
+
+    if (!["html", "json", "csv"].includes(format)) {
+      consola.error(`Invalid format "${format}". Use: html, json, csv`);
+      process.exit(1);
+    }
 
     const projectsDir = path.join(os.homedir(), ".claude", "projects");
     if (!fs.existsSync(projectsDir)) {
@@ -66,11 +82,47 @@ export default defineCommand({
     }
 
     const sessionId = args.session;
+
+    // JSON/CSV output: flat session rows to stdout
+    if (format === "json" || format === "csv") {
+      const sessions = sessionId
+        ? (() => {
+            const sessionPath = findSessionPath(projectsDir, sessionId);
+            if (!sessionPath) {
+              consola.error(`Session ${sessionId} not found`);
+              process.exit(1);
+            }
+            const stat = fs.statSync(sessionPath);
+            const project = path.basename(path.dirname(sessionPath));
+            return [
+              {
+                sessionId,
+                path: sessionPath,
+                date: stat.mtime.toLocaleDateString("en-CA"),
+                tokens: 0,
+                project,
+                mtime: stat.mtimeMs,
+              },
+            ];
+          })()
+        : findRecentSessions(projectsDir, 500, days);
+
+      if (sessions.length === 0) {
+        consola.error("No sessions found");
+        process.exit(1);
+      }
+
+      const rows = buildSessionRows(sessions);
+      const output = format === "json" ? formatJson(rows) : formatCsv(rows);
+      process.stdout.write(output + "\n");
+      return;
+    }
+
+    // HTML output (existing behavior)
     let treemapData;
     let barChartData: BarChartData = { days: [] };
 
     if (!sessionId) {
-      // All sessions mode
       const sessions = findRecentSessions(projectsDir, 500, days);
       if (sessions.length === 0) {
         consola.error("No sessions found");
@@ -82,7 +134,6 @@ export default defineCommand({
       treemapData = buildAllSessionsTreemap(sessions);
       barChartData = buildBarChartData(sessions);
     } else {
-      // Single session mode
       const sessionPath = findSessionPath(projectsDir, sessionId);
       if (!sessionPath) {
         consola.error(`Session ${sessionId} not found`);
@@ -92,13 +143,10 @@ export default defineCommand({
       consola.info(`📊 Generating treemap for session ${sessionId}...`);
       const entries = parseJsonl(sessionPath);
       treemapData = buildSessionTreemap(sessionId, entries);
-      // Bar chart not meaningful for single session, leave empty
     }
 
-    // Generate HTML
     const html = generateTreemapHtml(treemapData, barChartData);
 
-    // Write output file
     const reportsDir = path.join(os.homedir(), ".claude", "reports");
     if (!fs.existsSync(reportsDir)) {
       fs.mkdirSync(reportsDir, { recursive: true });
@@ -127,7 +175,6 @@ export default defineCommand({
         openInBrowser(url);
       }
 
-      // Keep server running until Ctrl+C
       await waitForShutdown(server);
       consola.info("\n👋 Stopping server...");
     } else if (args.open) {


### PR DESCRIPTION
## Summary
- New `--format` flag (`-f`) accepting `html` (default), `json`, `csv`
- JSON/CSV output structured session data to stdout (path, project, model, tokens, cost, date)
- JSON/CSV modes skip HTML generation and browser open
- Cost estimation based on model-proportional token distribution
- Tests for JSON and CSV formatters

## Test plan
- [x] `bun test -- graph` passes (94 tests)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)