### PR TITLE
feat(agentboard): show a looping indicator for self-paced /loop sessions

### DIFF
--- a/packages/agentboard/apps/tui/src/components/SessionCard.tsx
+++ b/packages/agentboard/apps/tui/src/components/SessionCard.tsx
@@ -361,6 +361,29 @@ function AgentRow(props: AgentRowProps) {
         }}
       </Show>
 
+      <Show
+        when={
+          props.agent.details?.loop && props.agent.details.loop.nextWakeAt > props.now()
+            ? props.agent.details.loop
+            : undefined
+        }
+      >
+        {(loop) => (
+          <text truncate>
+            <span style={{ fg: P().lavender, attributes: DIM }}>⟳ </span>
+            <span style={{ fg: P().subtext0 }}>
+              loops in {formatElapsed(loop().nextWakeAt - props.now())}
+            </span>
+            <Show when={loop().reason}>
+              <span style={{ fg: P().overlay0, attributes: DIM }}>
+                {" · "}
+                {truncate(loop().reason!.replace(/\s+/g, " ").trim(), 36)}
+              </span>
+            </Show>
+          </text>
+        )}
+      </Show>
+
       <Show when={cacheLabel()}>
         <text truncate>
           <span style={{ fg: P().overlay0, attributes: DIM }}>{cacheLabel()}</span>

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.test.ts
@@ -8,6 +8,7 @@ import {
   extractLastTool,
   subagentSignature,
   readActiveSubagents,
+  extractLoopState,
 } from "./claude-code";
 import type { ClaudeUsageSummary } from "./claude-usage";
 import type { SubagentInfo } from "../../contracts/agent";
@@ -182,6 +183,58 @@ describe("extractLastTool", () => {
         },
       ]),
     ).toBe("Read");
