### PR TITLE
fix(agentboard): prune dead idle sessions left behind by /clear

### DIFF
--- a/packages/agentboard/packages/runtime/src/agents/tracker.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/tracker.test.ts
@@ -199,6 +199,62 @@ describe("AgentTracker", () => {
     });
   });
 
+  describe("pruneIdle", () => {
+    const GRACE = 30_000;
+
+    it("prunes idle agents older than threshold", () => {
+      tracker.applyEvent(makeEvent({ status: "idle", ts: Date.now() - GRACE - 1000 }));
+      tracker.pruneIdle(GRACE);
+      expect(tracker.getState("main")).toBeNull();
+    });
+
+    it("leaves fresh idle agents alone", () => {
+      tracker.applyEvent(makeEvent({ status: "idle", ts: Date.now() - 1000 }));
+      tracker.pruneIdle(GRACE);
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+
+    it("does not prune non-idle agents", () => {
+      tracker.applyEvent(makeEvent({ status: "done", ts: Date.now() - GRACE - 1000 }));
+      tracker.pruneIdle(GRACE);
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+
+    it("respects pinned instances (live pane keeps the agent)", () => {
+      tracker.applyEvent(
+        makeEvent({ threadId: "t1", status: "idle", ts: Date.now() - GRACE - 1000 }),
+      );
+      tracker.setPinnedInstances("main", ["claude-code:t1"]);
+      tracker.pruneIdle(GRACE);
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+
+    it("prunes the cleared session but keeps the live one", () => {
+      // Simulates /clear: old session (t1) went idle, new session (t2) is live + pinned.
+      tracker.applyEvent(
+        makeEvent({ threadId: "t1", status: "idle", ts: Date.now() - GRACE - 1000 }),
+      );
+      tracker.applyEvent(makeEvent({ threadId: "t2", status: "running", ts: Date.now() }));
+      tracker.setPinnedInstances("main", ["claude-code:t2"]);
+      tracker.pruneIdle(GRACE);
+      const agents = tracker.getAgents("main");
+      expect(agents).toHaveLength(1);
+      expect(agents[0]!.threadId).toBe("t2");
+    });
+
+    it("uses details.lastActivityAt when present", () => {
+      tracker.applyEvent(
+        makeEvent({
+          status: "idle",
+          ts: Date.now() - GRACE - 1000,
+          details: { lastActivityAt: Date.now() - 1000 },
+        }),
+      );
+      tracker.pruneIdle(GRACE);
+      expect(tracker.getState("main")).not.toBeNull();
+    });
+  });
+
   describe("pruneSupersededByPane", () => {
     it("drops older instance when same agent reappears with new threadId in same pane", () => {
       tracker.applyEvent(makeEvent({ threadId: "t1", status: "waiting", paneId: "%5", ts: 1000 }));

--- a/packages/agentboard/packages/runtime/src/agents/tracker.ts
+++ b/packages/agentboard/packages/runtime/src/agents/tracker.ts
@@ -198,6 +198,30 @@ export class AgentTracker {
     }
   }
 
+  /**
+   * Auto-prune "idle" instances older than timeoutMs unless pinned.
+   * An agent only becomes idle when its process is gone or its journal stalled, so an
+   * unpinned idle instance is a dead session (e.g. a Claude session left behind by /clear).
+   * Live agents are pinned by the pane scanner and re-added via pane presence, so they survive.
+   */
+  pruneIdle(timeoutMs: number): void {
+    const now = Date.now();
+    for (const [session, sessionInstances] of this.instances) {
+      for (const [key, event] of sessionInstances) {
+        if (event.status !== "idle") continue;
+        if (this.isPinned(session, key)) continue;
+        const lastSeen = event.details?.lastActivityAt ?? event.ts;
+        if (now - lastSeen > timeoutMs) {
+          sessionInstances.delete(key);
+          this.unseenInstances.delete(this.unseenKey(session, key));
+        }
+      }
+      if (sessionInstances.size === 0) {
+        this.instances.delete(session);
+      }
+    }
+  }
+
   /** Auto-prune terminal instances older than timeout, but only if instance is not unseen or pinned */
   pruneTerminal(): void {
     const now = Date.now();

--- a/packages/agentboard/packages/runtime/src/server/index.ts
+++ b/packages/agentboard/packages/runtime/src/server/index.ts
@@ -24,6 +24,7 @@ import {
   SERVER_IDLE_TIMEOUT_MS,
   STUCK_RUNNING_TIMEOUT_MS,
   STALE_AGENT_TIMEOUT_MS,
+  IDLE_PRUNE_MS,
 } from "../shared";
 import type { ServerState, SessionData, ClientCommand, FocusUpdate, MetadataTone } from "../shared";
 
@@ -393,6 +394,7 @@ export function startServer(
     tracker.pruneStuck(STUCK_RUNNING_TIMEOUT_MS);
     tracker.pruneTerminal();
     tracker.pruneStale(STALE_AGENT_TIMEOUT_MS);
+    tracker.pruneIdle(IDLE_PRUNE_MS);
     tracker.pruneSupersededByPane();
     lastState = computeState();
     syncGitWatchers(lastState.sessions, broadcastState);

--- a/packages/agentboard/packages/runtime/src/server/pane-scanner.ts
+++ b/packages/agentboard/packages/runtime/src/server/pane-scanner.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import type { AgentStatus } from "../contracts/agent";
 import { TERMINAL_STATUSES } from "../contracts/agent";
+import { instanceKey } from "../agents/tracker";
 import type { SidebarPane } from "../contracts/mux";
 import type { ServerContext, PaneAgentPresence } from "./context";
 import { shell } from "./git-info";
@@ -311,9 +312,15 @@ export function refreshPaneAgents(ctx: ServerContext): void {
   }
 
   const nextBySession = scanAllTmuxPaneAgents(ctx.listSidebarPanesByProvider);
+  // Pin by tracker instance key (agent[:threadId]) so live panes match the
+  // watcher-tracked instances. The map keys are pane-based (agent:pane:<id>) and
+  // would never match, leaving live agents unpinned and exposed to pruning.
   const allPinnedKeys = new Map<string, string[]>();
   for (const [session, agents] of nextBySession) {
-    allPinnedKeys.set(session, [...agents.keys()]);
+    allPinnedKeys.set(
+      session,
+      [...agents.values()].map((p) => instanceKey(p.agent, p.threadId)),
+    );
   }
 
   // Check if anything changed

--- a/packages/agentboard/packages/runtime/src/shared.ts
+++ b/packages/agentboard/packages/runtime/src/shared.ts
@@ -12,6 +12,10 @@ export const PID_FILE = "/tmp/agentboard.pid";
 export const SERVER_IDLE_TIMEOUT_MS = 30_000;
 export const STUCK_RUNNING_TIMEOUT_MS = 3 * 60 * 1000;
 export const STALE_AGENT_TIMEOUT_MS = 12 * 60 * 60 * 1000;
+// An agent only goes "idle" once its process is gone / journal stalled, so an
+// unpinned idle instance is a dead session (e.g. a Claude session after /clear).
+// Prune it shortly after, leaving a brief grace for the pane scan to (re)pin live ones.
+export const IDLE_PRUNE_MS = 30_000;
 export const JOURNAL_IDLE_TIMEOUT_MS = 120_000;
 
 export interface SessionData {


### PR DESCRIPTION
## Problem

After `/clear` (or starting a new Claude session in a pane), the old session's card row never disappears — stale `○` / "cache expired" rows pile up in the sidebar. A user with 2 running agents was seeing ~8 rows.

## Root cause

Each Claude session is tracked by its journal UUID (`threadId`), so `/clear` writes a new `<uuid>.jsonl` and creates a *new* tracker instance alongside the old one — it's never replaced. The old session flips to `"idle"` once its process exits / journal stalls, but `"idle"` is not a terminal status, so nothing removed it:

- `pruneTerminal()` skips it (`idle` ∉ `TERMINAL_STATUSES`)
- `pruneSupersededByPane()` ignores it — watcher events carry no `paneId`
- `pruneStale()` only fires after **12 hours**

Also surfaced a latent bug: `refreshPaneAgents` pinned live panes using pane-based map keys (`claude-code:pane:%5`), but `isPinned()` is queried with instance keys (`claude-code:<threadId>`) — so the pins **never matched** and no Claude agent was ever actually protected from pruning.

## Fix

1. **`pruneIdle(timeoutMs)`** (`IDLE_PRUNE_MS = 30s`) — removes unpinned idle instances after a short grace. An agent only goes idle when its process is gone / journal stalled, so an unpinned idle instance is a dead session. Wired into `broadcastStateImmediate()`.
2. **Fix pin keys** — pin by `instanceKey(agent, threadId)` instead of pane-based map keys, so the live session is genuinely pinned and protected from `pruneIdle`/`pruneStale`. Live agents are also re-added via pane presence.

After `/clear`, the old session clears within ~30s instead of lingering for 12h; running sessions stay put.

## Verification

- `bun typecheck` — clean
- `bun run lint` — 0 warnings / 0 errors
- `bun test` — 455 pass, 0 fail (added 6 `pruneIdle` tests incl. a `/clear` simulation: idle `t1` pruned, pinned-live `t2` kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)