### PR TITLE
feat(agentboard): add session status count badges to TUI StatusBar

### DIFF
--- a/packages/agentboard/apps/tui/src/components/StatusBar.tsx
+++ b/packages/agentboard/apps/tui/src/components/StatusBar.tsx
@@ -1,18 +1,43 @@
-import { Show } from "solid-js";
+import { Show, For } from "solid-js";
 import type { Accessor } from "solid-js";
 import type { Theme } from "@tt-agentboard/runtime";
+import { STATUS_ICONS } from "@tt-agentboard/runtime";
 import { BOLD } from "../constants";
+
+export interface SessionStatusCounts {
+  active: number;
+  error: number;
+  idle: number;
+}
 
 export interface StatusBarProps {
   sessionCount: number;
   runningCount: number;
   errorCount: number;
   unseenCount: number;
+  sessionStatusCounts: SessionStatusCounts;
   theme: Accessor<Theme>;
+}
+
+interface BadgeConfig {
+  label: string;
+  count: number;
+  color: (p: Theme["palette"]) => string;
+  icon: string;
 }
 
 export function StatusBar(props: StatusBarProps) {
   const P = () => props.theme().palette;
+
+  const badges = (): BadgeConfig[] => {
+    const counts = props.sessionStatusCounts;
+    const all: BadgeConfig[] = [
+      { label: "active", count: counts.active, color: (p) => p.green, icon: STATUS_ICONS.running },
+      { label: "error", count: counts.error, color: (p) => p.red, icon: STATUS_ICONS.error },
+      { label: "idle", count: counts.idle, color: (p) => p.surface2, icon: STATUS_ICONS.idle },
+    ];
+    return all.filter((b) => b.count > 0);
+  };
 
   return (
     <box flexDirection="column" paddingLeft={1} paddingTop={1} paddingBottom={0} flexShrink={0}>
@@ -44,6 +69,23 @@ export function StatusBar(props: StatusBarProps) {
           </span>
         </Show>
       </text>
+      <Show when={badges().length > 0}>
+        <text>
+          <span style={{ fg: P().overlay1 }}>{"  "}</span>
+          <For each={badges()}>
+            {(badge, i) => (
+              <>
+                <Show when={i() > 0}>
+                  <span style={{ fg: P().surface2 }}> </span>
+                </Show>
+                <span style={{ fg: badge.color(P()) }}>
+                  {badge.icon} {badge.count} {badge.label}
+                </span>
+              </>
+            )}
+          </For>
+        </text>
+      </Show>
     </box>
   );
 }

--- a/packages/agentboard/apps/tui/src/index.tsx
+++ b/packages/agentboard/apps/tui/src/index.tsx
@@ -20,6 +20,7 @@ import type { ServerMessage, SessionData, ClientCommand, Theme } from "@tt-agent
 import { SessionCard } from "./components/SessionCard";
 import { DetailPanel } from "./components/DetailPanel";
 import { StatusBar } from "./components/StatusBar";
+import { computeSessionStatusCounts } from "./session-status";
 import {
   detectMuxContext,
   refocusMainPane,
@@ -583,6 +584,7 @@ function App() {
   );
 
   const unseenCount = createMemo(() => sessions.filter((s) => s.unseen).length);
+  const sessionStatusCounts = createMemo(() => computeSessionStatusCounts(sessions));
 
   const isFocused = createSelector(focusedSession);
 
@@ -594,6 +596,7 @@ function App() {
         runningCount={runningAgentCount()}
         errorCount={errorAgentCount()}
         unseenCount={unseenCount()}
+        sessionStatusCounts={sessionStatusCounts()}
         theme={theme}
       />
 

--- a/packages/agentboard/apps/tui/src/session-status.test.ts
+++ b/packages/agentboard/apps/tui/src/session-status.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import type { SessionData, AgentEvent } from "@tt-agentboard/runtime";
+import { computeSessionStatusCounts } from "./session-status";
+
+function makeSession(agentStatus?: AgentEvent["status"]): SessionData {
+  return {
+    name: "test",
+    createdAt: Date.now(),
+    dir: "/tmp",
+    branch: "main",
+    dirty: false,
+    isWorktree: false,
+    filesChanged: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    commitsDelta: 0,
+    unseen: false,
+    panes: 1,
+    ports: [],
+    windows: 1,
+    uptime: "0s",
+    agentState: agentStatus
+      ? { agent: "claude", session: "test", status: agentStatus, ts: Date.now() }
+      : null,
+    agents: [],
+    eventTimestamps: [],
+  };
+}
+
+describe("computeSessionStatusCounts", () => {
+  it("returns all zeros for empty sessions", () => {
+    expect(computeSessionStatusCounts([])).toEqual({ active: 0, error: 0, idle: 0 });
+  });
+
+  it("counts running sessions as active", () => {
+    const sessions = [makeSession("running"), makeSession("running")];
+    expect(computeSessionStatusCounts(sessions)).toEqual({ active: 2, error: 0, idle: 0 });
+  });
+
+  it("counts waiting sessions as active", () => {
+    const sessions = [makeSession("waiting")];
+    expect(computeSessionStatusCounts(sessions)).toEqual({ active: 1, error: 0, idle: 0 });
+  });
+
+  it("counts error sessions", () => {
+    const sessions = [makeSession("error")];
+    expect(computeSessionStatusCounts(sessions)).toEqual({ active: 0, error: 1, idle: 0 });
+  });
+
+  it("counts idle, done, interrupted, and null agentState as idle", () => {
+    const sessions = [
+      makeSession("idle"),
+      makeSession("done"),
+      makeSession("interrupted"),
+      makeSession(undefined),
+    ];
+    expect(computeSessionStatusCounts(sessions)).toEqual({ active: 0, error: 0, idle: 4 });
+  });
+
+  it("counts mixed statuses correctly", () => {
+    const sessions = [
+      makeSession("running"),
+      makeSession("error"),
+      makeSession("idle"),
+      makeSession("waiting"),
+      makeSession("done"),
+    ];
+    expect(computeSessionStatusCounts(sessions)).toEqual({ active: 2, error: 1, idle: 2 });
+  });
+});

--- a/packages/agentboard/apps/tui/src/session-status.ts
+++ b/packages/agentboard/apps/tui/src/session-status.ts
@@ -1,0 +1,19 @@
+import type { SessionData } from "@tt-agentboard/runtime";
+import type { SessionStatusCounts } from "./components/StatusBar";
+
+export function computeSessionStatusCounts(sessions: SessionData[]): SessionStatusCounts {
+  let active = 0;
+  let error = 0;
+  let idle = 0;
+  for (const s of sessions) {
+    const status = s.agentState?.status;
+    if (status === "running" || status === "waiting") {
+      active++;
+    } else if (status === "error") {
+      error++;
+    } else {
+      idle++;
+    }
+  }
+  return { active, error, idle };
+}


### PR DESCRIPTION
## Summary
- StatusBar shows active/error/idle count badges with theme-colored icons
- New `computeSessionStatusCounts()` pure function in `session-status.ts`
- Running/waiting → active, error → error, everything else → idle
- Only non-zero counts displayed
- 6 tests covering all status combinations

## Test plan
- [x] Tests pass (6 session-status tests)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)