### PR TITLE
fix: remove as-any cast in agentboard claude-code watcher

### DIFF
--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
@@ -25,6 +25,7 @@ import { JOURNAL_IDLE_TIMEOUT_MS } from "../../shared";
 interface ContentItem {
   type?: string;
   text?: string;
+  name?: string;
 }
 
 interface JournalEntry {
@@ -61,7 +62,7 @@ export function determineStatus(entry: JournalEntry): AgentStatus | null {
   if (msg.role === "assistant") {
     const toolUses = items.filter((c) => c.type === "tool_use");
     if (toolUses.length === 0) return "done";
-    const allAsking = toolUses.every((c) => (c as any).name === "AskUserQuestion");
+    const allAsking = toolUses.every((c) => c.name === "AskUserQuestion");
     return allAsking ? "question" : "running";
   }
 


### PR DESCRIPTION
## Summary
- Added `name?: string` to the `ContentItem` interface in the agentboard runtime's claude-code watcher
- Removed the `(c as any).name` unsafe cast when checking for `AskUserQuestion` tool uses
- Fixed pre-existing oxfmt formatting issues in graph and stream-parser files

## Test plan
- [x] All 395 tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [x] Typecheck: pre-existing failures in graph module (separate unit's scope), no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)