### PR TITLE
fix(agentboard): restart replaces server when PID file is stale

### DIFF
--- a/packages/agentboard/packages/runtime/src/server/index.ts
+++ b/packages/agentboard/packages/runtime/src/server/index.ts
@@ -1600,6 +1600,17 @@ export function startServer(
         return new Response("ok", { status: 200 });
       }
 
+      if (req.method === "POST" && url.pathname === "/shutdown") {
+        log("http", "POST /shutdown");
+        // Defer exit so this response flushes first; lets `tt agentboard
+        // restart` terminate a server whose PID file was lost/rotated.
+        setTimeout(() => {
+          cleanup();
+          process.exit(0);
+        }, 50);
+        return new Response("ok", { status: 200 });
+      }
+
       if (req.method === "POST" && url.pathname === "/switch-index") {
         try {
           const index = Number.parseInt(url.searchParams.get("index") ?? "", 10);

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -188,21 +188,37 @@ async function serverAlive(): Promise<boolean> {
 
 const PID_FILE = "/tmp/agentboard.pid";
 
-function stopServer(): boolean {
-  if (!existsSync(PID_FILE)) return false;
-  const pid = Number.parseInt(readFileSync(PID_FILE, "utf8").trim(), 10);
-  if (Number.isNaN(pid)) return false;
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch {
-    // process already dead
+async function stopServer(): Promise<boolean> {
+  // Preferred path: terminate the process named in the PID file.
+  if (existsSync(PID_FILE)) {
+    const pid = Number.parseInt(readFileSync(PID_FILE, "utf8").trim(), 10);
+    if (!Number.isNaN(pid)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+        // process already dead
+      }
+      try {
+        unlinkSync(PID_FILE);
+      } catch {
+        // intentionally ignored: PID file may already be gone
+      }
+      return true;
+    }
   }
-  try {
-    unlinkSync(PID_FILE);
-  } catch {
-    // intentionally ignored: PID file may already be gone
+
+  // Fallback: the PID file is missing/stale but a server is still squatting
+  // the port (e.g. file rotated out from under a long-lived process). Ask it
+  // to shut itself down so restart actually replaces it instead of no-oping.
+  if (await serverAlive()) {
+    await fetch(`http://${SERVER_HOST}:${SERVER_PORT}/shutdown`, {
+      method: "POST",
+      signal: AbortSignal.timeout(2000),
+    }).catch(() => {});
+    return true;
   }
-  return true;
+
+  return false;
 }
 
 async function ensureServerUp(): Promise<boolean> {
@@ -394,7 +410,7 @@ async function restart(): Promise<void> {
   }
 
   // 2. Stop existing server, then start fresh
-  const wasStopped = stopServer();
+  const wasStopped = await stopServer();
   if (wasStopped) {
     // Wait for port to free up
     for (let i = 0; i < 20; i++) {


### PR DESCRIPTION
## Summary

Fixes #249 — `tt agentboard restart` silently no-ops when the PID file is missing/stale, leaving the old server running while falsely reporting `✔ Server is running`.

- **Root cause:** `stopServer()` returned `false` when the PID file was missing/unparseable; `restart()` ignored that and `ensureServerUp()` saw the squatting old server answer `serverAlive()`, reporting success without replacing it.
- **Fix (issue's preferred option 1):**
  - Server: new `POST /shutdown` endpoint — defers 50ms so the response flushes, then runs `cleanup()` and exits cleanly.
  - CLI: `stopServer()` is now async. PID-file termination stays the primary path; when the PID file is missing/stale **and** a server still answers on the port, it falls back to `POST /shutdown`. `restart()` awaits it.

Net effect: the `✔ Server is running` message is truthful because the old process is genuinely gone before the fresh one starts.

## Test plan

- [x] `bun run format:check`, `bun run lint`, `bun typecheck`, `bun test` (449 pass, 0 fail)
- [ ] Manual: start server, delete `/tmp/agentboard.pid`, run `tt agentboard restart`, confirm PID/start-time changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)