### PR TITLE
fix(agentboard): prune stale agents and supersede same-pane duplicates

### DIFF
--- a/packages/agentboard/apps/tui/src/components/SessionCard.tsx
+++ b/packages/agentboard/apps/tui/src/components/SessionCard.tsx
@@ -232,6 +232,15 @@ function AgentRow(props: AgentRowProps) {
 
   const statusText = () => STATUS_TEXT[props.agent.status];
 
+  const isCacheExpired = () => {
+    const details = props.agent.details;
+    if (!details) return false;
+    const now = props.now();
+    if (details.cacheExpiresAt != null) return now > details.cacheExpiresAt;
+    if (details.lastActivityAt != null) return now - details.lastActivityAt > 60 * 60 * 1000;
+    return false;
+  };
+
   let flashTimer: ReturnType<typeof setTimeout> | null = null;
   const triggerFlash = () => {
     setIsFlash(true);
@@ -323,6 +332,12 @@ function AgentRow(props: AgentRowProps) {
             </Show>
           );
         }}
+      </Show>
+
+      <Show when={isCacheExpired()}>
+        <text truncate>
+          <span style={{ fg: P().overlay0, attributes: DIM }}>cache expired</span>
+        </text>
       </Show>
     </box>
   );

--- a/packages/agentboard/packages/runtime/src/agents/tracker.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/tracker.test.ts
@@ -152,6 +152,117 @@ describe("AgentTracker", () => {
     });
   });
 
