### PR TITLE
fix(publish): ship a consumer-installable tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,12 @@ jobs:
           if npm view @towles/tool@$VERSION version 2>/dev/null; then
             echo "Version $VERSION already published — skipping"
           else
-            npm publish --access public --provenance
+            # Build a consumer-safe tarball with bun (see scripts/pack-publish.ts):
+            # npm can't bundle the @towles/shared workspace dep, so external
+            # installs were shipping an unresolvable "@towles/shared: workspace:*".
+            # Then publish the prebuilt tarball with npm to keep provenance.
+            bun run pack:publish
+            npm publish ./dist-pack/towles-tool-$VERSION.tgz --access public --provenance
           fi
 
       - name: Create GitHub Release

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ docs/superpowers/
 .auto-claude/
 .auto-claude/**/prompt-*.md
 .claude-stream.ndjson
+
+# npm publish staging (scripts/pack-publish.ts)
+dist-pack/

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "scripts": {
     "version:sync": "bun run scripts/sync-versions.ts",
+    "pack:publish": "bun run scripts/pack-publish.ts",
     "prepublishOnly": "bun run version:sync",
     "dev": "bun run bin/run.ts",
     "format": "oxfmt --write .",

--- a/scripts/pack-publish.ts
+++ b/scripts/pack-publish.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+/**
+ * Builds a consumer-safe npm tarball into ./dist-pack.
+ *
+ * Two root-only workspace concerns make `@towles/tool` impossible to install
+ * outside this monorepo, and both must be resolved at pack time:
+ *
+ *   1. `@towles/shared` — never published to npm. As `workspace:*` it fails with
+ *      `@towles/shared@workspace:* failed to resolve`; rewritten to a concrete
+ *      `0.1.0` it fails with a registry 404. bun ignores `bundledDependencies`
+ *      when resolving a *declared* dependency, so we drop `@towles/shared` from
+ *      `dependencies` entirely. `bundledDependencies` still ships the package
+ *      (53 files) into the tarball's nested `node_modules/@towles/shared`, where
+ *      the runtime `import "@towles/shared"` resolves. See issue #257.
+ *
+ *   2. `patchedDependencies` — a workspace-root-only field. Left in the
+ *      published manifest, every consumer install fails with
+ *      `Couldn't find patch file: 'patches/prompts.patch'`, because bun resolves
+ *      the patch path relative to the consumer's project root, where it doesn't
+ *      exist (and root patches don't apply to installed dependencies anyway).
+ *      We strip it from the tarball manifest while keeping it for local dev.
+ *
+ * Both edits are made to a throwaway copy of the manifest; the original (with
+ * `workspace:*` and the prompts patch intact) is always restored afterward.
+ *
+ * Run via: bun run scripts/pack-publish.ts
+ */
+
+import { join } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+
+const ROOT = join(import.meta.dirname, "..");
+const PKG_PATH = join(ROOT, "package.json");
+const DEST = join(ROOT, "dist-pack");
+
+const original = await readFile(PKG_PATH, "utf-8");
+const pkg = JSON.parse(original);
+
+delete pkg.dependencies["@towles/shared"];
+delete pkg.patchedDependencies;
+
+try {
+  // Write the publish-only manifest, pack it, then always restore the original
+  // so the repo (and local dev's prompts patch) is left untouched.
+  await writeFile(PKG_PATH, JSON.stringify(pkg, null, 2) + "\n");
+
+  const proc = Bun.spawn(["bun", "pm", "pack", "--ignore-scripts", "--destination", DEST], {
+    cwd: ROOT,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(`bun pm pack exited with code ${code}`);
+  }
+} finally {
+  await writeFile(PKG_PATH, original);
+}


### PR DESCRIPTION
## Problem

`bun install @towles/tool` fails for every published version (0.0.136–0.0.140) — `tt` can't be installed or updated on a clean machine. Fixes #257.

The release workflow publishes with `npm publish`, but npm can't handle the bun workspace. Reproduced by packing + clean `bun install`, three layered bugs surfaced one after another:

1. **`@towles/shared: workspace:*`** — npm skips the workspace symlink and ships it unresolved → `@towles/shared@workspace:* failed to resolve`. (The reported symptom.)
2. **`patchedDependencies`** — a workspace-root-only field. In a published manifest it breaks *every* consumer install with `Couldn't find patch file: 'patches/prompts.patch'`. Masked by bug #1.
3. **`@towles/shared` as a registry dep** — even rewritten to `0.1.0`, bun ignores `bundledDependencies` for a *declared* dep and 404s on the unpublished package.

The existing `bundledDependencies` never worked through npm (0 files bundled via npm vs 53 via bun).

## Fix

- **`scripts/pack-publish.ts`** — builds the tarball with `bun pm pack` (bun *does* bundle `@towles/shared`). On a throwaway manifest copy it drops `dependencies['@towles/shared']` (so bun never hits the registry — the runtime import resolves to the bundled nested `node_modules/@towles/shared`) and `patchedDependencies`. The original manifest (with `workspace:*` and the prompts patch intact for local dev) is always restored — no git drift.
- **`release.yml`** — publish step runs `bun run pack:publish`, then `npm publish ./dist-pack/*.tgz --provenance`, keeping provenance attestation.
- **`package.json`** — `pack:publish` script. **`.gitignore`** — `dist-pack/`.

## Verification

End-to-end against a real tarball: clean `bun add` (20 packages, no errors), bundled `@towles/shared` present, `tt --help` runs (loads commands that import `@towles/shared`). `format:check`, `lint`, `typecheck` pass.

## Notes

- Already-published 0.0.136–0.0.140 stay broken (npm is immutable); next release (0.0.141) is the first clean one.
- The prompts patch won't apply for consumers (root patches never propagate). `gh/branch.ts` already uses `onCancel` + try/catch, so it behaves correctly without it — the patch only affected exit-code cleanliness in that one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)