### PR TITLE
fix(agentboard): distinguish waiting vs running agents, fix restart

### DIFF
--- a/packages/agentboard/apps/tui/src/components/SessionCard.tsx
+++ b/packages/agentboard/apps/tui/src/components/SessionCard.tsx
@@ -33,6 +33,7 @@ export function SessionCard(props: SessionCardProps) {
     if (s === "error") return P().red;
     if (s === "interrupted") return P().peach;
     if (s === "running") return P().yellow;
+    if (s === "waiting") return P().blue;
     if (props.isFocused) return P().lavender;
     return "transparent";
   };
@@ -47,6 +48,7 @@ export function SessionCard(props: SessionCardProps) {
   const statusIcon = () => {
     const s = status();
     if (s === "running") return SPINNERS[props.spinIdx() % SPINNERS.length]!;
+    if (s === "waiting") return "◉";
     if (isUnseenTerminal()) return UNSEEN_ICON;
     return "";
   };

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from "bun:test";
 import { determineStatus } from "./claude-code";
 
 describe("determineStatus", () => {
-  it('returns "idle" when no message', () => {
-    expect(determineStatus({})).toBe("idle");
-    expect(determineStatus({ message: undefined })).toBe("idle");
+  it("returns null when no message", () => {
+    expect(determineStatus({})).toBeNull();
+    expect(determineStatus({ message: undefined })).toBeNull();
   });
 
-  it('returns "idle" when message has no role', () => {
-    expect(determineStatus({ message: { content: "hi" } })).toBe("idle");
+  it("returns null when message has no role", () => {
+    expect(determineStatus({ message: { content: "hi" } })).toBeNull();
   });
 
   it('returns "running" for user messages', () => {
@@ -53,11 +53,11 @@ describe("determineStatus", () => {
     ).toBe("done");
   });
 
-  it('returns "idle" for unknown roles', () => {
+  it("returns null for unknown roles", () => {
     expect(
       determineStatus({
         message: { role: "system", content: "system message" },
       }),
-    ).toBe("idle");
+    ).toBeNull();
   });
 });

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
@@ -47,9 +47,9 @@ const STALE_MS = 5 * 60 * 1000;
 
 // --- Status detection ---
 
-export function determineStatus(entry: JournalEntry): AgentStatus {
+export function determineStatus(entry: JournalEntry): AgentStatus | null {
   const msg = entry.message;
-  if (!msg?.role) return "idle";
+  if (!msg?.role) return null;
 
   const content = msg.content;
   const items: ContentItem[] = Array.isArray(content)
@@ -59,13 +59,16 @@ export function determineStatus(entry: JournalEntry): AgentStatus {
       : [];
 
   if (msg.role === "assistant") {
-    const hasToolUse = items.some((c) => c.type === "tool_use");
-    return hasToolUse ? "running" : "done";
+    const toolUses = items.filter((c) => c.type === "tool_use");
+    if (toolUses.length === 0) return "done";
+    // AskUserQuestion means the agent is waiting for user input, not running
+    const allWaiting = toolUses.every((c) => (c as any).name === "AskUserQuestion");
+    return allWaiting ? "waiting" : "running";
   }
 
   if (msg.role === "user") return "running";
 
-  return "idle";
+  return null;
 }
 
 function extractThreadName(entry: JournalEntry): string | undefined {
@@ -195,7 +198,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
           const name = extractThreadName(entry);
           if (name) threadName = name;
         }
-        latestStatus = determineStatus(entry);
+        latestStatus = determineStatus(entry) ?? latestStatus;
       }
 
       // If "running" but journal file is stale, the process likely exited
@@ -238,7 +241,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
         if (name) threadName = name;
       }
 
-      latestStatus = determineStatus(entry);
+      latestStatus = determineStatus(entry) ?? latestStatus;
     }
 
     const prevStatus = prev?.status;

--- a/packages/agentboard/packages/runtime/src/server/index.ts
+++ b/packages/agentboard/packages/runtime/src/server/index.ts
@@ -187,6 +187,22 @@ export function startServer(
     return null;
   }
 
+  /** If any pane agent is alive for this session, override terminal agentState to waiting. */
+  function overrideTerminalIfPaneAlive(
+    sessionName: string,
+    state: AgentEvent | null,
+  ): AgentEvent | null {
+    if (!state || !TERMINAL_STATUSES.has(state.status)) return state;
+    const paneAgents = paneAgentsBySession.get(sessionName);
+    if (!paneAgents || paneAgents.size === 0) return state;
+    for (const presence of paneAgents.values()) {
+      if (presence.agent === state.agent && presence.threadId === state.threadId) {
+        return { ...state, status: "waiting" };
+      }
+    }
+    return state;
+  }
+
   /** Merge pane-detected agents into watcher-provided agents for a session.
    *  Watcher events take precedence — pane presence only adds synthetic entries
    *  for agents that aren't already tracked by watchers. */
@@ -205,12 +221,11 @@ export function startServer(
       const trackedIdx = trackedByKey.get(key);
 
       if (trackedIdx != null) {
-        // Watcher already tracks this agent — correct terminal statuses
-        // using pane liveness (process is confirmed alive, so terminal
-        // journal status is a between-turn artifact).
+        // Watcher already tracks this agent — process is confirmed alive,
+        // so terminal journal status means it's waiting for user input.
         const tracked = result[trackedIdx]!;
         if (TERMINAL_STATUSES.has(tracked.status)) {
-          tracked.status = "running";
+          tracked.status = "waiting";
           tracked.paneId = presence.paneId;
         }
         continue;
@@ -298,7 +313,7 @@ export function startServer(
           ports: getSessionPorts(name),
           windows,
           uptime,
-          agentState: tracker.getState(name),
+          agentState: overrideTerminalIfPaneAlive(name, tracker.getState(name)),
           agents: mergeAgentsWithPanePresence(name, tracker.getAgents(name)),
           eventTimestamps: tracker.getEventTimestamps(name),
           metadata: metadataStore.get(name),
@@ -1079,8 +1094,12 @@ export function startServer(
       const data = JSON.parse(readFileSync(join(sessionsDir, `${agentPid}.json`), "utf-8"));
       const threadId: string | undefined = data.sessionId;
       if (!threadId) return {};
-      // Try to get thread name and status from the journal
       const journalInfo = resolveClaudeCodeJournalInfo(threadId);
+      // Process is alive (found via process tree), so terminal journal status
+      // means it's waiting for user input.
+      if (journalInfo.status && TERMINAL_STATUSES.has(journalInfo.status)) {
+        journalInfo.status = "waiting";
+      }
       return { threadId, ...journalInfo };
     } catch {
       return {};
@@ -1119,10 +1138,16 @@ export function startServer(
                 if (t && !t.startsWith("<") && !t.startsWith("{")) threadName = t.slice(0, 80);
               }
 
-              // Determine status from last entry (same logic as ClaudeCodeAgentWatcher)
               if (msg.role === "assistant") {
                 const items = Array.isArray(msg.content) ? msg.content : [];
-                lastStatus = items.some((c: any) => c.type === "tool_use") ? "running" : "done";
+                const toolUses = items.filter((c: any) => c.type === "tool_use");
+                if (toolUses.length === 0) {
+                  lastStatus = "done";
+                } else {
+                  lastStatus = toolUses.every((c: any) => c.name === "AskUserQuestion")
+                    ? "waiting"
+                    : "running";
+                }
               } else if (msg.role === "user") {
                 lastStatus = "running";
               }

--- a/packages/agentboard/packages/runtime/src/server/pane-scanner.ts
+++ b/packages/agentboard/packages/runtime/src/server/pane-scanner.ts
@@ -100,9 +100,9 @@ function resolveClaudeCodePaneInfo(
     if (!threadId) return {};
     const journalInfo = resolveClaudeCodeJournalInfo(threadId);
     // Process is alive (found via process tree), so terminal journal status
-    // is a between-turn artifact — override to running.
+    // means it's waiting for user input.
     if (journalInfo.status && TERMINAL_STATUSES.has(journalInfo.status)) {
-      journalInfo.status = "running";
+      journalInfo.status = "waiting";
     }
     return { threadId, ...journalInfo };
   } catch {
@@ -143,7 +143,14 @@ function resolveClaudeCodeJournalInfo(threadId: string): {
 
             if (msg.role === "assistant") {
               const items = Array.isArray(msg.content) ? msg.content : [];
-              lastStatus = items.some((c: any) => c.type === "tool_use") ? "running" : "done";
+              const toolUses = items.filter((c: any) => c.type === "tool_use");
+              if (toolUses.length === 0) {
+                lastStatus = "done";
+              } else {
+                lastStatus = toolUses.every((c: any) => c.name === "AskUserQuestion")
+                  ? "waiting"
+                  : "running";
+              }
             } else if (msg.role === "user") {
               lastStatus = "running";
             }

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "citty";
 import { execSync, spawn, spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, realpathSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 import consola from "consola";
 import { colors } from "consola/utils";
@@ -184,6 +184,23 @@ async function serverAlive(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+const PID_FILE = "/tmp/agentboard.pid";
+
+function stopServer(): boolean {
+  if (!existsSync(PID_FILE)) return false;
+  const pid = Number.parseInt(readFileSync(PID_FILE, "utf8").trim(), 10);
+  if (Number.isNaN(pid)) return false;
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // process already dead
+  }
+  try {
+    unlinkSync(PID_FILE);
+  } catch {}
+  return true;
 }
 
 async function ensureServerUp(): Promise<boolean> {
@@ -374,7 +391,15 @@ async function restart(): Promise<void> {
     // no tmux or no sessions
   }
 
-  // 2. Ensure server is running
+  // 2. Stop existing server, then start fresh
+  const wasStopped = stopServer();
+  if (wasStopped) {
+    // Wait for port to free up
+    for (let i = 0; i < 20; i++) {
+      if (!(await serverAlive())) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
   if (!(await ensureServerUp())) {
     consola.error("Failed to start agentboard server");
     process.exit(1);


### PR DESCRIPTION
## Summary
- Agents waiting for user input now show blue ◉ "waiting" instead of incorrectly showing "running" or "idle"
- `AskUserQuestion` tool_use correctly detected as "waiting" since the agent is blocked on user input
- `tt agentboard restart` now properly kills the old server before starting a new one (was silently reusing the stale process)
- `determineStatus()` returns null for non-message journal entries (system/metadata) so they don't overwrite real status
- `overrideTerminalIfPaneAlive` fixed key format mismatch between pane map and instance keys
- SessionCard handles "waiting" status with blue accent color and ◉ icon

## Test plan
- [x] Typecheck passes
- [x] Unit tests pass (determineStatus returns null for system entries)
- [x] Pre-commit hooks pass
- [x] Manual: agents at prompt show blue ◉ waiting
- [x] Manual: agents during AskUserQuestion show blue ◉ waiting  
- [x] Manual: `tt agentboard restart` kills old server (PID changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)