### PR TITLE
feat: add doctor --format json for machine-readable output

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3,6 +3,7 @@ import consola from "consola";
 import { colors } from "consola/utils";
 import { debugArg } from "./shared.js";
 import { runAllChecks, checkAgentBoard, checkClaudePlugins } from "./doctor/checks.js";
+import { formatDoctorJson } from "./doctor/format.js";
 import { loadHistory, saveHistory, diffRuns } from "./doctor/history.js";
 import type { DiffEntry } from "./doctor/history.js";
 
@@ -39,11 +40,25 @@ export default defineCommand({
       description: "Compare current run against last tracked run",
       default: false,
     },
+    format: {
+      type: "string",
+      description: "Output format: text (default) or json",
+      default: "text",
+    },
   },
   async run({ args }) {
-    consola.info("Checking dependencies...\n");
+    const isJson = args.format === "json";
+
+    if (!isJson) {
+      consola.info("Checking dependencies...\n");
+    }
 
     const result = await runAllChecks();
+
+    if (isJson) {
+      console.log(formatDoctorJson(result));
+      return;
+    }
 
     for (const check of result.tools) {
       const icon = check.ok

--- a/src/commands/doctor/format.test.ts
+++ b/src/commands/doctor/format.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { formatDoctorJson } from "./format.js";
+import type { DoctorRunResult } from "./checks.js";
+
+function makeResult(overrides: Partial<DoctorRunResult> = {}): DoctorRunResult {
+  return {
+    timestamp: "2024-06-01T12:00:00.000Z",
+    tools: [
+      { name: "git", version: "2.40.0", ok: true },
+      { name: "node", version: "20.11.0", ok: true },
+      { name: "bun", version: "1.1.0", ok: true },
+    ],
+    ghAuth: true,
+    plugins: [{ name: "code-simplifier", ok: true }],
+    agentboard: [{ name: "database", ok: true }],
+    ...overrides,
+  };
+}
+
+describe("formatDoctorJson", () => {
+  it("returns valid JSON with all fields", () => {
+    const result = makeResult();
+    const output = formatDoctorJson(result);
+    const parsed = JSON.parse(output);
+
+    expect(parsed.timestamp).toBe("2024-06-01T12:00:00.000Z");
+    expect(parsed.tools).toHaveLength(3);
+    expect(parsed.ghAuth).toBe(true);
+    expect(parsed.plugins).toHaveLength(1);
+    expect(parsed.agentboard).toHaveLength(1);
+  });
+
+  it("includes tool details", () => {
+    const result = makeResult();
+    const parsed = JSON.parse(formatDoctorJson(result));
+    const git = parsed.tools.find((t: { name: string }) => t.name === "git");
+
+    expect(git).toEqual({ name: "git", version: "2.40.0", ok: true });
+  });
+
+  it("includes warning field when present", () => {
+    const result = makeResult({
+      tools: [{ name: "ttyd", version: null, ok: true, warning: "optional, not installed" }],
+    });
+    const parsed = JSON.parse(formatDoctorJson(result));
+
+    expect(parsed.tools[0].warning).toBe("optional, not installed");
+  });
+
+  it("preserves ghAuth false", () => {
+    const result = makeResult({ ghAuth: false });
+    const parsed = JSON.parse(formatDoctorJson(result));
+
+    expect(parsed.ghAuth).toBe(false);
+  });
+
+  it("roundtrips through JSON.parse", () => {
+    const result = makeResult();
+    const parsed = JSON.parse(formatDoctorJson(result));
+
+    expect(parsed).toEqual(result);
+  });
+});

--- a/src/commands/doctor/format.ts
+++ b/src/commands/doctor/format.ts
@@ -1,0 +1,5 @@
+import type { DoctorRunResult } from "./checks.js";
+
+export function formatDoctorJson(result: DoctorRunResult): string {
+  return JSON.stringify(result, null, 2);
+}


### PR DESCRIPTION
## Summary
- `--format json` flag outputs DoctorRunResult as JSON to stdout
- Skips all consola output in JSON mode for clean piping
- New `format.ts` module with `formatDoctorJson()` function
- 5 tests covering JSON roundtrip, field presence, edge cases

## Test plan
- [x] Tests pass (19 doctor tests)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)