### PR TITLE
fix(agentboard): show running status for live agents between turns

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -24,7 +24,7 @@ Then read the resulting file with the `Read` tool to view it visually.
 ## Full workflow
 
 1. Run the bash command above to capture the screen
-2. Get the filename from the output (latest Screenshot_*.png in /tmp)
+2. Get the filename from the output (latest Screenshot\_\*.png in /tmp)
 3. Use `Read` tool on the PNG path — Claude Code will render it as an image
 4. Analyze the screenshot and report findings
 

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "bun:test";
+import { determineStatus } from "./claude-code";
+
+describe("determineStatus", () => {
+  it('returns "idle" when no message', () => {
+    expect(determineStatus({})).toBe("idle");
+    expect(determineStatus({ message: undefined })).toBe("idle");
+  });
+
+  it('returns "idle" when message has no role', () => {
+    expect(determineStatus({ message: { content: "hi" } })).toBe("idle");
+  });
+
+  it('returns "running" for user messages', () => {
+    expect(determineStatus({ message: { role: "user", content: "hello" } })).toBe("running");
+  });
+
+  it('returns "running" for assistant messages with tool_use', () => {
+    expect(
+      determineStatus({
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me check that." },
+            { type: "tool_use" },
+          ],
+        },
+      }),
+    ).toBe("running");
+  });
+
+  it('returns "done" for assistant messages without tool_use', () => {
+    expect(
+      determineStatus({
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Here is the answer." }],
+        },
+      }),
+    ).toBe("done");
+  });
+
+  it('returns "done" for assistant messages with string content', () => {
+    expect(
+      determineStatus({
+        message: { role: "assistant", content: "plain text response" },
+      }),
+    ).toBe("done");
+  });
+
+  it('returns "done" for assistant messages with empty content', () => {
+    expect(
+      determineStatus({
+        message: { role: "assistant", content: [] },
+      }),
+    ).toBe("done");
+  });
+
+  it('returns "idle" for unknown roles', () => {
+    expect(
+      determineStatus({
+        message: { role: "system", content: "system message" },
+      }),
+    ).toBe("idle");
+  });
+});

--- a/packages/agentboard/packages/runtime/src/server/index.ts
+++ b/packages/agentboard/packages/runtime/src/server/index.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import type { MuxProvider } from "../contracts/mux";
 import { isFullSidebarCapable, isBatchCapable } from "../contracts/mux";
 import type { AgentEvent } from "../contracts/agent";
+import { TERMINAL_STATUSES } from "../contracts/agent";
 import type { AgentWatcher, AgentWatcherContext } from "../contracts/agent-watcher";
 import { AgentTracker, instanceKey } from "../agents/tracker";
 import { SessionOrder } from "./session-order";
