### PR TITLE
feat(agentboard): surface active workflow/background sub-agents on session cards

### DIFF
--- a/packages/agentboard/apps/tui/src/components/SessionCard.tsx
+++ b/packages/agentboard/apps/tui/src/components/SessionCard.tsx
@@ -327,6 +327,40 @@ function AgentRow(props: AgentRowProps) {
         }}
       </Show>
 
+      <Show when={props.agent.status === "running" && props.agent.details?.subagents?.length}>
+        {(_count) => {
+          const subagents = () => props.agent.details?.subagents ?? [];
+          return (
+            <>
+              <text truncate>
+                <span style={{ fg: P().mauve, attributes: DIM }}>⚡ </span>
+                <span style={{ fg: P().subtext0 }}>
+                  {subagents().length} agent{subagents().length === 1 ? "" : "s"}
+                </span>
+              </text>
+              <For each={subagents()}>
+                {(sa) => (
+                  <text truncate>
+                    <span style={{ fg: P().overlay0, attributes: DIM }}>{"  ↳ "}</span>
+                    <Show when={sa.agentType}>
+                      <span style={{ fg: P().teal, attributes: DIM }}>{sa.agentType}</span>
+                    </Show>
+                    <Show when={sa.description}>
+                      <span style={{ fg: P().overlay0, attributes: DIM }}>
+                        {sa.agentType ? " · " : ""}
+                      </span>
+                      <span style={{ fg: P().subtext0 }}>
+                        {truncate(sa.description!.replace(/\s+/g, " ").trim(), 40)}
+                      </span>
+                    </Show>
+                  </text>
+                )}
+              </For>
+            </>
+          );
+        }}
+      </Show>
+
       <Show when={cacheLabel()}>
         <text truncate>
           <span style={{ fg: P().overlay0, attributes: DIM }}>{cacheLabel()}</span>

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from "bun:test";
-import { determineStatus, summaryToDetails, extractLastTool } from "./claude-code";
+import { mkdtemp, mkdir, writeFile, utimes, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  determineStatus,
+  summaryToDetails,
+  extractLastTool,
+  subagentSignature,
+  readActiveSubagents,
+} from "./claude-code";
 import type { ClaudeUsageSummary } from "./claude-usage";
