### PR TITLE
feat: add journal list subcommand

### DIFF
--- a/src/commands/journal/index.ts
+++ b/src/commands/journal/index.ts
@@ -7,5 +7,6 @@ export default defineCommand({
     note: () => import("./note.js").then((m) => m.default),
     meeting: () => import("./meeting.js").then((m) => m.default),
     search: () => import("./search.js").then((m) => m.default),
+    list: () => import("./list.js").then((m) => m.default),
   },
 });

--- a/src/commands/journal/list.test.ts
+++ b/src/commands/journal/list.test.ts
@@ -1,0 +1,174 @@
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  collectJournalEntries,
+  filterAndSortEntries,
+  formatSize,
+  formatDate,
+  renderTable,
+} from "./list.js";
+import type { JournalEntry } from "./list.js";
+import { JOURNAL_TYPES } from "../../types/journal.js";
+
+describe("journal list", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = path.join(tmpdir(), `journal-list-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("collectJournalEntries", () => {
+    it("collects entries with metadata", () => {
+      const dailyDir = path.join(tmpDir, "daily-notes");
+      mkdirSync(dailyDir, { recursive: true });
+      writeFileSync(path.join(dailyDir, "2026-03-15-saturday.md"), "hello world");
+
+      const files = [path.join(dailyDir, "2026-03-15-saturday.md")];
+      const entries = collectJournalEntries(files, tmpDir);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].relativePath).toBe(path.join("daily-notes", "2026-03-15-saturday.md"));
+      expect(entries[0].type).toBe(JOURNAL_TYPES.DAILY_NOTES);
+      expect(entries[0].date).not.toBeNull();
+      expect(entries[0].date!.getFullYear()).toBe(2026);
+      expect(entries[0].size).toBeGreaterThan(0);
+    });
+
+    it("skips files that cannot be stat'd", () => {
+      const entries = collectJournalEntries(["/nonexistent/file.md"], tmpDir);
+      expect(entries).toHaveLength(0);
+    });
+  });
+
+  describe("filterAndSortEntries", () => {
+    const makeEntry = (overrides: Partial<JournalEntry>): JournalEntry => ({
+      filePath: "/tmp/file.md",
+      relativePath: "file.md",
+      type: null,
+      date: null,
+      size: 100,
+      ...overrides,
+    });
+
+    it("filters by type", () => {
+      const entries = [
+        makeEntry({ type: JOURNAL_TYPES.DAILY_NOTES, relativePath: "a.md" }),
+        makeEntry({ type: JOURNAL_TYPES.MEETING, relativePath: "b.md" }),
+        makeEntry({ type: JOURNAL_TYPES.NOTE, relativePath: "c.md" }),
+      ];
+
+      const result = filterAndSortEntries(entries, {
+        type: JOURNAL_TYPES.MEETING,
+        limit: 20,
+        sort: "date",
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe(JOURNAL_TYPES.MEETING);
+    });
+
+    it("sorts by date descending", () => {
+      const entries = [
+        makeEntry({ date: new Date(2026, 0, 1), relativePath: "jan.md" }),
+        makeEntry({ date: new Date(2026, 2, 15), relativePath: "mar.md" }),
+        makeEntry({ date: new Date(2026, 1, 10), relativePath: "feb.md" }),
+      ];
+
+      const result = filterAndSortEntries(entries, { limit: 20, sort: "date" });
+      expect(result[0].relativePath).toBe("mar.md");
+      expect(result[1].relativePath).toBe("feb.md");
+      expect(result[2].relativePath).toBe("jan.md");
+    });
+
+    it("sorts by name alphabetically", () => {
+      const entries = [
+        makeEntry({ relativePath: "c.md" }),
+        makeEntry({ relativePath: "a.md" }),
+        makeEntry({ relativePath: "b.md" }),
+      ];
+
+      const result = filterAndSortEntries(entries, { limit: 20, sort: "name" });
+      expect(result[0].relativePath).toBe("a.md");
+      expect(result[1].relativePath).toBe("b.md");
+      expect(result[2].relativePath).toBe("c.md");
+    });
+
+    it("respects limit", () => {
+      const entries = [
+        makeEntry({ relativePath: "a.md" }),
+        makeEntry({ relativePath: "b.md" }),
+        makeEntry({ relativePath: "c.md" }),
+      ];
+
+      const result = filterAndSortEntries(entries, { limit: 2, sort: "name" });
+      expect(result).toHaveLength(2);
+    });
+
+    it("puts entries without dates last when sorting by date", () => {
+      const entries = [
+        makeEntry({ date: null, relativePath: "no-date.md" }),
+        makeEntry({ date: new Date(2026, 5, 1), relativePath: "with-date.md" }),
+      ];
+
+      const result = filterAndSortEntries(entries, { limit: 20, sort: "date" });
+      expect(result[0].relativePath).toBe("with-date.md");
+      expect(result[1].relativePath).toBe("no-date.md");
+    });
+  });
+
+  describe("formatSize", () => {
+    it("formats bytes", () => {
+      expect(formatSize(500)).toBe("500B");
+    });
+
+    it("formats kilobytes", () => {
+      expect(formatSize(2048)).toBe("2.0KB");
+    });
+
+    it("formats megabytes", () => {
+      expect(formatSize(1048576)).toBe("1.0MB");
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats a valid date", () => {
+      expect(formatDate(new Date(2026, 2, 15))).toBe("2026-03-15");
+    });
+
+    it("returns dash for null", () => {
+      expect(formatDate(null)).toBe("-");
+    });
+  });
+
+  describe("renderTable", () => {
+    it("renders a formatted table with header and rows", () => {
+      const entries: JournalEntry[] = [
+        {
+          filePath: "/tmp/daily-notes/2026-03-15.md",
+          relativePath: "daily-notes/2026-03-15.md",
+          type: JOURNAL_TYPES.DAILY_NOTES,
+          date: new Date(2026, 2, 15),
+          size: 1234,
+        },
+      ];
+
+      const table = renderTable(entries);
+      const lines = table.split("\n");
+      expect(lines).toHaveLength(2); // header + 1 row
+      expect(lines[0]).toContain("FILE");
+      expect(lines[0]).toContain("TYPE");
+      expect(lines[0]).toContain("DATE");
+      expect(lines[0]).toContain("SIZE");
+      expect(lines[1]).toContain("daily-notes/2026-03-15.md");
+      expect(lines[1]).toContain("daily-notes");
+      expect(lines[1]).toContain("2026-03-15");
+      expect(lines[1]).toContain("1.2KB");
+    });
+  });
+});

--- a/src/commands/journal/list.ts
+++ b/src/commands/journal/list.ts
@@ -1,0 +1,213 @@
+import { statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { colors } from "consola/utils";
+import { withSettings, debugArg } from "../shared.js";
+import type { JournalType } from "../../types/journal.js";
+import { JOURNAL_TYPES } from "../../types/journal.js";
+import { collectMarkdownFiles, inferTypeFromPath, extractDateFromFilename } from "./search.js";
+
+export interface JournalEntry {
+  filePath: string;
+  relativePath: string;
+  type: JournalType | null;
+  date: Date | null;
+  size: number;
+}
+
+export interface ListOptions {
+  type?: JournalType;
+  limit: number;
+  sort: "date" | "name";
+}
+
+/**
+ * Collect journal entries with metadata from a list of file paths.
+ */
+export function collectJournalEntries(files: string[], baseDir: string): JournalEntry[] {
+  const entries: JournalEntry[] = [];
+  for (const filePath of files) {
+    let size = 0;
+    try {
+      size = statSync(filePath).size;
+    } catch {
+      continue;
+    }
+    entries.push({
+      filePath,
+      relativePath: path.relative(baseDir, filePath),
+      type: inferTypeFromPath(filePath),
+      date: extractDateFromFilename(filePath),
+      size,
+    });
+  }
+  return entries;
+}
+
+/**
+ * Filter and sort journal entries based on options.
+ */
+export function filterAndSortEntries(
+  entries: JournalEntry[],
+  options: ListOptions,
+): JournalEntry[] {
+  let filtered = entries;
+
+  if (options.type) {
+    filtered = filtered.filter((e) => e.type === options.type);
+  }
+
+  filtered.sort((a, b) => {
+    if (options.sort === "date") {
+      const dateA = a.date?.getTime() ?? 0;
+      const dateB = b.date?.getTime() ?? 0;
+      return dateB - dateA; // newest first
+    }
+    return a.relativePath.localeCompare(b.relativePath);
+  });
+
+  return filtered.slice(0, options.limit);
+}
+
+/**
+ * Format a file size in bytes to a human-readable string.
+ */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)}KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)}MB`;
+}
+
+/**
+ * Format a date as YYYY-MM-DD or return "-" if null.
+ */
+export function formatDate(date: Date | null): string {
+  if (!date) return "-";
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Render journal entries as a formatted table.
+ */
+export function renderTable(entries: JournalEntry[]): string {
+  const header = { file: "FILE", type: "TYPE", date: "DATE", size: "SIZE" };
+  const rows = entries.map((e) => ({
+    file: e.relativePath,
+    type: e.type ?? "unknown",
+    date: formatDate(e.date),
+    size: formatSize(e.size),
+  }));
+
+  const allRows = [header, ...rows];
+  const colWidths = {
+    file: Math.max(...allRows.map((r) => r.file.length)),
+    type: Math.max(...allRows.map((r) => r.type.length)),
+    date: Math.max(...allRows.map((r) => r.date.length)),
+    size: Math.max(...allRows.map((r) => r.size.length)),
+  };
+
+  const lines: string[] = [];
+  for (const row of allRows) {
+    const line = [
+      row.file.padEnd(colWidths.file),
+      row.type.padEnd(colWidths.type),
+      row.date.padEnd(colWidths.date),
+      row.size.padStart(colWidths.size),
+    ].join("  ");
+    lines.push(line);
+  }
+
+  return lines.join("\n");
+}
+
+const VALID_TYPES = new Set<string>([
+  JOURNAL_TYPES.DAILY_NOTES,
+  JOURNAL_TYPES.MEETING,
+  JOURNAL_TYPES.NOTE,
+]);
+
+export default defineCommand({
+  meta: {
+    name: "list",
+    description: "List recent journal entries",
+  },
+  args: {
+    debug: debugArg,
+    type: {
+      type: "string",
+      alias: "t",
+      description: "Filter by entry type: daily-notes, meeting, note",
+    },
+    limit: {
+      type: "string",
+      alias: "l",
+      description: "Maximum number of entries to show (default: 20)",
+    },
+    sort: {
+      type: "string",
+      alias: "s",
+      description: "Sort by: date, name (default: date)",
+    },
+  },
+  async run({ args }) {
+    const { settings } = await withSettings(args.debug);
+
+    try {
+      const baseFolder = settings.journalSettings.baseFolder;
+      const journalDir = path.join(baseFolder, "journal");
+
+      // Validate --type
+      let typeFilter: JournalType | undefined;
+      if (args.type) {
+        if (!VALID_TYPES.has(args.type)) {
+          consola.error(
+            `Invalid type "${args.type}". Must be one of: ${[...VALID_TYPES].join(", ")}`,
+          );
+          process.exit(1);
+        }
+        typeFilter = args.type as JournalType;
+      }
+
+      // Parse --limit
+      const limit = args.limit ? Number.parseInt(args.limit, 10) : 20;
+      if (Number.isNaN(limit) || limit < 1) {
+        consola.error(`Invalid limit "${args.limit}". Must be a positive integer.`);
+        process.exit(1);
+      }
+
+      // Validate --sort
+      const sort = (args.sort ?? "date") as "date" | "name";
+      if (sort !== "date" && sort !== "name") {
+        consola.error(`Invalid sort "${args.sort}". Must be one of: date, name`);
+        process.exit(1);
+      }
+
+      const files = collectMarkdownFiles(journalDir);
+      if (files.length === 0) {
+        consola.info(`No journal files found in ${colors.cyan(journalDir)}`);
+        return;
+      }
+
+      const entries = collectJournalEntries(files, baseFolder);
+      const result = filterAndSortEntries(entries, { type: typeFilter, limit, sort });
+
+      if (result.length === 0) {
+        consola.info("No matching journal entries found.");
+        return;
+      }
+
+      consola.info(`Showing ${colors.green(String(result.length))} journal entries:\n`);
+      console.log(renderTable(result));
+    } catch (error) {
+      consola.error("Failed to list journal entries:", error);
+      process.exit(1);
+    }
+  },
+});


### PR DESCRIPTION
## Summary
- New `tt journal list` to browse recent journal entries
- `--type` filter (daily-notes, meeting, note), `--limit` (default 20), `--sort` (date/name)
- Formatted table output with filename, type, date, size
- Reuses existing search.ts helpers
- 13 tests covering pure functions

## Test plan
- [x] Tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)