### PR TITLE
fix: detect subagent activity and fix sidebar pane title loss

### DIFF
--- a/plugins/tt-agentboard/apps/tui/src/index.tsx
+++ b/plugins/tt-agentboard/apps/tui/src/index.tsx
@@ -25,7 +25,7 @@ import {
   saveConfig,
 } from "@tt-agentboard/runtime";
 import type { ServerMessage, SessionData, ClientCommand, Theme } from "@tt-agentboard/runtime";
-import { TmuxClient } from "@tt-agentboard/mux-tmux";
+import { TmuxClient, SIDEBAR_PANE_TITLE } from "@tt-agentboard/mux-tmux";
 import { SessionCard } from "./components/SessionCard";
 import { DetailPanel } from "./components/DetailPanel";
 import { StatusBar } from "./components/StatusBar";
@@ -80,6 +80,11 @@ function persistDetailPanelHeight(sessionName: string, height: number): void {
   });
 }
 
+/** Ensure this sidebar pane is titled so getActiveSessionDirs() can filter it out. */
+if (muxCtx.type === "tmux") {
+  muxCtx.sdk.setPaneTitle(muxCtx.paneId, SIDEBAR_PANE_TITLE);
+}
+
 /** Refocus the main (non-sidebar) pane after TUI capability detection finishes.
  *  This must happen from the TUI process — doing it from the server races with
  *  capability query responses and leaks escape sequences to the main pane. */
@@ -102,7 +107,7 @@ function refocusMainPane() {
         { stdout: "pipe", stderr: "pipe" },
       );
       const lines = r.stdout.toString().trim().split("\n");