@@ -197,6 +198,22 @@ export function startServer(
     if (!paneAgents || paneAgents.size === 0) return watcherAgents;
 
     const result = [...watcherAgents];
+
+    // Correct watcher statuses using pane liveness: if a watcher reports
+    // a terminal status but the pane scanner confirms the process is alive,
+    // the agent is between turns — override to "running".
+    for (const [, presence] of paneAgents) {
+      if (!presence.threadId) continue;
+      const matchIdx = result.findIndex(
+        (a) => a.agent === presence.agent && a.threadId === presence.threadId,
+      );
+      if (matchIdx === -1) continue;
+      const tracked = result[matchIdx]!;
+      if (TERMINAL_STATUSES.has(tracked.status)) {
+        result[matchIdx] = { ...tracked, status: "running", paneId: presence.paneId };
+      }
+    }
+
     // Build a set of tracked agent:threadId keys for matching
     const trackedByKey = new Set(watcherAgents.map((a) => instanceKey(a.agent, a.threadId)));
     // Also track which agent names + threadIds are covered by watchers

--- a/packages/agentboard/packages/runtime/src/server/index.ts
+++ b/packages/agentboard/packages/runtime/src/server/index.ts
@@ -198,35 +198,26 @@ export function startServer(
     if (!paneAgents || paneAgents.size === 0) return watcherAgents;
 
     const result = [...watcherAgents];
-
-    // Correct watcher statuses using pane liveness: if a watcher reports
-    // a terminal status but the pane scanner confirms the process is alive,
-    // the agent is between turns — override to "running".
-    for (const [, presence] of paneAgents) {
-      if (!presence.threadId) continue;
-      const matchIdx = result.findIndex(
-        (a) => a.agent === presence.agent && a.threadId === presence.threadId,
-      );
-      if (matchIdx === -1) continue;
-      const tracked = result[matchIdx]!;
-      if (TERMINAL_STATUSES.has(tracked.status)) {
-        result[matchIdx] = { ...tracked, status: "running", paneId: presence.paneId };
-      }
-    }
-
-    // Build a set of tracked agent:threadId keys for matching
-    const trackedByKey = new Set(watcherAgents.map((a) => instanceKey(a.agent, a.threadId)));
-    // Also track which agent names + threadIds are covered by watchers
-    const trackedThreadIds = new Set(
-      watcherAgents.filter((a) => a.threadId).map((a) => `${a.agent}:${a.threadId}`),
+    const trackedByKey = new Map(
+      result.map((a, i) => [instanceKey(a.agent, a.threadId), i]),
     );
 
     for (const [, presence] of paneAgents) {
-      // If the pane scanner resolved a threadId, check if watcher already tracks it
-      if (presence.threadId && trackedThreadIds.has(`${presence.agent}:${presence.threadId}`))
+      const key = instanceKey(presence.agent, presence.threadId);
+      const trackedIdx = trackedByKey.get(key);
+
+      if (trackedIdx != null) {
+        // Watcher already tracks this agent — correct terminal statuses
+        // using pane liveness (process is confirmed alive, so terminal
+        // journal status is a between-turn artifact).
+        const tracked = result[trackedIdx]!;
+        if (TERMINAL_STATUSES.has(tracked.status)) {
+          tracked.status = "running";
+          tracked.paneId = presence.paneId;
+        }
         continue;
-      // Check by instanceKey as well
-      if (trackedByKey.has(instanceKey(presence.agent, presence.threadId))) continue;
+      }
+
       // If we have no threadId from pane scan and watcher tracks any instance of this agent, skip
       if (!presence.threadId && watcherAgents.some((a) => a.agent === presence.agent)) continue;
 

--- a/packages/agentboard/packages/runtime/src/server/pane-scanner.ts
+++ b/packages/agentboard/packages/runtime/src/server/pane-scanner.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { AgentStatus } from "../contracts/agent";
+import { TERMINAL_STATUSES } from "../contracts/agent";
 import type { SidebarPane } from "../contracts/mux";
 import type { ServerContext, PaneAgentPresence } from "./context";
 import { shell } from "./git-info";
@@ -98,6 +99,11 @@ function resolveClaudeCodePaneInfo(
     const threadId: string | undefined = data.sessionId;
     if (!threadId) return {};
     const journalInfo = resolveClaudeCodeJournalInfo(threadId);
+    // Process is alive (found via process tree), so terminal journal status
+    // is a between-turn artifact — override to running.
+    if (journalInfo.status && TERMINAL_STATUSES.has(journalInfo.status)) {
+      journalInfo.status = "running";
+    }
     return { threadId, ...journalInfo };
   } catch {
     return {};

--- a/src/commands/journal/search.test.ts
+++ b/src/commands/journal/search.test.ts
@@ -49,9 +49,7 @@ describe("journal search", () => {
     });
 
     it("detects meeting", () => {
-      expect(inferTypeFromPath("/journal/2026/01/meetings/standup.md")).toBe(
-        JOURNAL_TYPES.MEETING,
-      );
+      expect(inferTypeFromPath("/journal/2026/01/meetings/standup.md")).toBe(JOURNAL_TYPES.MEETING);
     });
 
     it("detects note", () => {

--- a/src/commands/journal/search.ts
+++ b/src/commands/journal/search.ts
@@ -83,10 +83,7 @@ export function extractDateFromFilename(filePath: string): Date | null {
 /**
  * Search journal files for a query string, returning matches with context.
  */
-export function searchJournalFiles(
-  files: string[],
-  options: SearchOptions,
-): SearchMatch[] {
+export function searchJournalFiles(files: string[], options: SearchOptions): SearchMatch[] {
   const { query, type, startDate, endDate, contextLines = 2 } = options;
   const lowerQuery = query.toLowerCase();
   const matches: SearchMatch[] = [];
@@ -229,7 +226,9 @@ export default defineCommand({
         return;
       }
 
-      consola.info(`Found ${colors.green(String(matches.length))} match(es) for "${colors.cyan(args.query)}":\n`);
+      consola.info(
+        `Found ${colors.green(String(matches.length))} match(es) for "${colors.cyan(args.query)}":\n`,
+      );
 
       // Group matches by file
       const byFile = new Map<string, SearchMatch[]>();


### PR DESCRIPTION
## Summary

- Override terminal agent statuses ("done"/"error"/"interrupted") to "running" when pane scanner confirms the Claude process is still alive
- Fixes the TUI spinner flickering to inactive between API turns
- Defense-in-depth: pane scanner's `resolveClaudeCodePaneInfo` also overrides terminal status since process liveness is already confirmed

## Test plan

- [x] `bun test` passes (395 tests)
- [x] `bun typecheck` clean
- [ ] Manual: watch agentboard TUI during auto-claude session — spinner should persist between turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)