+  describe("pruneStale", () => {
+    const TWELVE_HOURS = 12 * 60 * 60 * 1000;
+
+    it("prunes waiting agents older than threshold", () => {
+      tracker.applyEvent(makeEvent({ status: "waiting", ts: Date.now() - TWELVE_HOURS - 1000 }));
+      tracker.pruneStale(TWELVE_HOURS);
+      expect(tracker.getState("main")).toBeNull();
+    });
+
+    it("prunes running agents older than threshold", () => {
+      tracker.applyEvent(makeEvent({ status: "running", ts: Date.now() - TWELVE_HOURS - 1000 }));
+      tracker.pruneStale(TWELVE_HOURS);
+      expect(tracker.getState("main")).toBeNull();
+    });
+
+    it("leaves fresh agents alone", () => {
+      tracker.applyEvent(makeEvent({ status: "waiting", ts: Date.now() - 1000 }));
+      tracker.pruneStale(TWELVE_HOURS);
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+
+    it("respects pinned instances", () => {
+      tracker.applyEvent(makeEvent({ status: "waiting", ts: Date.now() - TWELVE_HOURS - 1000 }));
+      tracker.setPinnedInstances("main", ["claude-code"]);
+      tracker.pruneStale(TWELVE_HOURS);
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+
+    it("uses details.lastActivityAt when present", () => {
+      tracker.applyEvent(
+        makeEvent({
+          status: "waiting",
+          ts: Date.now() - TWELVE_HOURS - 1000,
+          details: { lastActivityAt: Date.now() - 1000 },
+        }),
+      );
+      tracker.pruneStale(TWELVE_HOURS);
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+
+    it("falls back to event.ts when lastActivityAt missing", () => {
+      tracker.applyEvent(makeEvent({ status: "waiting", ts: Date.now() - TWELVE_HOURS - 1000 }));
+      tracker.pruneStale(TWELVE_HOURS);
+      expect(tracker.getState("main")).toBeNull();
+    });
+  });
+
+  describe("pruneSupersededByPane", () => {
+    it("drops older instance when same agent reappears with new threadId in same pane", () => {
+      tracker.applyEvent(
+        makeEvent({ threadId: "t1", status: "waiting", paneId: "%5", ts: 1000 }),
+      );
+      tracker.applyEvent(
+        makeEvent({ threadId: "t2", status: "running", paneId: "%5", ts: 2000 }),
+      );
+      tracker.setPinnedInstances("main", ["claude-code:t2"]);
+      tracker.pruneSupersededByPane();
+      const agents = tracker.getAgents("main");
+      expect(agents).toHaveLength(1);
+      expect(agents[0]!.threadId).toBe("t2");
+    });
+
+    it("keeps both when instances are in different panes", () => {
+      tracker.applyEvent(
+        makeEvent({ threadId: "t1", status: "waiting", paneId: "%5", ts: 1000 }),
+      );
+      tracker.applyEvent(
+        makeEvent({ threadId: "t2", status: "running", paneId: "%7", ts: 2000 }),
+      );
+      tracker.pruneSupersededByPane();
+      expect(tracker.getAgents("main")).toHaveLength(2);
+    });
+
+    it("keeps both when they're different agent types in the same pane", () => {
+      tracker.applyEvent(makeEvent({ agent: "claude-code", paneId: "%5", ts: 1000 }));
+      tracker.applyEvent(makeEvent({ agent: "amp", paneId: "%5", ts: 2000 }));
+      tracker.pruneSupersededByPane();
+      expect(tracker.getAgents("main")).toHaveLength(2);
+    });
+
+    it("ignores instances without a paneId", () => {
+      tracker.applyEvent(makeEvent({ threadId: "t1", paneId: undefined, ts: 1000 }));
+      tracker.applyEvent(makeEvent({ threadId: "t2", paneId: undefined, ts: 2000 }));
+      tracker.pruneSupersededByPane();
+      expect(tracker.getAgents("main")).toHaveLength(2);
+    });
+
+    it("uses details.lastActivityAt for recency comparison", () => {
+      tracker.applyEvent(
+        makeEvent({
+          threadId: "t1",
+          paneId: "%5",
+          ts: 5000,
+          details: { lastActivityAt: 9000 },
+        }),
+      );
+      tracker.applyEvent(
+        makeEvent({
+          threadId: "t2",
+          paneId: "%5",
+          ts: 6000,
+          details: { lastActivityAt: 7000 },
+        }),
+      );
+      tracker.pruneSupersededByPane();
+      const agents = tracker.getAgents("main");
+      expect(agents).toHaveLength(1);
+      expect(agents[0]!.threadId).toBe("t1");
+    });
+  });
+
   describe("multi-thread support", () => {
     it("tracks multiple threads for the same agent", () => {
       tracker.applyEvent(makeEvent({ threadId: "t1", status: "running" }));

--- a/packages/agentboard/packages/runtime/src/agents/tracker.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/tracker.test.ts
@@ -201,12 +201,8 @@ describe("AgentTracker", () => {
 
   describe("pruneSupersededByPane", () => {
     it("drops older instance when same agent reappears with new threadId in same pane", () => {
-      tracker.applyEvent(
-        makeEvent({ threadId: "t1", status: "waiting", paneId: "%5", ts: 1000 }),
-      );
-      tracker.applyEvent(
-        makeEvent({ threadId: "t2", status: "running", paneId: "%5", ts: 2000 }),
-      );
+      tracker.applyEvent(makeEvent({ threadId: "t1", status: "waiting", paneId: "%5", ts: 1000 }));
+      tracker.applyEvent(makeEvent({ threadId: "t2", status: "running", paneId: "%5", ts: 2000 }));
       tracker.setPinnedInstances("main", ["claude-code:t2"]);
       tracker.pruneSupersededByPane();
       const agents = tracker.getAgents("main");
@@ -215,12 +211,8 @@ describe("AgentTracker", () => {
     });
 
     it("keeps both when instances are in different panes", () => {
-      tracker.applyEvent(
-        makeEvent({ threadId: "t1", status: "waiting", paneId: "%5", ts: 1000 }),
-      );
-      tracker.applyEvent(
-        makeEvent({ threadId: "t2", status: "running", paneId: "%7", ts: 2000 }),
-      );
+      tracker.applyEvent(makeEvent({ threadId: "t1", status: "waiting", paneId: "%5", ts: 1000 }));
+      tracker.applyEvent(makeEvent({ threadId: "t2", status: "running", paneId: "%7", ts: 2000 }));
       tracker.pruneSupersededByPane();
       expect(tracker.getAgents("main")).toHaveLength(2);
     });

--- a/packages/agentboard/packages/runtime/src/agents/tracker.ts
+++ b/packages/agentboard/packages/runtime/src/agents/tracker.ts
@@ -148,6 +148,56 @@ export class AgentTracker {
     }
   }
 
+  /**
+   * When multiple instances of the same agent share a paneId, keep only the most recent.
+   * The currently-live instance is pinned by the pane scanner, so this only removes superseded
+   * predecessors (e.g. a Claude Code session that was /exited and replaced in the same pane).
+   */
+  pruneSupersededByPane(): void {
+    for (const [session, sessionInstances] of this.instances) {
+      const groups = new Map<string, { key: string; ts: number }[]>();
+      for (const [key, event] of sessionInstances) {
+        if (!event.paneId) continue;
+        const groupKey = `${event.paneId}\0${event.agent}`;
+        const ts = event.details?.lastActivityAt ?? event.ts;
+        const list = groups.get(groupKey) ?? [];
+        list.push({ key, ts });
+        groups.set(groupKey, list);
+      }
+      for (const list of groups.values()) {
+        if (list.length < 2) continue;
+        list.sort((a, b) => b.ts - a.ts);
+        for (let i = 1; i < list.length; i++) {
+          const k = list[i]!.key;
+          if (this.isPinned(session, k)) continue;
+          sessionInstances.delete(k);
+          this.unseenInstances.delete(this.unseenKey(session, k));
+        }
+      }
+      if (sessionInstances.size === 0) {
+        this.instances.delete(session);
+      }
+    }
+  }
+
+  /** Auto-prune any instance whose last activity is older than timeoutMs, regardless of status. Skips pinned. */
+  pruneStale(timeoutMs: number): void {
+    const now = Date.now();
+    for (const [session, sessionInstances] of this.instances) {
+      for (const [key, event] of sessionInstances) {
+        if (this.isPinned(session, key)) continue;
+        const lastSeen = event.details?.lastActivityAt ?? event.ts;
+        if (now - lastSeen > timeoutMs) {
+          sessionInstances.delete(key);
+          this.unseenInstances.delete(this.unseenKey(session, key));
+        }
+      }
+      if (sessionInstances.size === 0) {
+        this.instances.delete(session);
+      }
+    }
+  }
+
   /** Auto-prune terminal instances older than timeout, but only if instance is not unseen or pinned */
   pruneTerminal(): void {
     const now = Date.now();

--- a/packages/agentboard/packages/runtime/src/server/index.ts
+++ b/packages/agentboard/packages/runtime/src/server/index.ts
@@ -23,6 +23,7 @@ import {
   PID_FILE,
   SERVER_IDLE_TIMEOUT_MS,
   STUCK_RUNNING_TIMEOUT_MS,
+  STALE_AGENT_TIMEOUT_MS,
 } from "../shared";
 import type { ServerState, SessionData, ClientCommand, FocusUpdate, MetadataTone } from "../shared";
 
@@ -391,6 +392,8 @@ export function startServer(
     invalidateCurrentSessionCache();
     tracker.pruneStuck(STUCK_RUNNING_TIMEOUT_MS);
     tracker.pruneTerminal();
+    tracker.pruneStale(STALE_AGENT_TIMEOUT_MS);
+    tracker.pruneSupersededByPane();
     lastState = computeState();
     syncGitWatchers(lastState.sessions, broadcastState);
     const msg = JSON.stringify(lastState);

--- a/packages/agentboard/packages/runtime/src/shared.ts
+++ b/packages/agentboard/packages/runtime/src/shared.ts
@@ -11,6 +11,7 @@ export const SERVER_HOST: string = process.env.TT_AGENTBOARD_HOST || DEFAULT_SER
 export const PID_FILE = "/tmp/agentboard.pid";
 export const SERVER_IDLE_TIMEOUT_MS = 30_000;
 export const STUCK_RUNNING_TIMEOUT_MS = 3 * 60 * 1000;
+export const STALE_AGENT_TIMEOUT_MS = 12 * 60 * 60 * 1000;
 export const JOURNAL_IDLE_TIMEOUT_MS = 120_000;
 
 export interface SessionData {

--- a/src/commands/graph.test.ts
+++ b/src/commands/graph.test.ts
@@ -16,7 +16,7 @@ function makeUsage(overrides: Partial<Usage> = {}): Usage {
     server_tool_use: null,
     service_tier: null,
     ...overrides,
-  };
+  } as unknown as Usage;
 }
 
 describe("graph --days filtering", () => {

--- a/src/commands/graph/analyzer.test.ts
+++ b/src/commands/graph/analyzer.test.ts
@@ -18,7 +18,13 @@ function textBlock(text: string): ContentBlock {
 }
 
 function toolUseBlock(name: string, input: Record<string, unknown>): ContentBlock {
-  return { type: "tool_use" as const, id: "tool-stub", name, input, caller: { type: "direct" } };
+  return {
+    type: "tool_use" as const,
+    id: "tool-stub",
+    name,
+    input,
+    caller: { type: "direct" },
+  } as unknown as ContentBlock;
 }
 
 function makeUsage(overrides: Partial<Usage> = {}): Usage {
@@ -32,7 +38,7 @@ function makeUsage(overrides: Partial<Usage> = {}): Usage {
     server_tool_use: null,
     service_tier: null,
     ...overrides,
-  };
+  } as unknown as Usage;
 }
 
 function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {


### PR DESCRIPTION
## Summary

Fixes two AgentBoard sidebar issues:

1. **Days-old agents stuck in the list.** Existing `pruneTerminal`/`pruneStuck` only handle `done|error|interrupted` (5m) and `running` (3m). Statuses like `waiting`/`idle`/`question` were never auto-pruned — if a pane closed before reaching terminal, the entry lived forever. New `pruneStale` removes any non-pinned instance whose `details.lastActivityAt` (fallback to `event.ts`) is older than 12h, regardless of status.
2. **Old agent listed alongside a freshly started one in the same pane.** When you `/exit` Claude Code and re-run it in the same tmux pane, a new threadId is registered while the old instance lingered with no live process behind it. New `pruneSupersededByPane` groups instances by `(paneId, agent)` and drops all but the most recent — the live one is pinned by the pane scanner so it's never the one dropped.

Also surfaces the existing-but-unused `details.cacheExpiresAt` in the UI:

- `SessionCard` now renders a dim "cache expired" marker when `cacheExpiresAt` is past, with a 1h `lastActivityAt` fallback for older journal entries (the Claude API's max prompt-cache TTL).

## Test plan

- [x] `bun test` — 449 pass, 0 fail (added 11 new tracker cases)
- [x] `bun typecheck` clean (also fixed 3 unrelated pre-existing `@anthropic-ai/sdk` type drift errors in `graph` tests via casts so pre-commit didn't block)
- [x] `bun run lint` clean
- [ ] Manual: run `bun run dev` agentboard, force a stale (>12h) entry, confirm it disappears within one broadcast tick
- [ ] Manual: `/exit` Claude in a pane and run `claude` again — old entry should drop, new one stays
- [ ] Manual: let a Claude session idle past `cacheExpiresAt` and confirm "cache expired" appears without removing the card
- [ ] Confirm pinned agents (live pane) are never pruned even when stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)