### PR TITLE
fix(agentboard): fix 4 bugs — env vars, ensure-sidebar, uninstall filter, stale signal

### DIFF
--- a/packages/agentboard/apps/tui/src/index.tsx
+++ b/packages/agentboard/apps/tui/src/index.tsx
@@ -388,8 +388,9 @@ function App() {
 
             if (!startupFocusSynced && sessions.some((session) => session.name === msg.name)) {
               startupFocusSynced = true;
+              const oldFocus = focusedSession();
               setFocusedSession(msg.name);
-              if (focusedSession() !== msg.name) {
+              if (oldFocus !== msg.name) {
                 startupFocusToPublish = msg.name;
               }
             }

--- a/packages/agentboard/packages/runtime/src/shared.ts
+++ b/packages/agentboard/packages/runtime/src/shared.ts
@@ -1,7 +1,10 @@
 import type { AgentStatus, AgentEvent } from "./contracts/agent";
 
-export const SERVER_PORT = 4201;
-export const SERVER_HOST = "127.0.0.1";
+export const DEFAULT_SERVER_PORT = 4201;
+export const DEFAULT_SERVER_HOST = "127.0.0.1";
+
+export const SERVER_PORT: number = Number(process.env.TT_AGENTBOARD_PORT) || DEFAULT_SERVER_PORT;
+export const SERVER_HOST: string = process.env.TT_AGENTBOARD_HOST || DEFAULT_SERVER_HOST;
 export const PID_FILE = "/tmp/agentboard.pid";
 export const SERVER_IDLE_TIMEOUT_MS = 30_000;
 export const STUCK_RUNNING_TIMEOUT_MS = 3 * 60 * 1000;

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -6,8 +6,8 @@ import consola from "consola";
 import { colors } from "consola/utils";
 import { debugArg } from "./shared.js";
 
-const SERVER_HOST = "127.0.0.1";
-const SERVER_PORT = 4201;
+const SERVER_HOST = process.env.TT_AGENTBOARD_HOST || "127.0.0.1";
+const SERVER_PORT = Number(process.env.TT_AGENTBOARD_PORT) || 4201;
 
 // Keybinding defaults
 const DEFAULT_KEY = "a";
@@ -146,14 +146,14 @@ function uninstall(): void {
   }
 
   const content = readFileSync(editPath, "utf8");
-  if (!content.includes("agentboard")) {
+  if (!content.includes(MARKER) && !content.includes(RUN_SHELL_LINE)) {
     consola.info("agentboard not found in tmux.conf");
     return;
   }
 
   const newContent = content
     .split("\n")
-    .filter((line) => !line.includes("agentboard"))
+    .filter((line) => !line.includes(MARKER) && !line.includes(RUN_SHELL_LINE))
     .join("\n")
     .replace(/\n{3,}/g, "\n\n");
 
@@ -333,12 +333,13 @@ async function runFocus(): Promise<void> {
     return;
   }
 
-  // Otherwise, ensure server + toggle sidebar on
+  // Otherwise, ensure server + open sidebar
   if (!(await ensureServerUp())) process.exit(0);
   const ctx = tmuxContext();
-  await fetch(`http://${SERVER_HOST}:${SERVER_PORT}/toggle`, { method: "POST", body: ctx }).catch(
-    () => {},
-  );
+  await fetch(`http://${SERVER_HOST}:${SERVER_PORT}/ensure-sidebar`, {
+    method: "POST",
+    body: ctx,
+  }).catch(() => {});
 
   // Wait for sidebar pane to appear
   for (let i = 0; i < 20; i++) {


### PR DESCRIPTION
## Summary

- **#195**: `SERVER_HOST`/`SERVER_PORT` now read from `TT_AGENTBOARD_HOST`/`TT_AGENTBOARD_PORT` env vars with existing defaults as fallback
- **#196**: `runFocus()` calls `/ensure-sidebar` instead of `/toggle` so sidebar is guaranteed to open
- **#197**: `uninstall()` filters by `MARKER` and `RUN_SHELL_LINE` constants instead of broad `"agentboard"` match
- **#199**: Read `focusedSession()` before `setFocusedSession()` inside `batch()` to avoid stale signal value

Closes #195, closes #196, closes #197, closes #199

## Test plan

- [x] All 397 tests pass
- [x] Typecheck, lint, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)