### PR TITLE
refactor: replace graph types with Anthropic SDK types

### DIFF
--- a/src/commands/graph.test.ts
+++ b/src/commands/graph.test.ts
@@ -2,7 +2,20 @@
  * Tests for graph command --days filtering and bar chart data
  */
 import { describe, it, expect } from "vitest";
+import type { Usage } from "@anthropic-ai/sdk/resources/messages/messages";
 import { analyzeSession, calculateCutoffMs, filterByDays } from "./graph/index.js";
+
+function makeUsage(overrides: Partial<Usage> = {}): Usage {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: null,
+    cache_creation_input_tokens: null,
+    server_tool_use: null,
+    service_tier: null,
+    ...overrides,
+  };
+}
 
 describe("graph --days filtering", () => {
   describe("calculateCutoffMs", () => {
@@ -98,14 +111,7 @@ describe("analyzeSession (bar chart token aggregation)", () => {
       message: {
         role: "assistant" as const,
         model,
-        usage: {
-          input_tokens: inputTokens,
-          output_tokens: outputTokens,
-          cache_read_input_tokens: null,
-          cache_creation_input_tokens: null,
-          server_tool_use: null,
-          service_tier: null,
-        },
+        usage: makeUsage({ input_tokens: inputTokens, output_tokens: outputTokens }),
       },
     };
   }

--- a/src/commands/graph.test.ts
+++ b/src/commands/graph.test.ts
@@ -98,7 +98,14 @@ describe("analyzeSession (bar chart token aggregation)", () => {
       message: {
         role: "assistant" as const,
         model,
-        usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+        usage: {
+          input_tokens: inputTokens,
+          output_tokens: outputTokens,
+          cache_read_input_tokens: null,
+          cache_creation_input_tokens: null,
+          server_tool_use: null,
+          service_tier: null,
+        },
       },
     };
   }

--- a/src/commands/graph/analyzer.test.ts
+++ b/src/commands/graph/analyzer.test.ts
@@ -33,8 +33,15 @@ function makeAssistantEntry(
     message: {
       role: "assistant",
       model,
-      usage: { input_tokens: inputTokens, output_tokens: outputTokens },
-      content: content ?? [{ type: "text", text: "response" }],
+      usage: {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+        server_tool_use: null,
+        service_tier: null,
+      },
+      content: content ?? [{ type: "text" as const, text: "response", citations: null }],
       ...extra,
     },
   });
@@ -76,8 +83,15 @@ describe("analyzeSession", () => {
         message: {
           role: "assistant",
           model: "claude-opus-4",
-          usage: { input_tokens: 1000, output_tokens: 0, cache_read_input_tokens: 800 },
-          content: [{ type: "text", text: "hi" }],
+          usage: {
+            input_tokens: 1000,
+            output_tokens: 0,
+            cache_read_input_tokens: 800,
+            cache_creation_input_tokens: null,
+            server_tool_use: null,
+            service_tier: null,
+          },
+          content: [{ type: "text" as const, text: "hi", citations: null }],
         },
       }),
     ];
@@ -87,9 +101,9 @@ describe("analyzeSession", () => {
 
   it("counts repeated file reads", () => {
     const content: ContentBlock[] = [
-      { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
-      { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
-      { type: "tool_use", name: "Read", input: { file_path: "/b.ts" } },
+      { type: "tool_use" as const, id: "tool-1", name: "Read", input: { file_path: "/a.ts" } },
+      { type: "tool_use" as const, id: "tool-2", name: "Read", input: { file_path: "/a.ts" } },
+      { type: "tool_use" as const, id: "tool-3", name: "Read", input: { file_path: "/b.ts" } },
     ];
     const entries = [makeAssistantEntry("claude-opus-4", 100, 50, content)];
     const result = analyzeSession(entries);
@@ -145,7 +159,7 @@ describe("extractSessionLabel", () => {
         type: "user",
         message: {
           role: "user",
-          content: [{ type: "text", text: "Array content message" }],
+          content: [{ type: "text" as const, text: "Array content message", citations: null }],
         },
       }),
     ];
@@ -158,7 +172,7 @@ describe("extractSessionLabel", () => {
         type: "assistant",
         message: {
           role: "assistant",
-          content: [{ type: "text", text: "I'll help you with that" }],
+          content: [{ type: "text" as const, text: "I'll help you with that", citations: null }],
         },
       }),
     ];
@@ -314,14 +328,14 @@ describe("extractToolData", () => {
   });
 
   it("returns empty when no tool_use blocks", () => {
-    const content: ContentBlock[] = [{ type: "text", text: "hello" }];
+    const content: ContentBlock[] = [{ type: "text" as const, text: "hello", citations: null }];
     expect(extractToolData(content, 100, 50)).toEqual([]);
   });
 
   it("extracts tool calls and distributes tokens", () => {
     const content: ContentBlock[] = [
-      { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
-      { type: "tool_use", name: "Bash", input: { command: "ls" } },
+      { type: "tool_use" as const, id: "tool-1", name: "Read", input: { file_path: "/a.ts" } },
+      { type: "tool_use" as const, id: "tool-2", name: "Bash", input: { command: "ls" } },
     ];
     const result = extractToolData(content, 200, 100);
     expect(result).toHaveLength(2);
@@ -343,11 +357,11 @@ describe("aggregateSessionTools", () => {
   it("aggregates tools across entries", () => {
     const entries = [
       makeAssistantEntry("claude-opus-4", 100, 50, [
-        { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
+        { type: "tool_use" as const, id: "tool-1", name: "Read", input: { file_path: "/a.ts" } },
       ]),
       makeAssistantEntry("claude-opus-4", 200, 100, [
-        { type: "tool_use", name: "Read", input: { file_path: "/b.ts" } },
-        { type: "tool_use", name: "Bash", input: { command: "ls" } },
+        { type: "tool_use" as const, id: "tool-2", name: "Read", input: { file_path: "/b.ts" } },
+        { type: "tool_use" as const, id: "tool-3", name: "Bash", input: { command: "ls" } },
       ]),
     ];
     const result = aggregateSessionTools(entries);
@@ -359,10 +373,10 @@ describe("aggregateSessionTools", () => {
   it("sorts by total token usage descending", () => {
     const entries = [
       makeAssistantEntry("claude-opus-4", 100, 50, [
-        { type: "tool_use", name: "Bash", input: { command: "ls" } },
+        { type: "tool_use" as const, id: "tool-1", name: "Bash", input: { command: "ls" } },
       ]),
       makeAssistantEntry("claude-opus-4", 1000, 500, [
-        { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
+        { type: "tool_use" as const, id: "tool-2", name: "Read", input: { file_path: "/a.ts" } },
       ]),
     ];
     const result = aggregateSessionTools(entries);

--- a/src/commands/graph/analyzer.test.ts
+++ b/src/commands/graph/analyzer.test.ts
@@ -13,14 +13,12 @@ import { extractToolData, extractToolDetail, sanitizeString, truncateDetail } fr
 
 // ── Helpers ──
 
-let toolIdCounter = 0;
-
 function textBlock(text: string): ContentBlock {
   return { type: "text" as const, text, citations: null };
 }
 
 function toolUseBlock(name: string, input: Record<string, unknown>): ContentBlock {
-  return { type: "tool_use" as const, id: `tool-${++toolIdCounter}`, name, input };
+  return { type: "tool_use" as const, id: "tool-stub", name, input };
 }
 
 function makeUsage(overrides: Partial<Usage> = {}): Usage {

--- a/src/commands/graph/analyzer.test.ts
+++ b/src/commands/graph/analyzer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ContentBlock, JournalEntry } from "./types";
+import type { Usage } from "@anthropic-ai/sdk/resources/messages/messages";
 import {
   aggregateSessionTools,
   analyzeSession,
@@ -11,6 +12,28 @@ import { extractSessionLabel } from "./labels";
 import { extractToolData, extractToolDetail, sanitizeString, truncateDetail } from "./tools";
 
 // ── Helpers ──
+
+let toolIdCounter = 0;
+
+function textBlock(text: string): ContentBlock {
+  return { type: "text" as const, text, citations: null };
+}
+
+function toolUseBlock(name: string, input: Record<string, unknown>): ContentBlock {
+  return { type: "tool_use" as const, id: `tool-${++toolIdCounter}`, name, input };
+}
+
+function makeUsage(overrides: Partial<Usage> = {}): Usage {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: null,
+    cache_creation_input_tokens: null,
+    server_tool_use: null,
+    service_tier: null,
+    ...overrides,
+  };
+}
 
 function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
   return {
@@ -33,15 +56,8 @@ function makeAssistantEntry(
     message: {
       role: "assistant",
       model,
-      usage: {
-        input_tokens: inputTokens,
-        output_tokens: outputTokens,
-        cache_read_input_tokens: null,
-        cache_creation_input_tokens: null,
-        server_tool_use: null,
-        service_tier: null,
-      },
-      content: content ?? [{ type: "text" as const, text: "response", citations: null }],
+      usage: makeUsage({ input_tokens: inputTokens, output_tokens: outputTokens }),
+      content: content ?? [textBlock("response")],
       ...extra,
     },
   });
@@ -83,15 +99,8 @@ describe("analyzeSession", () => {
         message: {
           role: "assistant",
           model: "claude-opus-4",
-          usage: {
-            input_tokens: 1000,
-            output_tokens: 0,
-            cache_read_input_tokens: 800,
-            cache_creation_input_tokens: null,
-            server_tool_use: null,
-            service_tier: null,
-          },
-          content: [{ type: "text" as const, text: "hi", citations: null }],
+          usage: makeUsage({ input_tokens: 1000, output_tokens: 0, cache_read_input_tokens: 800 }),
+          content: [textBlock("hi")],
         },
       }),
     ];
@@ -101,9 +110,9 @@ describe("analyzeSession", () => {
 
   it("counts repeated file reads", () => {
     const content: ContentBlock[] = [
-      { type: "tool_use" as const, id: "tool-1", name: "Read", input: { file_path: "/a.ts" } },
-      { type: "tool_use" as const, id: "tool-2", name: "Read", input: { file_path: "/a.ts" } },
-      { type: "tool_use" as const, id: "tool-3", name: "Read", input: { file_path: "/b.ts" } },
+      toolUseBlock("Read", { file_path: "/a.ts" }),
+      toolUseBlock("Read", { file_path: "/a.ts" }),
+      toolUseBlock("Read", { file_path: "/b.ts" }),
     ];
     const entries = [makeAssistantEntry("claude-opus-4", 100, 50, content)];
     const result = analyzeSession(entries);
@@ -159,7 +168,7 @@ describe("extractSessionLabel", () => {
         type: "user",
         message: {
           role: "user",
-          content: [{ type: "text" as const, text: "Array content message", citations: null }],
+          content: [textBlock("Array content message")],
         },
       }),
     ];
@@ -172,7 +181,7 @@ describe("extractSessionLabel", () => {
         type: "assistant",
         message: {
           role: "assistant",
-          content: [{ type: "text" as const, text: "I'll help you with that", citations: null }],
+          content: [textBlock("I'll help you with that")],
         },
       }),
     ];
@@ -328,14 +337,14 @@ describe("extractToolData", () => {
   });
 
   it("returns empty when no tool_use blocks", () => {
-    const content: ContentBlock[] = [{ type: "text" as const, text: "hello", citations: null }];
+    const content: ContentBlock[] = [textBlock("hello")];
     expect(extractToolData(content, 100, 50)).toEqual([]);
   });
 
   it("extracts tool calls and distributes tokens", () => {
     const content: ContentBlock[] = [
-      { type: "tool_use" as const, id: "tool-1", name: "Read", input: { file_path: "/a.ts" } },
-      { type: "tool_use" as const, id: "tool-2", name: "Bash", input: { command: "ls" } },
+      toolUseBlock("Read", { file_path: "/a.ts" }),
+      toolUseBlock("Bash", { command: "ls" }),
     ];
     const result = extractToolData(content, 200, 100);
     expect(result).toHaveLength(2);
@@ -356,12 +365,10 @@ describe("aggregateSessionTools", () => {
 
   it("aggregates tools across entries", () => {
     const entries = [
-      makeAssistantEntry("claude-opus-4", 100, 50, [
-        { type: "tool_use" as const, id: "tool-1", name: "Read", input: { file_path: "/a.ts" } },
-      ]),
+      makeAssistantEntry("claude-opus-4", 100, 50, [toolUseBlock("Read", { file_path: "/a.ts" })]),
       makeAssistantEntry("claude-opus-4", 200, 100, [
-        { type: "tool_use" as const, id: "tool-2", name: "Read", input: { file_path: "/b.ts" } },
-        { type: "tool_use" as const, id: "tool-3", name: "Bash", input: { command: "ls" } },
+        toolUseBlock("Read", { file_path: "/b.ts" }),
+        toolUseBlock("Bash", { command: "ls" }),
       ]),
     ];
     const result = aggregateSessionTools(entries);
@@ -372,11 +379,9 @@ describe("aggregateSessionTools", () => {
 
   it("sorts by total token usage descending", () => {
     const entries = [
-      makeAssistantEntry("claude-opus-4", 100, 50, [
-        { type: "tool_use" as const, id: "tool-1", name: "Bash", input: { command: "ls" } },
-      ]),
+      makeAssistantEntry("claude-opus-4", 100, 50, [toolUseBlock("Bash", { command: "ls" })]),
       makeAssistantEntry("claude-opus-4", 1000, 500, [
-        { type: "tool_use" as const, id: "tool-2", name: "Read", input: { file_path: "/a.ts" } },
+        toolUseBlock("Read", { file_path: "/a.ts" }),
       ]),
     ];
     const result = aggregateSessionTools(entries);

--- a/src/commands/graph/tools.ts
+++ b/src/commands/graph/tools.ts
@@ -68,7 +68,7 @@ export function extractToolData(
   const toolBlocks: Array<{ name: string; detail?: string }> = [];
   for (const block of content) {
     if (block.type === "tool_use" && block.name) {
-      const detail = extractToolDetail(block.name, block.input);
+      const detail = extractToolDetail(block.name, block.input as Record<string, unknown>);
       toolBlocks.push({ name: block.name, detail });
     }
   }

--- a/src/commands/graph/types.ts
+++ b/src/commands/graph/types.ts
@@ -1,11 +1,7 @@
 // Types for parsing Claude Code session JSONL files
-export interface ContentBlock {
-  type: string;
-  text?: string;
-  id?: string;
-  name?: string;
-  input?: Record<string, unknown>;
-}
+import type { ContentBlock, Usage } from "@anthropic-ai/sdk/resources/messages/messages";
+
+export type { ContentBlock };
 
 export interface JournalEntry {
   type: string;
@@ -14,12 +10,7 @@ export interface JournalEntry {
   message?: {
     role: "user" | "assistant";
     model?: string;
-    usage?: {
-      input_tokens?: number;
-      output_tokens?: number;
-      cache_read_input_tokens?: number;
-      cache_creation_input_tokens?: number;
-    };
+    usage?: Usage;
     content?: ContentBlock[] | string;
   };
   uuid?: string;


### PR DESCRIPTION
## Summary
- Replace custom `ContentBlock` interface and inline `usage` type in `types.ts` with `ContentBlock` and `Usage` from `@anthropic-ai/sdk`
- Add cast for `block.input` in `tools.ts` since SDK uses `unknown` instead of `Record<string, unknown>`
- Update test data in `analyzer.test.ts` and `graph.test.ts` to satisfy SDK's stricter discriminated union types (add `citations`, `id`, `service_tier`, etc.)

## Test plan
- [x] `bun typecheck` passes
- [x] `bun test` passes (395 tests)
- [x] `bun run lint` passes (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)