### PR TITLE
fix: add debug logging and use consola across agentboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
       "dependencies": {
         "@tt-agentboard/mux-tmux": "workspace:*",
         "@tt-agentboard/runtime": "workspace:*",
+        "consola": "^3.4.2",
       },
       "devDependencies": {
         "@types/bun": "latest",

--- a/packages/agentboard/apps/server/package.json
+++ b/packages/agentboard/apps/server/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@tt-agentboard/mux-tmux": "workspace:*",
-    "@tt-agentboard/runtime": "workspace:*"
+    "@tt-agentboard/runtime": "workspace:*",
+    "consola": "^3.4.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/packages/agentboard/apps/server/src/main.ts
+++ b/packages/agentboard/apps/server/src/main.ts
@@ -8,6 +8,7 @@ import {
   startServer,
 } from "@tt-agentboard/runtime";
 import { TmuxProvider } from "@tt-agentboard/mux-tmux";
+import consola from "consola";
 
 const config = loadConfig();
 const loader = new PluginLoader();
@@ -17,12 +18,12 @@ try {
   const provider = new TmuxProvider();
   loader.registerMux(provider);
 } catch (err) {
-  console.error("Failed to initialize tmux provider:", err);
+  consola.error("Failed to initialize tmux provider:", err);
 }
 
 const mux = loader.resolve(config.mux);
 if (!mux) {
-  console.error(
+  consola.error(
     "No terminal multiplexer detected.\n" +
       `Registered providers: ${loader.registry.list().join(", ") || "(none)"}\n` +
       "$TMUX environment variable is not set — are you running inside a tmux session?\n" +
@@ -38,8 +39,8 @@ loader.registerWatcher(new OpenCodeAgentWatcher());
 
 const watchers = loader.getWatchers();
 if (watchers.length > 0) {
-  console.log(`Agent watchers: ${watchers.map((watcher) => watcher.name).join(", ")}`);
+  consola.info(`Agent watchers: ${watchers.map((watcher) => watcher.name).join(", ")}`);
 }
 
-console.log(`Primary mux provider: ${mux.name}`);
+consola.info(`Primary mux provider: ${mux.name}`);
 startServer(mux, [], watchers);

--- a/packages/agentboard/packages/runtime/package.json
+++ b/packages/agentboard/packages/runtime/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "bun test"
   },
+  "dependencies": {
+    "consola": "^3.4.2"
+  },
   "devDependencies": {
     "@types/bun": "latest",
     "typescript": "^5"

--- a/packages/agentboard/packages/runtime/src/server/git-info.ts
+++ b/packages/agentboard/packages/runtime/src/server/git-info.ts
@@ -1,6 +1,7 @@
 import { existsSync, watch } from "node:fs";
 import type { FSWatcher } from "node:fs";
 import { join } from "node:path";
+import consola from "consola";
 import type { SessionData } from "../shared";
 
 // --- Shell helper (for git commands only) ---
@@ -151,8 +152,8 @@ export function syncGitWatchers(sessions: SessionData[], broadcastFn: () => void
     try {
       const watcher = watch(headPath, () => onGitHeadChange(broadcastFn));
       gitHeadWatchers.set(dir, watcher);
-    } catch {
-      /* ignore */
+    } catch (err) {
+      consola.debug(`Failed to watch git HEAD at ${headPath}:`, err);
     }
   }
 }

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -233,7 +233,9 @@ function findSidebarPane(windowId: string): string | null {
       const [paneId, title] = line.split(" ", 2);
       if (title === "agentboard-sidebar" && paneId) return paneId;
     }
-  } catch {}
+  } catch (err) {
+    consola.debug(`findSidebarPane failed for window ${windowId}:`, err);
+  }
   return null;
 }
 

--- a/src/commands/doctor/history.ts
+++ b/src/commands/doctor/history.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import consola from "consola";
 import { readFile, writeFile, fileExists } from "@towles/shared";
 import type { DoctorRunResult } from "./checks.js";
 
@@ -22,7 +23,8 @@ export function loadHistory(historyPath?: string): DoctorRunResult[] {
   if (!fileExists(path)) return [];
   try {
     return JSON.parse(readFile(path));
-  } catch {
+  } catch (err) {
+    consola.debug(`Failed to parse doctor history at ${path}:`, err);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- Replace `console.log/error` with `consola.info/error` in server main.ts
- Add debug logging for git watcher setup failures in git-info.ts
- Add debug logging for sidebar pane lookup failures in agentboard.ts
- Add consola as a dependency to the runtime package

## Test plan
- [x] Build passes
- [x] No new typecheck errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)