-      const main = lines.find((l) => !l.includes("agentboard-sidebar"));
+      const main = lines.find((l) => !l.includes(SIDEBAR_PANE_TITLE));
       if (main) {
         const paneId = main.split(" ")[0];
         Bun.spawnSync(["tmux", "select-pane", "-t", paneId], { stdout: "pipe", stderr: "pipe" });

--- a/plugins/tt-agentboard/packages/mux-tmux/src/index.ts
+++ b/plugins/tt-agentboard/packages/mux-tmux/src/index.ts
@@ -15,4 +15,4 @@ export {
 } from "./client";
 
 // Re-export TmuxProvider from provider module
-export { TmuxProvider, type TmuxProviderSettings } from "./provider";
+export { TmuxProvider, SIDEBAR_PANE_TITLE, type TmuxProviderSettings } from "./provider";

--- a/plugins/tt-agentboard/packages/mux-tmux/src/provider.ts
+++ b/plugins/tt-agentboard/packages/mux-tmux/src/provider.ts
@@ -24,7 +24,7 @@ function plog(msg: string, data?: Record<string, unknown>) {
 }
 
 const STASH_SESSION = "_ab_stash";
-const SIDEBAR_PANE_TITLE = "agentboard-sidebar";
+export const SIDEBAR_PANE_TITLE = "agentboard-sidebar";
 
 export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapable, BatchCapable {
   readonly specificationVersion = "v1" as const;

--- a/plugins/tt-agentboard/packages/runtime/src/agents/watchers/claude-code.ts
+++ b/plugins/tt-agentboard/packages/runtime/src/agents/watchers/claude-code.ts
@@ -266,18 +266,40 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
         }
 
         for (const file of files) {
-          if (!file.endsWith(".jsonl")) continue;
-          const filePath = join(dirPath, file);
-          let fileStat;
-          try {
-            fileStat = await stat(filePath);
-          } catch {
-            continue;
+          if (file.endsWith(".jsonl")) {
+            const filePath = join(dirPath, file);
+            let fileStat;
+            try {
+              fileStat = await stat(filePath);
+            } catch {
+              continue;
+            }
+            if (now - fileStat.mtimeMs > STALE_MS) continue;
+            this.watchDir(dirPath, projectDir);
+            await this.processFile(filePath, projectDir);
+          } else {
+            // Scan subagent directories: <session-id>/subagents/*.jsonl
+            const subagentsDir = join(dirPath, file, "subagents");
+            let subFiles: string[];
+            try {
+              subFiles = await readdir(subagentsDir);
+            } catch {
+              continue;
+            }
+            for (const subFile of subFiles) {
+              if (!subFile.endsWith(".jsonl")) continue;
+              const filePath = join(subagentsDir, subFile);
+              let fileStat;
+              try {
+                fileStat = await stat(filePath);
+              } catch {
+                continue;
+              }
+              if (now - fileStat.mtimeMs > STALE_MS) continue;
+              this.watchDir(subagentsDir, projectDir);
+              await this.processFile(filePath, projectDir);
+            }
           }
-          if (now - fileStat.mtimeMs > STALE_MS) continue;
-          // Lazily watch dirs that become active
-          this.watchDir(dirPath);
-          await this.processFile(filePath, projectDir);
         }
       }
     } finally {
@@ -304,9 +326,9 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
 
   private watchedDirs = new Set<string>();
 
-  private watchDir(dirPath: string): void {
+  private watchDir(dirPath: string, explicitProjectDir?: string): void {
     if (this.watchedDirs.has(dirPath)) return;
-    const projectDir = decodeProjectDir(basename(dirPath));
+    const projectDir = explicitProjectDir ?? decodeProjectDir(basename(dirPath));
     try {
       const w = watch(dirPath, (_eventType, filename) => {
         if (!filename?.endsWith(".jsonl")) return;
@@ -350,10 +372,26 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
         continue;
       }
 
+      const projectDir = decodeProjectDir(dir);
+
       // Only watch directories that have recently-modified files
       if (this.hasRecentFiles(dirPath)) {
-        this.watchDir(dirPath);
+        this.watchDir(dirPath, projectDir);
       }
+
+      // Also watch subagent directories
+      try {
+        const entries = fs.readdirSync(dirPath);
+        for (const entry of entries) {
+          if (entry.endsWith(".jsonl")) continue;
+          const subagentsDir = join(dirPath, entry, "subagents");
+          try {
+            if (fs.statSync(subagentsDir).isDirectory() && this.hasRecentFiles(subagentsDir)) {
+              this.watchDir(subagentsDir, projectDir);
+            }
+          } catch {}
+        }
+      } catch {}
     }
 
     // Watch projects dir for new project directories

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -400,14 +400,18 @@ async function restart(): Promise<void> {
     // no tmux or no sessions
   }
 
-  // 2. Ensure server is running
+  // 2. Re-register tmux hooks and keybindings (lost on tmux restart)
+  init();
+  consola.success("Hooks and keybindings re-registered");
+
+  // 3. Ensure server is running
   if (!(await ensureServerUp())) {
     consola.error("Failed to start agentboard server");
     process.exit(1);
   }
   consola.success("Server is running");
 
-  // 3. Toggle sidebar on (the server spawns sidebars in all active windows)
+  // 4. Toggle sidebar on (the server spawns sidebars in all active windows)
   try {
     const res = await fetch(`http://${SERVER_HOST}:${SERVER_PORT}/toggle`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- **Subagent detection**: Claude Code watcher now scans `<session-id>/subagents/*.jsonl` files, so worktree-spawned agents appear in the agentboard
- **Sidebar title fix**: TUI self-sets its pane title to `agentboard-sidebar` on startup, preventing `getActiveSessionDirs()` from picking the wrong directory when titles are lost after server restarts
- **Constant cleanup**: Exported `SIDEBAR_PANE_TITLE` from mux-tmux and replaced hardcoded strings in the TUI
- **Restart command**: Re-registers tmux hooks/keybindings before starting the server

## Root cause
Two bugs combined to hide agents:
1. Sidebar panes lost their title → session directory resolved to the agentboard plugin path instead of the project path → `resolveSession()` couldn't match JSONL activity to tmux sessions
2. Subagent JSONL files in nested `subagents/` directories were never scanned by the watcher

## Test plan
- [ ] Start agentboard with agents using worktree subagents — verify subagents appear
- [ ] Kill and restart the agentboard server — verify sidebar titles persist and agents remain visible
- [ ] `bun test` passes (25/25 agentboard tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)