### PR TITLE
fix(agentboard): pass solid preload explicitly — bun pm pack drops bunfig.toml

### DIFF
--- a/packages/agentboard/package.json
+++ b/packages/agentboard/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "server": "bun run src/server/main.ts",
-    "tui": "bun run src/tui/index.tsx",
+    "tui": "bun run --preload @opentui/solid/preload src/tui/index.tsx",
     "dev:server": "bun --watch run src/server/main.ts",
-    "dev:tui": "bun --watch run src/tui/index.tsx",
+    "dev:tui": "bun --watch run --preload @opentui/solid/preload src/tui/index.tsx",
     "test": "bun test src/runtime",
     "typecheck": "tsgo --noEmit -p tsconfig.json"
   },

--- a/packages/agentboard/src/tui/bunfig.toml
+++ b/packages/agentboard/src/tui/bunfig.toml
@@ -1,1 +1,0 @@
-preload = ["@opentui/solid/preload"]

--- a/src/commands/agentboard.ts
+++ b/src/commands/agentboard.ts
@@ -520,9 +520,12 @@ function startTui(): void {
   const agentboardDir = resolve(import.meta.dirname, "../../packages/agentboard");
   const tuiEntry = resolve(agentboardDir, "src/tui/index.tsx");
 
-  execSync(`bun run ${tuiEntry}`, {
+  // The solid JSX transform must be preloaded explicitly: `bun pm pack`
+  // silently excludes bunfig.toml, so a cwd-based config never survives
+  // a published install.
+  execSync(`bun run --preload @opentui/solid/preload ${tuiEntry}`, {
     stdio: "inherit",
-    cwd: resolve(agentboardDir, "src/tui"),
+    cwd: agentboardDir,
   });
 }
 


### PR DESCRIPTION
## Problem

Opening the agentboard sidebar in tmux from a global install (v0.0.143) closed the pane instantly. The TUI crashed with:

```
Cannot find module 'react/jsx-dev-runtime'
```

## Root cause

The solid JSX transform was configured via `packages/agentboard/src/tui/bunfig.toml` (`preload = ["@opentui/solid/preload"]`), added in the v0.0.143 layout flatten. But `bun pm pack` silently excludes `bunfig.toml` from tarballs, so the published package shipped without it — bun fell back to the React JSX transform and the TUI died before the pane could show the error.

## Fix

- `startTui()` passes `bun run --preload @opentui/solid/preload` explicitly, removing the dependency on a cwd config file that can never survive packing.
- The `tui` / `dev:tui` package scripts get the same flag (their cwd never picked up the bunfig anyway).
- `src/tui/bunfig.toml` deleted — one mechanism.

## Verification

- Global-install repro: `tt agentboard tui` crashed before, renders and stays alive with the preload flag.
- Repo: `bun run bin/run.ts agentboard tui` renders the sidebar.
- `/verify` passes: format, lint, typecheck, 475 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)