+import type { SubagentInfo } from "../../contracts/agent";
 
 describe("determineStatus", () => {
   it("returns null when no message", () => {
@@ -172,5 +182,129 @@ describe("extractLastTool", () => {
         },
       ]),
     ).toBe("Read");
+  });
+});
+
+describe("subagentSignature", () => {
+  it("is empty for no sub-agents", () => {
+    expect(subagentSignature([])).toBe("");
+  });
+
+  it("is order-independent", () => {
+    const a: SubagentInfo[] = [
+      { agentType: "Explore", description: "find code" },
+      { agentType: "general-purpose", description: "fix bug" },
+    ];
+    const b: SubagentInfo[] = [
+      { agentType: "general-purpose", description: "fix bug" },
+      { agentType: "Explore", description: "find code" },
+    ];
+    expect(subagentSignature(a)).toBe(subagentSignature(b));
+  });
+
+  it("changes when an agent is added or removed", () => {
+    const one: SubagentInfo[] = [{ agentType: "Explore", description: "find code" }];
+    const two: SubagentInfo[] = [
+      { agentType: "Explore", description: "find code" },
+      { agentType: "Plan", description: "design" },
+    ];
+    expect(subagentSignature(one)).not.toBe(subagentSignature(two));
+  });
+
+  it("tolerates missing fields", () => {
+    expect(subagentSignature([{}])).toBe(" ");
+  });
+});
+
+describe("readActiveSubagents", () => {
+  const NOW = 1_700_000_000_000;
+  const ACTIVE_MTIME = NOW - 10_000; // 10s ago: well within the 2-min active window
+  const STALE_MTIME = NOW - 5 * 60_000; // 5m ago: finished agent, should be excluded
+
+  async function makeSubagentsDir(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "agentboard-subagents-"));
+    const dir = join(root, "subagents");
+    await mkdir(dir, { recursive: true });
+    return dir;
+  }
+
+  async function writeAgent(
+    dir: string,
+    id: string,
+    mtimeMs: number,
+    meta?: { agentType?: string; description?: string },
+  ): Promise<void> {
+    const jsonl = join(dir, `agent-${id}.jsonl`);
+    await writeFile(jsonl, '{"type":"user"}\n');
+    if (meta) await writeFile(join(dir, `agent-${id}.meta.json`), JSON.stringify(meta));
+    const sec = mtimeMs / 1000;
+    await utimes(jsonl, sec, sec);
+  }
+
+  it("returns [] when the directory does not exist", async () => {
+    expect(await readActiveSubagents(join(tmpdir(), "nope-does-not-exist-xyz"), NOW)).toEqual([]);
+  });
+
+  it("includes recently-active agents with meta", async () => {
+    const dir = await makeSubagentsDir();
+    try {
+      await writeAgent(dir, "aaa", ACTIVE_MTIME, {
+        agentType: "Explore",
+        description: "find code",
+      });
+      const result = await readActiveSubagents(dir, NOW);
+      expect(result).toEqual([{ agentType: "Explore", description: "find code" }]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes agents whose journal is stale (finished)", async () => {
+    const dir = await makeSubagentsDir();
+    try {
+      await writeAgent(dir, "live", ACTIVE_MTIME, { agentType: "Explore" });
+      await writeAgent(dir, "dead", STALE_MTIME, { agentType: "Plan" });
+      const result = await readActiveSubagents(dir, NOW);
+      expect(result).toEqual([{ agentType: "Explore", description: undefined }]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("counts an agent even when its meta.json is missing", async () => {
+    const dir = await makeSubagentsDir();
+    try {
+      await writeAgent(dir, "nometa", ACTIVE_MTIME);
+      const result = await readActiveSubagents(dir, NOW);
+      expect(result).toEqual([{}]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("sorts most-recently-active first", async () => {
+    const dir = await makeSubagentsDir();
+    try {
+      await writeAgent(dir, "older", NOW - 60_000, { agentType: "older" });
+      await writeAgent(dir, "newer", NOW - 5_000, { agentType: "newer" });
+      const result = await readActiveSubagents(dir, NOW);
+      expect(result.map((s) => s.agentType)).toEqual(["newer", "older"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores non-agent files in the directory", async () => {
+    const dir = await makeSubagentsDir();
+    try {
+      await writeAgent(dir, "real", ACTIVE_MTIME, { agentType: "Explore" });
+      const stray = join(dir, "notes.txt");
+      await writeFile(stray, "ignore me");
+      await utimes(stray, ACTIVE_MTIME / 1000, ACTIVE_MTIME / 1000);
+      const result = await readActiveSubagents(dir, NOW);
+      expect(result).toHaveLength(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
@@ -16,7 +16,7 @@ import type { FSWatcher } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
-import type { AgentStatus } from "../../contracts/agent";
+import type { AgentStatus, SubagentInfo } from "../../contracts/agent";
 import type { AgentWatcher, AgentWatcherContext } from "../../contracts/agent-watcher";
 import { JOURNAL_IDLE_TIMEOUT_MS } from "../../shared";
 import { createClaudePidLookup } from "./claude-pid";
@@ -47,10 +47,14 @@ interface SessionState {
   projectDir?: string;
   usage?: ClaudeUsageSummary;
   lastTool?: string;
+  subagents?: SubagentInfo[];
+  /** Stable signature of `subagents`, used to detect changes without deep comparison. */
+  subagentSig?: string;
 }
 
 const POLL_MS = 2000;
 const STALE_MS = 5 * 60 * 1000;
+const JSONL_SUFFIX = ".jsonl";
 
 // --- Status detection ---
 
@@ -113,6 +117,71 @@ export function extractLastTool(entries: JournalEntry[]): string | undefined {
   return undefined;
 }
 
+// --- Sub-agent (workflow / background Task) detection ---
+
+interface SubagentMeta {
+  agentType?: string;
+  description?: string;
+}
+
+/** Build a stable, order-independent signature for a set of sub-agents so the watcher
+ * can detect changes (a new agent spinning up, one going idle) without deep comparison. */
+export function subagentSignature(subagents: SubagentInfo[]): string {
+  return subagents
+    .map((s) => `${s.agentType ?? ""} ${s.description ?? ""}`)
+    .sort()
+    .join("");
+}
+
+/**
+ * Scan a session's `subagents/` directory for currently-active sub-agents.
+ *
+ * Claude Code writes each sub-agent (workflow fan-out, background Task/Agent) to
+ * `<session-id>/subagents/agent-<id>.jsonl` with a sibling `agent-<id>.meta.json`.
+ * A sub-agent counts as "active" when its journal was modified within
+ * `JOURNAL_IDLE_TIMEOUT_MS` — finished agents leave stale files behind.
+ *
+ * Returns most-recently-active first. Best-effort: missing dir / unreadable meta yields fewer entries.
+ */
+export async function readActiveSubagents(
+  subagentsDir: string,
+  now: number,
+): Promise<SubagentInfo[]> {
+  let files: string[];
+  try {
+    files = await readdir(subagentsDir);
+  } catch {
+    return [];
+  }
+
+  const active: { info: SubagentInfo; mtimeMs: number }[] = [];
+  for (const file of files) {
+    if (!file.startsWith("agent-") || !file.endsWith(JSONL_SUFFIX)) continue;
+    const filePath = join(subagentsDir, file);
+
+    let mtimeMs: number;
+    try {
+      mtimeMs = (await stat(filePath)).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (now - mtimeMs > JOURNAL_IDLE_TIMEOUT_MS) continue;
+
+    let info: SubagentInfo = {};
+    const metaPath = `${filePath.slice(0, -JSONL_SUFFIX.length)}.meta.json`;
+    try {
+      const meta = JSON.parse(await Bun.file(metaPath).text()) as SubagentMeta;
+      info = { agentType: meta.agentType, description: meta.description };
+    } catch {
+      // intentionally ignored: meta may not be written yet; still count the agent
+    }
+    active.push({ info, mtimeMs });
+  }
+
+  active.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return active.map((a) => a.info);
+}
+
 /** Decode Claude's encoded project dir name back to a path.
  * Claude Code encodes `/` as `-` with no escape for literal dashes,
  * so paths like `/home/user/my-project` are ambiguous with `/home/user/my/project`.
@@ -139,10 +208,14 @@ export function summaryToDetails(
 function buildDetails(
   usage: ClaudeUsageSummary | undefined,
   lastTool: string | undefined,
+  subagents: SubagentInfo[] | undefined,
 ): import("../../contracts/agent").AgentEventDetails | undefined {
-  if (!usage && !lastTool) return undefined;
+  const hasSubagents = subagents != null && subagents.length > 0;
+  if (!usage && !lastTool && !hasSubagents) return undefined;
   const base = usage ? summaryToDetails(usage) : {};
-  return lastTool ? { ...base, lastTool } : base;
+  if (lastTool) base.lastTool = lastTool;
+  if (hasSubagents) base.subagents = subagents;
+  return base;
 }
 
 // --- Watcher implementation ---
@@ -200,6 +273,12 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
     const threadId = basename(filePath, ".jsonl");
     const prev = this.sessions.get(threadId);
 
+    // Sub-agents (workflow fan-out / background Tasks) write to a sibling dir while the
+    // parent journal can stay static for minutes — scan on every poll, not just on growth.
+    const subagentsDir = join(filePath.slice(0, -JSONL_SUFFIX.length), "subagents");
+    const subagents = await readActiveSubagents(subagentsDir, Date.now());
+    const subagentSig = subagentSignature(subagents);
+
     if (prev && size === prev.fileSize) {
       // Post-seed: check if the process is actually still alive.
       if (this.seeded && prev.status === "running") {
@@ -220,6 +299,8 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
 
         if (becomeIdle) {
           prev.status = "idle";
+          prev.subagents = subagents;
+          prev.subagentSig = subagentSig;
           const session = prev.projectDir ? this.ctx?.resolveSession(prev.projectDir) : undefined;
           if (session) {
             this.ctx?.emit({
@@ -229,9 +310,28 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
               ts: Date.now(),
               threadId,
               threadName: prev.threadName,
-              details: buildDetails(prev.usage, prev.lastTool),
+              details: buildDetails(prev.usage, prev.lastTool, subagents),
             });
           }
+          return;
+        }
+      }
+
+      // Main journal unchanged, but the live sub-agent set may have shifted (workflow progress).
+      if (subagentSig !== (prev.subagentSig ?? "")) {
+        prev.subagents = subagents;
+        prev.subagentSig = subagentSig;
+        const session = prev.projectDir ? this.ctx?.resolveSession(prev.projectDir) : undefined;
+        if (session) {
+          this.ctx?.emit({
+            agent: "claude-code",
+            session,
+            status: prev.status,
+            ts: Date.now(),
+            threadId,
+            threadName: prev.threadName,
+            details: buildDetails(prev.usage, prev.lastTool, subagents),
+          });
         }
       }
       return;
@@ -287,6 +387,8 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
         projectDir,
         usage,
         lastTool,
+        subagents,
+        subagentSig,
       });
       return;
     }
@@ -344,9 +446,11 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
       projectDir,
       usage,
       lastTool,
+      subagents,
+      subagentSig,
     });
 
-    if (latestStatus !== prevStatus) {
+    if (latestStatus !== prevStatus || subagentSig !== (prev?.subagentSig ?? "")) {
       const session = this.ctx.resolveSession(projectDir);
       if (session) {
         this.ctx.emit({
@@ -356,7 +460,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
           ts: Date.now(),
           threadId,
           threadName,
-          details: buildDetails(usage, lastTool),
+          details: buildDetails(usage, lastTool, subagents),
         });
       }
     }
@@ -434,7 +538,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
             ts: Date.now(),
             threadId,
             threadName: state.threadName,
-            details: buildDetails(state.usage, state.lastTool),
+            details: buildDetails(state.usage, state.lastTool, state.subagents),
           });
         }
       }

--- a/packages/agentboard/packages/runtime/src/contracts/agent.ts
+++ b/packages/agentboard/packages/runtime/src/contracts/agent.ts
@@ -7,6 +7,14 @@ export type AgentStatus =
   | "question"
   | "interrupted";
 
+/** A sub-agent spawned by the parent session — workflow fan-out or a background Task/Agent. */
+export interface SubagentInfo {
+  /** Sub-agent type, e.g. "Explore", "general-purpose", or a workflow agent label. */
+  agentType?: string;
+  /** Short human description of the sub-agent's task (from its meta.json). */
+  description?: string;
+}
+
 export interface AgentEventDetails {
   /** Model name from most recent assistant turn (e.g. "claude-opus-4-6") */
   model?: string;
@@ -22,6 +30,12 @@ export interface AgentEventDetails {
   lastActivityAt?: number;
   /** Name of the most recent tool invoked by the agent (e.g. "Read", "Bash", "Edit"). Populated only by the claude-code watcher. */
   lastTool?: string;
+  /**
+   * Currently-active sub-agents (workflow fan-out / background Tasks), judged by recent
+   * journal mtime. Empty/undefined when the session has no live sub-agents.
+   * Populated only by the claude-code watcher.
+   */
+  subagents?: SubagentInfo[];
 }
 
 export interface AgentEvent {


### PR DESCRIPTION
## What

AgentBoard session cards now show when a slot is running a **Workflow** or **background `Task`/`Agent`** fan-out, including how many sub-agents are currently working and what each is doing.

```
⠋ refactor the watcher                    12s
  opus · ⟶ Workflow
⚡ 3 agents
  ↳ Explore · find session lifecycle code
  ↳ general-purpose · fix the stale-card bug
  ↳ Plan · design the emit path
```

## Why

The `claude-code` watcher only read the top-level session journal, so a session running a workflow looked like a single running agent — the fan-out was invisible.

## How

- Sub-agents are written to `<session-id>/subagents/agent-<id>.jsonl` + a `.meta.json` (`agentType`, `description`).
- The watcher scans that dir on **every poll** (the parent journal stays static for minutes while a workflow runs) and counts agents whose journal mtime is within `JOURNAL_IDLE_TIMEOUT_MS` (2 min) — finished agents drop off automatically, most-recent first.
- A signature diff triggers an emit when the live set changes, even while the parent status stays `running`.
- `SessionCard` renders a `⚡ N agents` line plus a row per active sub-agent.

## Files
- `contracts/agent.ts` — new `SubagentInfo` type + `subagents?` on `AgentEventDetails`
- `agents/watchers/claude-code.ts` — `readActiveSubagents()`, `subagentSignature()`, `buildDetails()` extension, `processFile` branches + seeded-emit
- `apps/tui/src/components/SessionCard.tsx` — count + per-agent rows
- `claude-code.test.ts` — 11 new tests

## Note
`/loop` is intentionally not shown — a loop re-fires the *main* session, so it already appears as normal main-loop activity, not a sub-agent.

## Verification
`verify: ok (format, lint, typecheck, test)` — 470 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)