### PR TITLE
feat: add auto-claude config-init interactive setup

### DIFF
--- a/src/commands/auto-claude/config-init-helpers.ts
+++ b/src/commands/auto-claude/config-init-helpers.ts
@@ -1,0 +1,79 @@
+import { AutoClaudeConfigSchema } from "./config.js";
+import type { AutoClaudeConfig } from "./config.js";
+
+export const CONFIG_DIR = ".auto-claude";
+export const CONFIG_FILENAME = "config.json";
+export const CONFIG_PATH = `${CONFIG_DIR}/${CONFIG_FILENAME}`;
+
+export interface ConfigInitInput {
+  triggerLabel: string;
+  mainBranch: string;
+  scopePath: string;
+  model: string;
+  repo: string;
+}
+
+/**
+ * Build a full AutoClaudeConfig from user inputs, applying schema defaults.
+ */
+export function buildConfig(input: ConfigInitInput): AutoClaudeConfig {
+  return AutoClaudeConfigSchema.parse({
+    triggerLabel: input.triggerLabel,
+    mainBranch: input.mainBranch,
+    scopePath: input.scopePath,
+    model: input.model,
+    repo: input.repo,
+  });
+}
+
+/**
+ * Validate that a trigger label is non-empty and contains no spaces.
+ */
+export function validateTriggerLabel(label: string): string | true {
+  const trimmed = label.trim();
+  if (trimmed.length === 0) return "Trigger label cannot be empty";
+  if (/\s/.test(trimmed)) return "Trigger label cannot contain spaces";
+  return true;
+}
+
+/**
+ * Validate that a branch name is non-empty.
+ */
+export function validateBranchName(name: string): string | true {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return "Branch name cannot be empty";
+  return true;
+}
+
+/**
+ * Validate that a scope path is non-empty.
+ */
+export function validateScopePath(path: string): string | true {
+  const trimmed = path.trim();
+  if (trimmed.length === 0) return "Scope path cannot be empty";
+  return true;
+}
+
+/**
+ * Format the config as a human-readable summary for confirmation.
+ */
+export function formatConfigSummary(config: AutoClaudeConfig): string {
+  return [
+    `  repo:           ${config.repo}`,
+    `  triggerLabel:   ${config.triggerLabel}`,
+    `  mainBranch:     ${config.mainBranch}`,
+    `  scopePath:      ${config.scopePath}`,
+    `  model:          ${config.model}`,
+    `  remote:         ${config.remote}`,
+    `  maxIterations:  ${config.maxImplementIterations}`,
+    `  maxReviewRetries: ${config.maxReviewRetries}`,
+    `  loopInterval:   ${config.loopIntervalMinutes}min`,
+  ].join("\n");
+}
+
+/**
+ * Serialize config to JSON for writing to disk.
+ */
+export function serializeConfig(config: AutoClaudeConfig): string {
+  return JSON.stringify(config, null, 2) + "\n";
+}