+  });
+});
+
+describe("extractLoopState", () => {
+  const TS = "2026-06-08T21:00:00.000Z";
+  const TS_MS = Date.parse(TS);
+
+  const wakeup = (delaySeconds: number, reason?: string, ts = TS) => ({
+    type: "assistant" as const,
+    timestamp: ts,
+    message: {
+      role: "assistant",
+      content: [{ type: "tool_use", name: "ScheduleWakeup", input: { delaySeconds, reason } }],
+    },
+  });
+
+  it("returns undefined when no ScheduleWakeup present", () => {
+    expect(
+      extractLoopState([
+        { message: { role: "assistant", content: [{ type: "tool_use", name: "Read" }] } },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("computes nextWakeAt from timestamp + delaySeconds and keeps the reason", () => {
+    expect(extractLoopState([wakeup(240, "watch the deploy")])).toEqual({
+      nextWakeAt: TS_MS + 240_000,
+      reason: "watch the deploy",
+    });
+  });
+
+  it("uses the most recent ScheduleWakeup when several exist", () => {
+    const later = "2026-06-08T21:10:00.000Z";
+    const result = extractLoopState([wakeup(60, "first"), wakeup(120, "second", later)]);
+    expect(result).toEqual({ nextWakeAt: Date.parse(later) + 120_000, reason: "second" });
+  });
+
+  it("returns undefined when the entry has no parseable timestamp", () => {
+    const w = wakeup(60, "x");
+    w.timestamp = "not-a-date";
+    expect(extractLoopState([w])).toBeUndefined();
+  });
+
+  it("ignores ScheduleWakeup that is not a tool_use (e.g. tool definition text)", () => {
+    expect(
+      extractLoopState([
+        {
+          timestamp: TS,
+          message: { role: "assistant", content: [{ type: "text", text: "ScheduleWakeup" }] },
+        },
+      ]),
+    ).toBeUndefined();
   });
 });
 

--- a/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
+++ b/packages/agentboard/packages/runtime/src/agents/watchers/claude-code.ts
@@ -16,7 +16,7 @@ import type { FSWatcher } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
-import type { AgentStatus, SubagentInfo } from "../../contracts/agent";
+import type { AgentStatus, SubagentInfo, LoopInfo } from "../../contracts/agent";
 import type { AgentWatcher, AgentWatcherContext } from "../../contracts/agent-watcher";
 import { JOURNAL_IDLE_TIMEOUT_MS } from "../../shared";
 import { createClaudePidLookup } from "./claude-pid";
@@ -30,10 +30,12 @@ interface ContentItem {
   type?: string;
   text?: string;
   name?: string;
+  input?: { delaySeconds?: number; reason?: string };
 }
 
 interface JournalEntry {
   type?: string;
+  timestamp?: string;
   message?: {
     role?: string;
     content?: ContentItem[] | string;
@@ -50,6 +52,7 @@ interface SessionState {
   subagents?: SubagentInfo[];
   /** Stable signature of `subagents`, used to detect changes without deep comparison. */
   subagentSig?: string;
+  loop?: LoopInfo;
 }
 
 const POLL_MS = 2000;
@@ -112,6 +115,26 @@ export function extractLastTool(entries: JournalEntry[]): string | undefined {
       if (!item.name) continue;
       if (item.name === "AskUserQuestion") continue;
       return item.name;
+    }
+  }
+  return undefined;
+}
+
+/** Extract self-paced `/loop` state from the most recent ScheduleWakeup tool call.
+ * Returns the scheduled next-wake time; the caller treats a future `nextWakeAt` as
+ * "looping, sleeping between iterations" and a past one as "loop ended". */
+export function extractLoopState(entries: JournalEntry[]): LoopInfo | undefined {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i]!;
+    if (entry.message?.role !== "assistant") continue;
+    const content = entry.message.content;
+    if (!Array.isArray(content)) continue;
+    for (const item of content) {
+      if (item.type !== "tool_use" || item.name !== "ScheduleWakeup") continue;
+      const delaySeconds = item.input?.delaySeconds;
+      const scheduledAt = entry.timestamp ? Date.parse(entry.timestamp) : Number.NaN;
+      if (typeof delaySeconds !== "number" || Number.isNaN(scheduledAt)) return undefined;
+      return { nextWakeAt: scheduledAt + delaySeconds * 1000, reason: item.input?.reason };
     }
   }
   return undefined;
@@ -209,12 +232,14 @@ function buildDetails(
   usage: ClaudeUsageSummary | undefined,
   lastTool: string | undefined,
   subagents: SubagentInfo[] | undefined,
+  loop: LoopInfo | undefined,
 ): import("../../contracts/agent").AgentEventDetails | undefined {
   const hasSubagents = subagents != null && subagents.length > 0;
-  if (!usage && !lastTool && !hasSubagents) return undefined;
+  if (!usage && !lastTool && !hasSubagents && !loop) return undefined;
   const base = usage ? summaryToDetails(usage) : {};
   if (lastTool) base.lastTool = lastTool;
   if (hasSubagents) base.subagents = subagents;
+  if (loop) base.loop = loop;
   return base;
 }
 
@@ -310,7 +335,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
               ts: Date.now(),
               threadId,
               threadName: prev.threadName,
-              details: buildDetails(prev.usage, prev.lastTool, subagents),
+              details: buildDetails(prev.usage, prev.lastTool, subagents, prev.loop),
             });
           }
           return;
@@ -330,7 +355,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
             ts: Date.now(),
             threadId,
             threadName: prev.threadName,
-            details: buildDetails(prev.usage, prev.lastTool, subagents),
+            details: buildDetails(prev.usage, prev.lastTool, subagents, prev.loop),
           });
         }
       }
@@ -369,6 +394,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
 
       const usage = extractUsageSummary(parsed) ?? undefined;
       const lastTool = extractLastTool(parsed);
+      const loop = extractLoopState(parsed);
 
       // If "running" but journal file is stale, the process likely exited
       if (latestStatus === "running") {
@@ -389,6 +415,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
         lastTool,
         subagents,
         subagentSig,
+        loop,
       });
       return;
     }
@@ -430,6 +457,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
     const usage = newUsage ?? prev?.usage;
     const newLastTool = extractLastTool(parsed);
     const lastTool = newLastTool ?? prev?.lastTool;
+    const loop = extractLoopState(parsed) ?? prev?.loop;
 
     if (latestStatus === "running") {
       const pid = await this.pidLookup.pidForThread(threadId);
@@ -448,9 +476,14 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
       lastTool,
       subagents,
       subagentSig,
+      loop,
     });
 
