### PR TITLE
feat(agentboard): faster exit detection + cache countdown + model display

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
       "name": "@tt-agentboard/runtime",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.56.0",
         "consola": "^3.4.2",
       },
       "devDependencies": {
@@ -990,6 +991,8 @@
 
     "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@tt-agentboard/runtime/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
     "babel-plugin-jsx-dom-expressions/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
@@ -1005,6 +1008,8 @@
     "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
+    "@tt-agentboard/runtime/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "babel-plugin-jsx-dom-expressions/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
   }

--- a/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
+++ b/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
@@ -44,17 +44,7 @@ export function buildSparkline(
     .join("");
 }
 
-// --- Context / cache display helpers ---
-
-const BAR_FILLED = "▰";
-const BAR_EMPTY = "▱";
-const BAR_WIDTH = 10;
-
-function contextBar(pct: number): string {
-  const clamped = Math.max(0, Math.min(100, pct));
-  const filled = Math.round((clamped / 100) * BAR_WIDTH);
-  return BAR_FILLED.repeat(filled) + BAR_EMPTY.repeat(BAR_WIDTH - filled);
-}
+// --- Model / cache display helpers ---
 
 function shortModel(model: string): string {
   if (!model) return "";
@@ -384,38 +374,29 @@ function AgentListItem(props: AgentListItemProps) {
             </text>
           </Show>
 
-          {/* Row 3: context bar + model + cache countdown */}
+          {/* Row 3: model + cache countdown */}
           <Show when={props.agent.details}>
             {(d) => {
               const details = d();
-              const pct = () =>
-                details.contextUsed && details.contextMax
-                  ? Math.round((details.contextUsed / details.contextMax) * 100)
-                  : 0;
-              const bar = () => contextBar(pct());
-              const barColor = () => {
-                const p = pct();
-                if (p < 40) return P().green;
-                if (p < 60) return P().yellow;
-                if (p < 80) return P().peach;
-                return P().red;
-              };
               const model = () => (details.model ? shortModel(details.model) : "");
               const cacheText = () =>
                 details.cacheExpiresAt != null
                   ? `Cache ${formatCacheRemaining(details.cacheExpiresAt, now())}`
                   : null;
               return (
-                <text truncate>
-                  <span style={{ fg: barColor() }}>{bar()}</span>
-                  <span style={{ fg: P().overlay0, attributes: DIM }}> {pct()}%</span>
-                  <Show when={model()}>
-                    <span style={{ fg: P().subtext0, attributes: DIM }}> · {model()}</span>
-                  </Show>
-                  <Show when={cacheText()}>
-                    <span style={{ fg: P().sky, attributes: DIM }}> · {cacheText()}</span>
-                  </Show>
-                </text>
+                <Show when={model() || cacheText()}>
+                  <text truncate>
+                    <Show when={model()}>
+                      <span style={{ fg: P().subtext0, attributes: DIM }}>{model()}</span>
+                    </Show>
+                    <Show when={cacheText()}>
+                      <span style={{ fg: P().sky, attributes: DIM }}>
+                        {model() ? " · " : ""}
+                        {cacheText()}
+                      </span>
+                    </Show>
+                  </text>
+                </Show>
               );
             }}
           </Show>

--- a/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
+++ b/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show } from "solid-js";
+import { createSignal, For, Show, onCleanup } from "solid-js";
 import type { Accessor } from "solid-js";
 import type { MouseEvent } from "@opentui/core";
 import type { SessionData, Theme } from "@tt-agentboard/runtime";
@@ -42,6 +42,38 @@ export function buildSparkline(
       return SPARK_BLOCKS[level];
     })
     .join("");
+}
+
+// --- Context / cache display helpers ---
+
+const BAR_FILLED = "▰";
+const BAR_EMPTY = "▱";
+const BAR_WIDTH = 10;
+
+function contextBar(pct: number): string {
+  const clamped = Math.max(0, Math.min(100, pct));
+  const filled = Math.round((clamped / 100) * BAR_WIDTH);
+  return BAR_FILLED.repeat(filled) + BAR_EMPTY.repeat(BAR_WIDTH - filled);
+}
+
+function shortModel(model: string): string {
+  if (!model) return "";
+  const stripped = model.replace(/^claude-/, "").replace(/\[1m\]$/i, "");
+  return stripped;
+}
+
+function formatCacheRemaining(expiresAt: number, now: number): string {
+  const ms = expiresAt - now;
+  if (ms <= 0) return "cold";
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min >= 60) {
+    const hrs = Math.floor(min / 60);
+    const rem = min % 60;
+    return `${hrs}h${rem}m`;
+  }
+  return `${min}m${sec.toString().padStart(2, "0")}s`;
 }
 
 // --- Detail Panel ---