--- a/src/commands/auto-claude/config-init.test.ts
+++ b/src/commands/auto-claude/config-init.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildConfig,
+  formatConfigSummary,
+  serializeConfig,
+  validateBranchName,
+  validateScopePath,
+  validateTriggerLabel,
+} from "./config-init-helpers";
+
+describe("validateTriggerLabel", () => {
+  it("accepts a valid label", () => {
+    expect(validateTriggerLabel("auto-claude")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(validateTriggerLabel("")).toBe("Trigger label cannot be empty");
+  });
+
+  it("rejects whitespace-only", () => {
+    expect(validateTriggerLabel("   ")).toBe("Trigger label cannot be empty");
+  });
+
+  it("rejects label with spaces", () => {
+    expect(validateTriggerLabel("auto claude")).toBe("Trigger label cannot contain spaces");
+  });
+});
+
+describe("validateBranchName", () => {
+  it("accepts a valid branch name", () => {
+    expect(validateBranchName("main")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(validateBranchName("")).toBe("Branch name cannot be empty");
+  });
+});
+
+describe("validateScopePath", () => {
+  it("accepts a valid path", () => {
+    expect(validateScopePath(".")).toBe(true);
+  });
+
+  it("accepts a subdirectory", () => {
+    expect(validateScopePath("src/lib")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(validateScopePath("")).toBe("Scope path cannot be empty");
+  });
+});
+
+describe("buildConfig", () => {
+  it("builds config with provided values", () => {
+    const config = buildConfig({
+      triggerLabel: "my-label",
+      mainBranch: "develop",
+      scopePath: "src/",
+      model: "sonnet",
+      repo: "owner/repo",
+    });
+
+    expect(config.triggerLabel).toBe("my-label");
+    expect(config.mainBranch).toBe("develop");
+    expect(config.scopePath).toBe("src/");
+    expect(config.model).toBe("sonnet");
+    expect(config.repo).toBe("owner/repo");
+  });
+
+  it("applies schema defaults for fields not in input", () => {
+    const config = buildConfig({
+      triggerLabel: "auto-claude",
+      mainBranch: "main",
+      scopePath: ".",
+      model: "opus",
+      repo: "owner/repo",
+    });
+
+    expect(config.remote).toBe("origin");
+    expect(config.maxImplementIterations).toBe(5);
+    expect(config.maxReviewRetries).toBe(2);
+    expect(config.loopIntervalMinutes).toBe(30);
+  });
+});
+
+describe("formatConfigSummary", () => {
+  it("includes all key fields", () => {
+    const config = buildConfig({
+      triggerLabel: "auto-claude",
+      mainBranch: "main",
+      scopePath: ".",
+      model: "opus",
+      repo: "owner/repo",
+    });
+
+    const summary = formatConfigSummary(config);
+    expect(summary).toContain("owner/repo");
+    expect(summary).toContain("auto-claude");
+    expect(summary).toContain("main");
+    expect(summary).toContain("opus");
+    expect(summary).toContain("origin");
+    expect(summary).toContain("30min");
+  });
+});
+
+describe("serializeConfig", () => {
+  it("returns valid JSON with trailing newline", () => {
+    const config = buildConfig({
+      triggerLabel: "auto-claude",
+      mainBranch: "main",
+      scopePath: ".",
+      model: "opus",
+      repo: "owner/repo",
+    });
+
+    const json = serializeConfig(config);
+    expect(json.endsWith("\n")).toBe(true);
+
+    const parsed = JSON.parse(json);
+    expect(parsed.repo).toBe("owner/repo");
+    expect(parsed.triggerLabel).toBe("auto-claude");
+  });
+
+  it("is pretty-printed with 2-space indent", () => {
+    const config = buildConfig({
+      triggerLabel: "test",
+      mainBranch: "main",
+      scopePath: ".",
+      model: "opus",
+      repo: "o/r",
+    });
+
+    const json = serializeConfig(config);
+    expect(json).toContain('  "repo"');
+  });
+});

--- a/src/commands/auto-claude/config-init.ts
+++ b/src/commands/auto-claude/config-init.ts
@@ -1,0 +1,159 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { defineCommand } from "citty";
+import consola from "consola";
+import prompts from "prompts";
+
+import { git, run } from "@towles/shared";
+import { debugArg } from "../shared.js";
+import { AutoClaudeConfigSchema } from "./config.js";
+import {
+  CONFIG_DIR,
+  CONFIG_PATH,
+  buildConfig,
+  formatConfigSummary,
+  serializeConfig,
+  validateBranchName,
+  validateScopePath,
+  validateTriggerLabel,
+} from "./config-init-helpers.js";
+
+async function detectRepo(): Promise<string> {
+  const result = await run(
+    "gh",
+    ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+    { throwOnError: true },
+  );
+  return result.stdout.trim();
+}
+
+async function detectMainBranch(): Promise<string> {
+  try {
+    const branch = await git(["symbolic-ref", "refs/remotes/origin/HEAD"]);
+    return branch.trim().replace("refs/remotes/origin/", "");
+  } catch {
+    return "main";
+  }
+}
+
+async function detectGitRoot(): Promise<string> {
+  return (await git(["rev-parse", "--show-toplevel"])).trim();
+}
+
+export default defineCommand({
+  meta: { name: "config-init", description: "Initialize auto-claude config for the current repo" },
+  args: {
+    debug: debugArg,
+    "non-interactive": {
+      type: "boolean" as const,
+      description: "Use all defaults without prompting",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const gitRoot = await detectGitRoot();
+    const configPath = join(gitRoot, CONFIG_PATH);
+
+    if (existsSync(configPath)) {
+      consola.warn(`Config already exists at ${CONFIG_PATH}`);
+      if (!args["non-interactive"]) {
+        const { overwrite } = await prompts({
+          type: "confirm",
+          name: "overwrite",
+          message: "Overwrite existing config?",
+          initial: false,
+        });
+        if (!overwrite) {
+          consola.info("Aborted.");
+          return;
+        }
+      }
+    }
+
+    const defaults = AutoClaudeConfigSchema.parse({
+      repo: await detectRepo(),
+      mainBranch: await detectMainBranch(),
+    });
+
+    if (args["non-interactive"]) {
+      const config = buildConfig({
+        triggerLabel: defaults.triggerLabel,
+        mainBranch: defaults.mainBranch,
+        scopePath: defaults.scopePath,
+        model: defaults.model,
+        repo: defaults.repo,
+      });
+
+      const dirPath = join(gitRoot, CONFIG_DIR);
+      mkdirSync(dirPath, { recursive: true });
+      writeFileSync(configPath, serializeConfig(config));
+      consola.success(`Config written to ${CONFIG_PATH}`);
+      return;
+    }
+
+    // Interactive prompts
+    const answers = await prompts([
+      {
+        type: "text",
+        name: "triggerLabel",
+        message: "Trigger label",
+        initial: defaults.triggerLabel,
+        validate: (v: string) => validateTriggerLabel(v),
+      },
+      {
+        type: "text",
+        name: "mainBranch",
+        message: "Main branch name",
+        initial: defaults.mainBranch,
+        validate: (v: string) => validateBranchName(v),
+      },
+      {
+        type: "text",
+        name: "scopePath",
+        message: "Scope path",
+        initial: defaults.scopePath,
+        validate: (v: string) => validateScopePath(v),
+      },
+      {
+        type: "text",
+        name: "model",
+        message: "Claude model",
+        initial: defaults.model,
+      },
+    ]);
+
+    // User cancelled (Ctrl-C during prompts)
+    if (!answers.triggerLabel) {
+      consola.info("Aborted.");
+      return;
+    }
+
+    const config = buildConfig({
+      triggerLabel: answers.triggerLabel,
+      mainBranch: answers.mainBranch,
+      scopePath: answers.scopePath,
+      model: answers.model,
+      repo: defaults.repo,
+    });
+
+    consola.box(`Config summary:\n\n${formatConfigSummary(config)}`);
+
+    const { confirmed } = await prompts({
+      type: "confirm",
+      name: "confirmed",
+      message: `Write config to ${CONFIG_PATH}?`,
+      initial: true,
+    });
+
+    if (!confirmed) {
+      consola.info("Aborted.");
+      return;
+    }
+
+    const dirPath = join(gitRoot, CONFIG_DIR);
+    mkdirSync(dirPath, { recursive: true });
+    writeFileSync(configPath, serializeConfig(config));
+    consola.success(`Config written to ${CONFIG_PATH}`);
+  },
+});

--- a/src/commands/auto-claude/index.ts
+++ b/src/commands/auto-claude/index.ts
@@ -90,6 +90,7 @@ export default defineCommand({
     list: () => import("./list.js").then((m) => m.default),
     status: () => import("./status.js").then((m) => m.default),
     retry: () => import("./retry.js").then((m) => m.default),
+    "config-init": () => import("./config-init.js").then((m) => m.default),
   },
   async run({ args }) {
     // Explain mode: print pipeline summary and exit


### PR DESCRIPTION
## Summary
- New `tt ac config-init` subcommand for guided config setup
- Detects repo root and branch from git, prompts for label/scope/model
- Shows summary and writes `.auto-claude/config.json`
- `--non-interactive` flag for CI/agent use (applies all defaults)
- Pure helper functions: `buildConfig`, `validateTriggerLabel`, `validateBranchName`, `validateScopePath`
- 14 tests covering validation and config generation

## Test plan
- [x] `bun test -- config-init` passes (14 tests)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)