-    if (latestStatus !== prevStatus || subagentSig !== (prev?.subagentSig ?? "")) {
+    if (
+      latestStatus !== prevStatus ||
+      subagentSig !== (prev?.subagentSig ?? "") ||
+      loop?.nextWakeAt !== prev?.loop?.nextWakeAt
+    ) {
       const session = this.ctx.resolveSession(projectDir);
       if (session) {
         this.ctx.emit({
@@ -460,7 +493,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
           ts: Date.now(),
           threadId,
           threadName,
-          details: buildDetails(usage, lastTool, subagents),
+          details: buildDetails(usage, lastTool, subagents, loop),
         });
       }
     }
@@ -538,7 +571,7 @@ export class ClaudeCodeAgentWatcher implements AgentWatcher {
             ts: Date.now(),
             threadId,
             threadName: state.threadName,
-            details: buildDetails(state.usage, state.lastTool, state.subagents),
+            details: buildDetails(state.usage, state.lastTool, state.subagents, state.loop),
           });
         }
       }

--- a/packages/agentboard/packages/runtime/src/contracts/agent.ts
+++ b/packages/agentboard/packages/runtime/src/contracts/agent.ts
@@ -7,6 +7,14 @@ export type AgentStatus =
   | "question"
   | "interrupted";
 
+/** State of a self-paced `/loop` — the session scheduled its own next wake-up via ScheduleWakeup. */
+export interface LoopInfo {
+  /** Epoch ms when the loop is scheduled to fire next. In the past once the loop has ended. */
+  nextWakeAt: number;
+  /** Short reason the session gave for the scheduled wake-up. */
+  reason?: string;
+}
+
 /** A sub-agent spawned by the parent session — workflow fan-out or a background Task/Agent. */
 export interface SubagentInfo {
   /** Sub-agent type, e.g. "Explore", "general-purpose", or a workflow agent label. */
@@ -36,6 +44,12 @@ export interface AgentEventDetails {
    * Populated only by the claude-code watcher.
    */
   subagents?: SubagentInfo[];
+  /**
+   * Set when the session is running a self-paced `/loop` (scheduled its next wake via
+   * ScheduleWakeup). `nextWakeAt` in the future = sleeping between iterations.
+   * Populated only by the claude-code watcher.
+   */
+  loop?: LoopInfo;
 }
 
 export interface AgentEvent {


### PR DESCRIPTION
## What

AgentBoard session cards now show when a slot is running a self-paced `/loop`, with a live countdown to the next wake-up:

```
⠋ babysit the PR queue                    8s
  opus · ⟶ ScheduleWakeup
⟳ loops in 4m · cloud run staging + prod deploys
```

## Why

Follow-up to #255 (sub-agent activity). A `/loop` doesn't spawn sub-agents — it re-fires the *main* session on a timer — so it needed its own signal.

## How

- A dynamic `/loop` ends each iteration by calling **`ScheduleWakeup`**, written to the journal as an assistant `tool_use` with `input.delaySeconds` + `input.reason` and a top-level `timestamp`.
- `extractLoopState()` finds the most recent such call and computes `nextWakeAt = timestamp + delaySeconds*1000`.
- `SessionCard` renders `⟳ loops in <countdown> · <reason>` while `nextWakeAt` is in the future. Once the loop ends and nothing reschedules, `nextWakeAt` falls into the past and the badge **self-expires** — no explicit "loop stopped" marker needed.
- Loop state is carried forward across incremental journal reads and added to the emit-change trigger so the countdown refreshes as iterations reschedule.

## Files
- `contracts/agent.ts` — new `LoopInfo` type + `loop?` on `AgentEventDetails`
- `agents/watchers/claude-code.ts` — `extractLoopState()`, `buildDetails()` extension, threaded through all `processFile` branches + seeded-emit
- `apps/tui/src/components/SessionCard.tsx` — `⟳ loops in …` line, gated on `nextWakeAt > now()`
- `claude-code.test.ts` — 5 new tests (compute/reason, most-recent-wins, unparseable timestamp, non-tool_use, absent)

## Note
Covers the model-self-paced loop. Fixed-interval `/loop 5m /foo` is harness-driven and doesn't emit `ScheduleWakeup`, so it isn't shown — call out if you want that variant covered too (it'd key off the re-injected `/loop` user turn instead).

## Verification
`verify: ok (format, lint, typecheck, test)` — 477 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)