### PR TITLE
feat: add auto-claude --explain and --step-template flags

### DIFF
--- a/src/commands/auto-claude/explain.test.ts
+++ b/src/commands/auto-claude/explain.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { ARTIFACTS, PIPELINE_STEPS, STEP_NAMES } from "./prompt-templates/index";
+import { buildStepInfos, printStepTemplate } from "./explain";
+
+describe("buildStepInfos", () => {
+  it("returns one entry per pipeline step", () => {
+    const infos = buildStepInfos();
+    expect(infos).toHaveLength(PIPELINE_STEPS.length);
+  });
+
+  it("preserves pipeline step order", () => {
+    const infos = buildStepInfos();
+    expect(infos.map((i) => i.name)).toEqual(STEP_NAMES);
+  });
+
+  it("every step has a template file, description, inputs, and outputs", () => {
+    for (const info of buildStepInfos()) {
+      expect(info.templateFile).toBeTruthy();
+      expect(info.description.length).toBeGreaterThan(0);
+      expect(info.inputs.length).toBeGreaterThan(0);
+      expect(info.outputs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("plan step reads initial-ramblings and outputs plan", () => {
+    const plan = buildStepInfos().find((i) => i.name === "plan")!;
+    expect(plan.inputs).toContain(ARTIFACTS.initialRamblings);
+    expect(plan.outputs).toContain(ARTIFACTS.plan);
+  });
+
+  it("implement step reads plan and outputs completed-summary", () => {
+    const impl = buildStepInfos().find((i) => i.name === "implement")!;
+    expect(impl.inputs).toContain(ARTIFACTS.plan);
+    expect(impl.outputs).toContain(ARTIFACTS.completedSummary);
+  });
+
+  it("review step outputs review artifact", () => {
+    const review = buildStepInfos().find((i) => i.name === "review")!;
+    expect(review.outputs).toContain(ARTIFACTS.review);
+  });
+});
+
+describe("printStepTemplate", () => {
+  it("throws for an unknown step name", () => {
+    expect(() => printStepTemplate("nonexistent")).toThrow(/Unknown step "nonexistent"/);
+  });
+
+  it("throws with valid step names in the error message", () => {
+    expect(() => printStepTemplate("bad")).toThrow(/plan, implement, simplify, review/);
+  });
+
+  it("does not throw for valid step names", () => {
+    for (const name of STEP_NAMES) {
+      expect(() => printStepTemplate(name)).not.toThrow();
+    }
+  });
+});

--- a/src/commands/auto-claude/explain.ts
+++ b/src/commands/auto-claude/explain.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import consola from "consola";
+import { colorize } from "consola/utils";
+
+import { ARTIFACTS, PIPELINE_STEPS, TEMPLATES } from "./prompt-templates/index.js";
+import type { StepName } from "./prompt-templates/index.js";
+import { TEMPLATES_DIR } from "./templates.js";
+
+interface StepInfo {
+  order: number;
+  name: string;
+  label: string;
+  templateFile: string;
+  description: string;
+  inputs: string[];
+  outputs: string[];
+}
+
+const STEP_DETAILS: Record<StepName, { description: string; inputs: string[]; outputs: string[] }> =
+  {
+    plan: {
+      description: "Research the issue and codebase, then produce a detailed implementation plan",
+      inputs: [ARTIFACTS.initialRamblings],
+      outputs: [ARTIFACTS.plan],
+    },
+    implement: {
+      description:
+        "Follow the plan checklist task-by-task using red/green TDD, then verify all checks pass",
+      inputs: [ARTIFACTS.plan, `${ARTIFACTS.review} (on retry)`],
+      outputs: [ARTIFACTS.completedSummary],
+    },
+    simplify: {
+      description:
+        "Review branch changes and simplify: remove dead code, inline over-abstractions, tighten types",
+      inputs: [ARTIFACTS.completedSummary],
+      outputs: [ARTIFACTS.simplifySummary],
+    },
+    review: {
+      description:
+        "Run automated checks then manually review the diff for correctness, security, and coverage",
+      inputs: [ARTIFACTS.plan, "git diff"],
+      outputs: [ARTIFACTS.review],
+    },
+  };
+
+export function buildStepInfos(): StepInfo[] {
+  const templateMap: Record<string, string> = TEMPLATES;
+  return PIPELINE_STEPS.map((s) => ({
+    order: s.order,
+    name: s.name,
+    label: s.label,
+    templateFile: templateMap[s.name] ?? "(none)",
+    ...STEP_DETAILS[s.name],
+  }));
+}
+
+export function printExplain(): void {
+  consola.log("");
+  consola.log(colorize("bold", "auto-claude pipeline"));
+  consola.log(
+    colorize("dim", "Steps 2-4 loop up to maxReviewRetries times if review returns FAIL\n"),
+  );
+
+  for (const step of buildStepInfos()) {
+    consola.log(colorize("cyan", `  ${step.label}`));
+    consola.log(`    ${step.description}`);
+    consola.log(`    ${colorize("dim", "template:")} ${step.templateFile}`);
+    consola.log(`    ${colorize("green", "inputs:")}  ${step.inputs.join(", ")}`);
+    consola.log(`    ${colorize("yellow", "outputs:")} ${step.outputs.join(", ")}`);
+    consola.log("");
+  }
+}
+
+export function printStepTemplate(stepName: string): void {
+  const step = PIPELINE_STEPS.find((s) => s.name === stepName);
+  if (!step) {
+    throw new Error(
+      `Unknown step "${stepName}". Valid steps: ${PIPELINE_STEPS.map((s) => s.name).join(", ")}`,
+    );
+  }
+
+  const templateMap: Record<string, string> = TEMPLATES;
+  const templateFile = templateMap[step.name];
+  if (!templateFile) {
+    throw new Error(`No template found for step "${stepName}"`);
+  }
+
+  const templatePath = join(TEMPLATES_DIR, templateFile);
+  const content = readFileSync(templatePath, "utf-8");
+
+  consola.log("");
+  consola.log(colorize("bold", `Template: ${templateFile}`));
+  consola.log(colorize("dim", `Step: ${step.label} (${step.name})\n`));
+  consola.log(content);
+}

--- a/src/commands/auto-claude/index.ts
+++ b/src/commands/auto-claude/index.ts
@@ -6,6 +6,7 @@ import { defineCommand } from "citty";
 import consola from "consola";
 
 import { debugArg } from "../shared.js";
+import { printExplain, printStepTemplate } from "./explain.js";
 import { STEP_NAMES, runPipeline } from "./pipeline.js";
 import { fetchIssue, fetchIssues } from "./steps/fetch-issues.js";
 import { getConfig, initConfig } from "./config.js";
@@ -75,6 +76,15 @@ export default defineCommand({
       type: "string" as const,
       description: "Path within repo to scope work (default: .)",
     },
+    explain: {
+      type: "boolean" as const,
+      description: "Print a summary of all pipeline steps and exit",
+      default: false,
+    },
+    "step-template": {
+      type: "string" as const,
+      description: `Print the raw prompt template for a step and exit (${STEP_NAMES.join(", ")})`,
+    },
   },
   subCommands: {
     list: () => import("./list.js").then((m) => m.default),
@@ -82,6 +92,23 @@ export default defineCommand({
     retry: () => import("./retry.js").then((m) => m.default),
   },
   async run({ args }) {
+    // Explain mode: print pipeline summary and exit
+    if (args.explain) {
+      printExplain();
+      return;
+    }
+
+    // Step template mode: print raw template and exit
+    if (args["step-template"]) {
+      try {
+        printStepTemplate(args["step-template"] as string);
+      } catch (e) {
+        consola.error(e instanceof Error ? e.message : String(e));
+        process.exit(1);
+      }
+      return;
+    }
+
     // Prompt mode: run a single prompt with structured output, skip issue pipeline
     if (args.prompt) {
       await initConfig({ model: args.model });


### PR DESCRIPTION
## Summary
- `--explain` flag prints formatted summary of all pipeline steps (name, description, inputs, outputs)
- `--step-template <name>` prints the raw prompt template for a specific step
- Both flags short-circuit before pipeline execution
- 9 tests covering step info correctness and error handling

## Test plan
- [x] `bun test -- auto-claude` passes (142 tests)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)