@@ -242,6 +274,11 @@ function AgentListItem(props: AgentListItemProps) {
   const SC = () => props.statusColors();
   const [isDismissHover, setIsDismissHover] = createSignal(false);
   const [isFlash, setIsFlash] = createSignal(false);
+  const [now, setNow] = createSignal(Date.now());
+  // Tick every second while any details.cacheExpiresAt is in the future
+  // (cheap; only runs while component is mounted)
+  const ticker = setInterval(() => setNow(Date.now()), 1000);
+  onCleanup(() => clearInterval(ticker));
 
   const isTerminal = () => ["done", "error", "interrupted"].includes(props.agent.status);
   const isUnseen = () => isTerminal() && props.agent.unseen === true;
@@ -345,6 +382,42 @@ function AgentListItem(props: AgentListItemProps) {
                 {props.agent.threadName}
               </span>
             </text>
+          </Show>
+
+          {/* Row 3: context bar + model + cache countdown */}
+          <Show when={props.agent.details}>
+            {(d) => {
+              const details = d();
+              const pct = () =>
+                details.contextUsed && details.contextMax
+                  ? Math.round((details.contextUsed / details.contextMax) * 100)
+                  : 0;
+              const bar = () => contextBar(pct());
+              const barColor = () => {
+                const p = pct();
+                if (p < 40) return P().green;
+                if (p < 60) return P().yellow;
+                if (p < 80) return P().peach;
+                return P().red;
+              };
+              const model = () => (details.model ? shortModel(details.model) : "");
+              const cacheText = () =>
+                details.cacheExpiresAt != null
+                  ? `Cache ${formatCacheRemaining(details.cacheExpiresAt, now())}`
+                  : null;
+              return (
+                <text truncate>
+                  <span style={{ fg: barColor() }}>{bar()}</span>
+                  <span style={{ fg: P().overlay0, attributes: DIM }}> {pct()}%</span>
+                  <Show when={model()}>
+                    <span style={{ fg: P().subtext0, attributes: DIM }}> · {model()}</span>
+                  </Show>
+                  <Show when={cacheText()}>
+                    <span style={{ fg: P().sky, attributes: DIM }}> · {cacheText()}</span>
+                  </Show>
+                </text>
+              );
+            }}
           </Show>
         </box>
       </box>

--- a/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
+++ b/packages/agentboard/apps/tui/src/components/DetailPanel.tsx
@@ -52,18 +52,17 @@ function shortModel(model: string): string {
   return stripped;
 }
 
-function formatCacheRemaining(expiresAt: number, now: number): string {
-  const ms = expiresAt - now;
-  if (ms <= 0) return "cold";
-  const totalSec = Math.floor(ms / 1000);
-  const min = Math.floor(totalSec / 60);
-  const sec = totalSec % 60;
-  if (min >= 60) {
-    const hrs = Math.floor(min / 60);
-    const rem = min % 60;
-    return `${hrs}h${rem}m`;
-  }
-  return `${min}m${sec.toString().padStart(2, "0")}s`;
+const CACHE_BAR_WIDTH = 10;
+const CACHE_BAR_FILLED = "▰";
+const CACHE_BAR_EMPTY = "▱";
+
+/** Render a drain-down bar: full = freshly cached, empty = expired. */
+function cacheBar(expiresAt: number, ttlMs: number, now: number): string {
+  const remaining = expiresAt - now;
+  if (remaining <= 0 || ttlMs <= 0) return CACHE_BAR_EMPTY.repeat(CACHE_BAR_WIDTH);
+  const fraction = Math.max(0, Math.min(1, remaining / ttlMs));
+  const filled = Math.round(fraction * CACHE_BAR_WIDTH);
+  return CACHE_BAR_FILLED.repeat(filled) + CACHE_BAR_EMPTY.repeat(CACHE_BAR_WIDTH - filled);
 }
 
 // --- Detail Panel ---
@@ -374,26 +373,34 @@ function AgentListItem(props: AgentListItemProps) {
             </text>
           </Show>
 
-          {/* Row 3: model + cache countdown */}
+          {/* Row 3: model + cache-remaining progress bar */}
           <Show when={props.agent.details}>
             {(d) => {
               const details = d();
               const model = () => (details.model ? shortModel(details.model) : "");
-              const cacheText = () =>
-                details.cacheExpiresAt != null
-                  ? `Cache ${formatCacheRemaining(details.cacheExpiresAt, now())}`
-                  : null;
+              const hasCache = () => details.cacheExpiresAt != null && details.cacheTtlMs != null;
+              const bar = () =>
+                hasCache() ? cacheBar(details.cacheExpiresAt!, details.cacheTtlMs!, now()) : "";
+              const barColor = () => {
+                if (!hasCache()) return P().overlay0;
+                const remaining = details.cacheExpiresAt! - now();
+                if (remaining <= 0) return P().overlay0;
+                const fraction = remaining / details.cacheTtlMs!;
+                if (fraction > 0.5) return P().green;
+                if (fraction > 0.2) return P().yellow;
+                return P().peach;
+              };
               return (
-                <Show when={model() || cacheText()}>
+                <Show when={model() || hasCache()}>
                   <text truncate>
                     <Show when={model()}>
                       <span style={{ fg: P().subtext0, attributes: DIM }}>{model()}</span>
                     </Show>
-                    <Show when={cacheText()}>
-                      <span style={{ fg: P().sky, attributes: DIM }}>
-                        {model() ? " · " : ""}
-                        {cacheText()}
+                    <Show when={hasCache()}>
+                      <span style={{ fg: P().overlay0, attributes: DIM }}>
+                        {model() ? " · cache " : "cache "}
                       </span>
+                      <span style={{ fg: barColor() }}>{bar()}</span>
                     </Show>
                   </text>
                 </Show>

--- a/packages/agentboard/packages/runtime/package.json
+++ b/packages/agentboard/packages/runtime/package.json
@@ -8,6 +8,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.56.0",
     "consola": "^3.4.2"
   },
   "devDependencies": {

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
-import { determineStatus } from "./claude-code";
+import { determineStatus, summaryToDetails } from "./claude-code";
+import type { ClaudeUsageSummary } from "./claude-usage";
 
 describe("determineStatus", () => {
   it("returns null when no message", () => {
@@ -59,5 +60,41 @@ describe("determineStatus", () => {
         message: { role: "system", content: "system message" },
       }),
     ).toBeNull();
+  });
+});
+
+describe("summaryToDetails", () => {
+  it("maps all fields including cache", () => {
+    const s: ClaudeUsageSummary = {
+      model: "claude-opus-4-6",
+      contextUsed: 1000,
+      contextMax: 200_000,
+      cacheTtlMs: 300_000,
+      cacheExpiresAt: 1_700_000_000_000,
+      lastActivityAt: 1_699_999_700_000,
+    };
+    expect(summaryToDetails(s)).toEqual({
+      model: "claude-opus-4-6",
+      contextUsed: 1000,
+      contextMax: 200_000,
+      cacheTtlMs: 300_000,
+      cacheExpiresAt: 1_700_000_000_000,
+      lastActivityAt: 1_699_999_700_000,
+    });
+  });
+
+  it("omits cache fields when null (converts to undefined)", () => {
+    const s: ClaudeUsageSummary = {
+      model: "claude-haiku-4-5",
+      contextUsed: 500,
+      contextMax: 200_000,
+      cacheTtlMs: null,
+      cacheExpiresAt: null,
+      lastActivityAt: 1_700_000_000_000,
+    };
+    const details = summaryToDetails(s);
+    expect(details.cacheTtlMs).toBeUndefined();
+    expect(details.cacheExpiresAt).toBeUndefined();
+    expect(details.model).toBe("claude-haiku-4-5");
   });
 });

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
@@ -105,7 +105,7 @@ function decodeProjectDir(encoded: string): string {
 
 // --- Usage summary → AgentEventDetails ---
 
-function summaryToDetails(
+export function summaryToDetails(
   s: ClaudeUsageSummary,
 ): import("../../contracts/agent").AgentEventDetails {
   return {

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
@@ -19,6 +19,10 @@ import { homedir } from "node:os";
 import type { AgentStatus } from "../../contracts/agent";
 import type { AgentWatcher, AgentWatcherContext } from "../../contracts/agent-watcher";
 import { JOURNAL_IDLE_TIMEOUT_MS } from "../../shared";
+import { createClaudePidLookup } from "./claude-pid";
+import type { ClaudePidLookup } from "./claude-pid";
+import { extractUsageSummary } from "./claude-usage";
+import type { ClaudeUsageSummary } from "./claude-usage";
 
 // --- Types ---
 
@@ -41,6 +45,7 @@ interface SessionState {
   fileSize: number;
   threadName?: string;
   projectDir?: string;
+  usage?: ClaudeUsageSummary;
 }
 
 const POLL_MS = 2000;
@@ -98,6 +103,21 @@ function decodeProjectDir(encoded: string): string {
   return encoded.replace(/-/g, "/");
 }
 
+// --- Usage summary → AgentEventDetails ---
+
+function summaryToDetails(
+  s: ClaudeUsageSummary,
+): import("../../contracts/agent").AgentEventDetails {
+  return {
+    model: s.model,
+    contextUsed: s.contextUsed,
+    contextMax: s.contextMax,
+    cacheExpiresAt: s.cacheExpiresAt ?? undefined,
+    cacheTtlMs: s.cacheTtlMs ?? undefined,
+    lastActivityAt: s.lastActivityAt,
+  };
+}
+
 // --- Watcher implementation ---
 
 export class ClaudeCodeAgentWatcher implements AgentWatcher {
@@ -110,9 +130,11 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
   private projectsDir: string;
   private scanning = false;
   private seeded = false;
+  private pidLookup: ClaudePidLookup;
 
-  constructor() {
+  constructor(pidLookup: ClaudePidLookup = createClaudePidLookup()) {
     this.projectsDir = join(homedir(), ".claude", "projects");
+    this.pidLookup = pidLookup;
   }
 
   start(ctx: AgentWatcherContext): void {
@@ -150,26 +172,36 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
     const prev = this.sessions.get(threadId);
 
     if (prev && size === prev.fileSize) {
-      // Post-seed: if status is "running" but journal hasn't been written to
-      // in >2min, the process likely exited — downgrade to "idle".
+      // Post-seed: check if the process is actually still alive.
       if (this.seeded && prev.status === "running") {
-        try {
-          const mtime = (await stat(filePath)).mtimeMs;
-          if (Date.now() - mtime > JOURNAL_IDLE_TIMEOUT_MS) {
-            prev.status = "idle";
-            const session = prev.projectDir ? this.ctx?.resolveSession(prev.projectDir) : undefined;
-            if (session) {
-              this.ctx?.emit({
-                agent: "claude-code",
-                session,
-                status: "idle",
-                ts: Date.now(),
-                threadId,
-                threadName: prev.threadName,
-              });
-            }
+        const pid = await this.pidLookup.pidForThread(threadId);
+        const processGone = pid != null && !this.pidLookup.isAlive(pid);
+
+        let becomeIdle = false;
+        if (processGone) {
+          becomeIdle = true;
+        } else {
+          try {
+            const mtime = (await stat(filePath)).mtimeMs;
+            if (Date.now() - mtime > JOURNAL_IDLE_TIMEOUT_MS) becomeIdle = true;
+          } catch {}
+        }
+
+        if (becomeIdle) {
+          prev.status = "idle";
+          const session = prev.projectDir ? this.ctx?.resolveSession(prev.projectDir) : undefined;
+          if (session) {
+            this.ctx?.emit({
+              agent: "claude-code",
+              session,
+              status: "idle",
+              ts: Date.now(),
+              threadId,
+              threadName: prev.threadName,
+              details: prev.usage ? summaryToDetails(prev.usage) : undefined,
+            });
           }
-        } catch {}
+        }
       }
       return;
     }
@@ -184,22 +216,27 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
       }
 
       const lines = text.split("\n").filter(Boolean);
-      let latestStatus: AgentStatus = "idle";
-      let threadName: string | undefined;
 
+      const parsed: JournalEntry[] = [];
       for (const line of lines) {
-        let entry: JournalEntry;
         try {
-          entry = JSON.parse(line);
+          parsed.push(JSON.parse(line) as JournalEntry);
         } catch {
           continue;
         }
+      }
+
+      let latestStatus: AgentStatus = "idle";
+      let threadName: string | undefined;
+      for (const entry of parsed) {
         if (!threadName) {
           const name = extractThreadName(entry);
           if (name) threadName = name;
         }
         latestStatus = determineStatus(entry) ?? latestStatus;
       }
+
+      const usage = extractUsageSummary(parsed) ?? undefined;
 
       // If "running" but journal file is stale, the process likely exited
       if (latestStatus === "running") {
@@ -209,7 +246,13 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
         } catch {}
       }
 
-      this.sessions.set(threadId, { status: latestStatus, fileSize: size, threadName, projectDir });
+      this.sessions.set(threadId, {
+        status: latestStatus,
+        fileSize: size,
+        threadName,
+        projectDir,
+        usage,
+      });
       return;
     }
 
@@ -225,27 +268,45 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
     }
 
     const lines = text.split("\n").filter(Boolean);
-    let latestStatus: AgentStatus = prev?.status ?? "idle";
-    let threadName = prev?.threadName;
 
+    const parsed: JournalEntry[] = [];
     for (const line of lines) {
-      let entry: JournalEntry;
       try {
-        entry = JSON.parse(line);
+        parsed.push(JSON.parse(line) as JournalEntry);
       } catch {
         continue;
       }
+    }
 
+    let latestStatus: AgentStatus = prev?.status ?? "idle";
+    let threadName = prev?.threadName;
+    for (const entry of parsed) {
       if (!threadName) {
         const name = extractThreadName(entry);
         if (name) threadName = name;
       }
-
       latestStatus = determineStatus(entry) ?? latestStatus;
     }
 
+    // Merge new usage summary onto the previous one (incremental reads may not include the latest assistant turn)
+    const newUsage = extractUsageSummary(parsed);
+    const usage = newUsage ?? prev?.usage;
+
+    if (latestStatus === "running") {
+      const pid = await this.pidLookup.pidForThread(threadId);
+      if (pid != null && !this.pidLookup.isAlive(pid)) {
+        latestStatus = "idle";
+      }
+    }
+
     const prevStatus = prev?.status;
-    this.sessions.set(threadId, { status: latestStatus, fileSize: size, threadName, projectDir });
+    this.sessions.set(threadId, {
+      status: latestStatus,
+      fileSize: size,
+      threadName,
+      projectDir,
+      usage,
+    });
 
     if (latestStatus !== prevStatus) {
       const session = this.ctx.resolveSession(projectDir);
@@ -257,6 +318,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
           ts: Date.now(),
           threadId,
           threadName,
+          details: usage ? summaryToDetails(usage) : undefined,
         });
       }
     }
@@ -265,6 +327,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
   private async scan(): Promise<void> {
     if (this.scanning || !this.ctx) return;
     this.scanning = true;
+    this.pidLookup.invalidate();
 
     try {
       let dirs: string[];
@@ -313,15 +376,27 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
         // Emit seeded sessions with non-idle status (like amp watcher does)
         for (const [threadId, state] of this.sessions) {
           if (state.status === "idle" || !state.projectDir) continue;
+
+          let status = state.status;
+          if (status === "running") {
+            const pid = await this.pidLookup.pidForThread(threadId);
+            if (pid != null && !this.pidLookup.isAlive(pid)) {
+              status = "idle";
+              state.status = "idle";
+              continue;
+            }
+          }
+
           const session = this.ctx?.resolveSession(state.projectDir);
           if (!session) continue;
           this.ctx?.emit({
             agent: "claude-code",
             session,
-            status: state.status,
+            status,
             ts: Date.now(),
             threadId,
             threadName: state.threadName,
+            details: state.usage ? summaryToDetails(state.usage) : undefined,
           });
         }
       }

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-pid.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-pid.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClaudePidLookup } from "./claude-pid";
+
+let tmpDir: string;
+let sessionsDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "claude-pid-test-"));
+  sessionsDir = join(tmpDir, "sessions");
+  mkdirSync(sessionsDir);
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeSession(pid: number, sessionId: string) {
+  writeFileSync(
+    join(sessionsDir, `${pid}.json`),
+    JSON.stringify({ pid, sessionId, cwd: "/tmp", startedAt: Date.now(), kind: "interactive" }),
+  );
+}
+
+describe("claude-pid lookup", () => {
+  it("finds PID by threadId", async () => {
+    writeSession(12345, "thread-a");
+    writeSession(67890, "thread-b");
+    const lookup = createClaudePidLookup(sessionsDir);
+    expect(await lookup.pidForThread("thread-a")).toBe(12345);
+    expect(await lookup.pidForThread("thread-b")).toBe(67890);
+  });
+
+  it("returns null for unknown threadId", async () => {
+    writeSession(12345, "thread-a");
+    const lookup = createClaudePidLookup(sessionsDir);
+    expect(await lookup.pidForThread("thread-missing")).toBeNull();
+  });
+
+  it("returns null when sessions dir is missing", async () => {
+    const lookup = createClaudePidLookup(join(tmpDir, "does-not-exist"));
+    expect(await lookup.pidForThread("thread-a")).toBeNull();
+  });
+
+  it("skips invalid session JSON files", async () => {
+    writeFileSync(join(sessionsDir, "bad.json"), "not json");
+    writeSession(12345, "thread-a");
+    const lookup = createClaudePidLookup(sessionsDir);
+    expect(await lookup.pidForThread("thread-a")).toBe(12345);
+  });
+
+  it("isAlive returns true for current process pid", () => {
+    const lookup = createClaudePidLookup(sessionsDir);
+    expect(lookup.isAlive(process.pid)).toBe(true);
+  });
+
+  it("isAlive returns false for pid 999999999", () => {
+    const lookup = createClaudePidLookup(sessionsDir);
+    expect(lookup.isAlive(999_999_999)).toBe(false);
+  });
+
+  it("invalidate clears the cache so new sessions are picked up", async () => {
+    const lookup = createClaudePidLookup(sessionsDir);
+    // Prime cache with empty result
+    expect(await lookup.pidForThread("thread-a")).toBeNull();
+    writeSession(12345, "thread-a");
+    // Still null because cache is stale
+    expect(await lookup.pidForThread("thread-a")).toBeNull();
+    lookup.invalidate();
+    expect(await lookup.pidForThread("thread-a")).toBe(12345);
+  });
+});

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-pid.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-pid.ts
@@ -1,0 +1,57 @@
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface ClaudePidLookup {
+  pidForThread(threadId: string): Promise<number | null>;
+  isAlive(pid: number): boolean;
+  invalidate(): void;
+}
+
+const DEFAULT_SESSIONS_DIR = join(homedir(), ".claude", "sessions");
+
+export function createClaudePidLookup(sessionsDir: string = DEFAULT_SESSIONS_DIR): ClaudePidLookup {
+  let cache: Map<string, number> | null = null;
+
+  async function loadCache(): Promise<Map<string, number>> {
+    const map = new Map<string, number>();
+    let files: string[];
+    try {
+      files = await readdir(sessionsDir);
+    } catch {
+      return map;
+    }
+
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const text = await readFile(join(sessionsDir, file), "utf-8");
+        const data = JSON.parse(text) as { pid?: number; sessionId?: string };
+        if (typeof data.pid === "number" && typeof data.sessionId === "string") {
+          map.set(data.sessionId, data.pid);
+        }
+      } catch {
+        // skip unreadable / invalid JSON
+      }
+    }
+    return map;
+  }
+
+  return {
+    async pidForThread(threadId) {
+      if (!cache) cache = await loadCache();
+      return cache.get(threadId) ?? null;
+    },
+    isAlive(pid) {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    invalidate() {
+      cache = null;
+    },
+  };
+}

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-usage.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-usage.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "bun:test";
+import { contextMax, contextUsed, cacheTtlMs, extractUsageSummary } from "./claude-usage";
+
+describe("contextMax", () => {
+  it("returns 1M for sonnet with [1m] suffix", () => {
+    expect(contextMax("claude-sonnet-4-5[1m]")).toBe(1_000_000);
+  });
+
+  it("returns 200K for opus", () => {
+    expect(contextMax("claude-opus-4-6")).toBe(200_000);
+  });
+
+  it("returns 200K for haiku", () => {
+    expect(contextMax("claude-haiku-4-5")).toBe(200_000);
+  });
+
+  it("returns 200K for empty or unknown model", () => {
+    expect(contextMax("")).toBe(200_000);
+    expect(contextMax("gpt-4")).toBe(200_000);
+  });
+});
+
+describe("contextUsed", () => {
+  it("sums input + output + cache_read + cache_creation", () => {
+    expect(
+      contextUsed({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 1000,
+        cache_creation_input_tokens: 200,
+      }),
+    ).toBe(1350);
+  });
+
+  it("treats missing fields as 0", () => {
+    expect(contextUsed({ input_tokens: 10 })).toBe(10);
+    expect(contextUsed({})).toBe(0);
+  });
+
+  it("treats null cache fields as 0", () => {
+    expect(
+      contextUsed({
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+      }),
+    ).toBe(15);
+  });
+});
+
+describe("cacheTtlMs", () => {
+  it("returns null when no cache activity", () => {
+    expect(cacheTtlMs({ input_tokens: 100, output_tokens: 50 })).toBeNull();
+  });
+
+  it("returns 1h when ephemeral_1h_input_tokens > 0", () => {
+    expect(
+      cacheTtlMs({
+        cache_creation: { ephemeral_1h_input_tokens: 100, ephemeral_5m_input_tokens: 0 },
+      }),
+    ).toBe(60 * 60 * 1000);
+  });
+
+  it("returns 5m when only 5m tokens", () => {
+    expect(
+      cacheTtlMs({
+        cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 100 },
+      }),
+    ).toBe(5 * 60 * 1000);
+  });
+
+  it("returns 5m when only cache_read (no creation this turn)", () => {
+    expect(cacheTtlMs({ cache_read_input_tokens: 500 })).toBe(5 * 60 * 1000);
+  });
+
+  it("prefers 1h when both present", () => {
+    expect(
+      cacheTtlMs({
+        cache_creation: { ephemeral_1h_input_tokens: 50, ephemeral_5m_input_tokens: 100 },
+      }),
+    ).toBe(60 * 60 * 1000);
+  });
+});
+
+describe("extractUsageSummary", () => {
+  const assistantEntry = (timestamp: string, model: string, usage: unknown) => ({
+    type: "assistant",
+    timestamp,
+    message: { role: "assistant", model, usage },
+  });
+
+  it("returns null for empty entries", () => {
+    expect(extractUsageSummary([])).toBeNull();
+  });
+
+  it("returns null when no assistant entry has usage", () => {
+    expect(
+      extractUsageSummary([
+        {
+          type: "user",
+          timestamp: "2026-04-12T00:00:00Z",
+          message: { role: "user", content: "hi" },
+        } as never,
+      ]),
+    ).toBeNull();
+  });
+
+  it("extracts fields from most recent assistant entry with usage", () => {
+    const entries = [
+      assistantEntry("2026-04-12T00:00:00Z", "claude-opus-4-6", {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      }),
+      assistantEntry("2026-04-12T00:05:00Z", "claude-opus-4-6", {
+        input_tokens: 1,
+        output_tokens: 249,
+        cache_read_input_tokens: 50612,
+        cache_creation_input_tokens: 2297,
+        cache_creation: { ephemeral_1h_input_tokens: 2297, ephemeral_5m_input_tokens: 0 },
+      }),
+    ] as never[];
+
+    const result = extractUsageSummary(entries);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe("claude-opus-4-6");
+    expect(result!.contextUsed).toBe(53159);
+    expect(result!.contextMax).toBe(200_000);
+    expect(result!.cacheTtlMs).toBe(60 * 60 * 1000);
+    expect(result!.lastActivityAt).toBe(new Date("2026-04-12T00:05:00Z").getTime());
+    expect(result!.cacheExpiresAt).toBe(result!.lastActivityAt + 60 * 60 * 1000);
+  });
+
+  it("leaves cacheExpiresAt and cacheTtlMs null when no cache activity", () => {
+    const entries = [
+      assistantEntry("2026-04-12T00:00:00Z", "claude-opus-4-6", {
+        input_tokens: 100,
+        output_tokens: 50,
+      }),
+    ] as never[];
+
+    const result = extractUsageSummary(entries);
+    expect(result!.cacheExpiresAt).toBeNull();
+    expect(result!.cacheTtlMs).toBeNull();
+  });
+});

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-usage.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-usage.ts
@@ -1,0 +1,78 @@
+import type { Usage } from "@anthropic-ai/sdk/resources/messages/messages";
+
+type PartialUsage = Partial<Usage> & {
+  cache_creation?: {
+    ephemeral_5m_input_tokens?: number;
+    ephemeral_1h_input_tokens?: number;
+  } | null;
+};
+
+interface AssistantLikeEntry {
+  type?: string;
+  timestamp?: string;
+  message?: {
+    role?: string;
+    model?: string;
+    usage?: PartialUsage | null;
+  };
+}
+
+export interface ClaudeUsageSummary {
+  model: string;
+  contextUsed: number;
+  contextMax: number;
+  cacheTtlMs: number | null;
+  cacheExpiresAt: number | null;
+  lastActivityAt: number;
+}
+
+const FIVE_MIN_MS = 5 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+export function contextMax(model: string): number {
+  if (/\[1m\]$/i.test(model)) return 1_000_000;
+  return 200_000;
+}
+
+export function contextUsed(u: PartialUsage): number {
+  return (
+    (u.input_tokens ?? 0) +
+    (u.output_tokens ?? 0) +
+    (u.cache_read_input_tokens ?? 0) +
+    (u.cache_creation_input_tokens ?? 0)
+  );
+}
+
+export function cacheTtlMs(u: PartialUsage): number | null {
+  const c = u.cache_creation ?? null;
+  const h = c?.ephemeral_1h_input_tokens ?? 0;
+  const m = c?.ephemeral_5m_input_tokens ?? 0;
+  const reads = u.cache_read_input_tokens ?? 0;
+  if (h > 0) return ONE_HOUR_MS;
+  if (m > 0 || reads > 0) return FIVE_MIN_MS;
+  return null;
+}
+
+export function extractUsageSummary(entries: AssistantLikeEntry[]): ClaudeUsageSummary | null {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i]!;
+    if (e.message?.role !== "assistant") continue;
+    const usage = e.message.usage;
+    if (!usage) continue;
+
+    const model = e.message.model ?? "";
+    const ts = e.timestamp ? Date.parse(e.timestamp) : Number.NaN;
+    if (Number.isNaN(ts)) continue;
+
+    const ttl = cacheTtlMs(usage);
+    return {
+      model,
+      contextUsed: contextUsed(usage),
+      contextMax: contextMax(model),
+      cacheTtlMs: ttl,
+      cacheExpiresAt: ttl === null ? null : ts + ttl,
+      lastActivityAt: ts,
+    };
+  }
+  return null;
+}

--- a/packages/agentboard/packages/runtime/src/contracts/agent.ts
+++ b/packages/agentboard/packages/runtime/src/contracts/agent.ts
@@ -7,6 +7,21 @@ export type AgentStatus =
   | "question"
   | "interrupted";
 
+export interface AgentEventDetails {
+  /** Model name from most recent assistant turn (e.g. "claude-opus-4-6") */
+  model?: string;
+  /** Total tokens consumed in the most recent turn (input + output + cache) */
+  contextUsed?: number;
+  /** Inferred context window size for the model (200K or 1M) */
+  contextMax?: number;
+  /** Epoch ms when the prompt cache expires; undefined = no cache active */
+  cacheExpiresAt?: number;
+  /** Cache TTL type: 300_000 (5m) or 3_600_000 (1h) */
+  cacheTtlMs?: number;
+  /** Epoch ms of the most recent assistant entry in the journal */
+  lastActivityAt?: number;
+}
+
 export interface AgentEvent {
   agent: string;
   session: string;
@@ -18,6 +33,8 @@ export interface AgentEvent {
   unseen?: boolean;
   /** Set by pane scanner — the tmux pane ID where this agent was detected */
   paneId?: string;
+  /** Optional per-agent live details. Currently populated only by the claude-code watcher. */
+  details?: AgentEventDetails;
 }
 
 export const TERMINAL_STATUSES = new Set<AgentStatus>(["done", "error", "interrupted"]);

--- a/packages/agentboard/packages/runtime/src/server/pane-scanner.ts
+++ b/packages/agentboard/packages/runtime/src/server/pane-scanner.ts
@@ -14,21 +14,27 @@ const AGENT_TITLE_PATTERNS: Record<string, string[]> = {
   opencode: ["opencode"],
 };
 
-/** Build parent->children map from a single ps snapshot (avoids per-pane pgrep calls). */
+/** Build parent->children map from a single ps snapshot (avoids per-pane pgrep calls).
+ *  Skips stopped (T) and zombie (Z) processes — they have a comm but aren't actively running. */
 function buildProcessTree(): { childrenOf: Map<number, number[]>; commOf: Map<number, string> } {
   const childrenOf = new Map<number, number[]>();
   const commOf = new Map<number, string>();
-  const psResult = Bun.spawnSync(["ps", "-eo", "pid=,ppid=,comm="], {
+  const psResult = Bun.spawnSync(["ps", "-eo", "pid=,ppid=,stat=,comm="], {
     stdout: "pipe",
     stderr: "pipe",
   });
   for (const line of psResult.stdout.toString().trim().split("\n")) {
     const parts = line.trim().split(/\s+/);
-    if (parts.length < 3) continue;
+    if (parts.length < 4) continue;
     const pid = Number.parseInt(parts[0], 10);
     const ppid = Number.parseInt(parts[1], 10);
-    const comm = parts.slice(2).join(" ").toLowerCase();
+    const stat = parts[2] ?? "";
+    const comm = parts.slice(3).join(" ").toLowerCase();
     if (Number.isNaN(pid) || Number.isNaN(ppid)) continue;
+    // First char of stat is the primary process state.
+    // T = stopped (e.g. Ctrl+Z), Z = zombie, X = dead. Treat all as not-running.
+    const state = stat.charAt(0);
+    if (state === "T" || state === "Z" || state === "X") continue;
     commOf.set(pid, comm);
     let arr = childrenOf.get(ppid);
     if (!arr) {


### PR DESCRIPTION
## Summary
- **Immediate process-exit detection** — the claude-code watcher now checks PID liveness via `process.kill(pid, 0)`, flipping status to `idle` within 2s when Claude exits (was up to 120s waiting for journal staleness)
- **Cache TTL display** — reads `usage.cache_creation.ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens` from the JSONL journal to derive the cache window, then renders a draining progress bar in the detail panel (green > 50%, yellow > 20%, peach near expiry)
- **Model name in detail panel** — shows `opus-4-6` etc. next to the cache bar
- **Pane scanner false-positive fix** — previously matched stopped (`T` state) / zombie (`Z`) claude processes, causing ghost `waiting` statuses; now filtered out

## Architecture

Two new helper modules in the runtime package:
- `claude-pid.ts` — maps `threadId → pid` via `~/.claude/sessions/<pid>.json` and checks liveness
- `claude-usage.ts` — pure functions to extract cache TTL and model from journal entries

`AgentEvent` gained an optional `details` field carrying model + cache expiry info. Other watchers leave it undefined.

## Test plan
- [x] Unit tests pass (`bun test` — 61 runtime tests, 422 total across repo)
- [x] Typecheck clean (`bun typecheck`)
- [x] Lint clean (`bun run lint`)
- [ ] Manual: start agentboard, start a Claude session, verify cache bar ticks down
- [ ] Manual: `kill <claude pid>` and verify status flips to `idle` within ~2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)