### PR TITLE
fix(agentboard): correct sessionizer popup path; guard tarball contents at test time

### DIFF
--- a/packages/agentboard/src/tui/index.tsx
+++ b/packages/agentboard/src/tui/index.tsx
@@ -229,7 +229,7 @@ function App() {
       send({ type: "new-session" });
       return;
     }
-    const scriptPath = new URL("../scripts/sessionizer.sh", import.meta.url).pathname;
+    const scriptPath = new URL("./scripts/sessionizer.sh", import.meta.url).pathname;
     muxCtx.sdk.displayPopup({
       command: `bash "${scriptPath}"`,
       title: " new session ",

--- a/src/pack-contents.test.ts
+++ b/src/pack-contents.test.ts
@@ -1,0 +1,107 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Guards the published artifact against two failure classes that have shipped
+ * broken releases before (v0.0.143):
+ *
+ * 1. `bun pm pack` silently excludes certain filenames (bunfig.toml among
+ *    them), so a file can be tracked, committed, and still missing from the
+ *    tarball. Test: every git-tracked file under the package.json `files`
+ *    globs must appear in the tarball.
+ *
+ * 2. Runtime assets resolved relative to a module (`new URL(..., import.meta.url)`,
+ *    `join(__dirname, ...)`) break when files move — the layout flatten pointed
+ *    the sessionizer popup at a path that no longer existed. Test: every such
+ *    literal in the packed sources must resolve to a real file in the tarball.
+ */
+
+const ROOT = resolve(import.meta.dirname, "..");
+let workDir: string;
+let extractDir: string;
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), "tt-pack-test-"));
+  execFileSync("bun", ["pm", "pack", "--ignore-scripts", "--quiet", "--destination", workDir], {
+    cwd: ROOT,
+    stdio: "pipe",
+  });
+  const tarball = readdirSync(workDir).find((f) => f.endsWith(".tgz"));
+  if (!tarball) throw new Error(`bun pm pack produced no tarball in ${workDir}`);
+  extractDir = join(workDir, "extract");
+  execFileSync("tar", ["-xzf", join(workDir, tarball), "-C", workDir], { stdio: "pipe" });
+  // tarball root is "package/"
+  extractDir = join(workDir, "package");
+});
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("packed tarball", () => {
+  it("contains every git-tracked file under the published `files` globs", () => {
+    const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as {
+      files: string[];
+    };
+    const tracked = execFileSync("git", ["ls-files", "--", ...pkg.files], {
+      cwd: ROOT,
+      encoding: "utf8",
+    })
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+
+    const missing = tracked.filter((f) => !existsSync(join(extractDir, f)));
+    expect(missing, `tracked files dropped by bun pm pack: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("resolves every module-relative asset reference to a file in the tarball", () => {
+    const sources = walk(extractDir).filter(
+      (f) => (f.endsWith(".ts") || f.endsWith(".tsx")) && !f.endsWith(".test.ts"),
+    );
+
+    // new URL("<rel>", import.meta.url) and
+    // join/resolve(__dirname | import.meta.dirname | import.meta.dir, "<seg>", ...)
+    const urlPattern = /new URL\(\s*"([^"]+)"\s*,\s*import\.meta\.url\s*\)/g;
+    const joinPattern =
+      /(?:\w+\.)?(?:join|resolve)\(\s*(?:__dirname|import\.meta\.dirname|import\.meta\.dir)\s*((?:,\s*"[^"]+"\s*)+)\)/g;
+
+    const broken: string[] = [];
+    for (const file of sources) {
+      const content = readFileSync(file, "utf8");
+      const base = dirname(file);
+      const refs: string[] = [];
+
+      for (const m of content.matchAll(urlPattern)) refs.push(resolve(base, m[1]!));
+      for (const m of content.matchAll(joinPattern)) {
+        const segments = [...m[1]!.matchAll(/"([^"]+)"/g)].map((s) => s[1]!);
+        refs.push(resolve(base, ...segments));
+      }
+
+      for (const ref of refs) {
+        if (!existsSync(ref)) {
+          broken.push(
+            `${file.slice(extractDir.length + 1)} -> ${ref.slice(extractDir.length + 1)}`,
+          );
+        }
+      }
+    }
+    expect(
+      broken,
+      `asset references that don't exist in the tarball:\n${broken.join("\n")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Hitting "n" (new session) in the agentboard sidebar flashed a popup that closed instantly. The popup runs `bash .../scripts/sessionizer.sh`, resolved as `../scripts/` relative to `src/tui/index.tsx` — pointing at `src/scripts/`, which stopped existing in the v0.0.143 layout flatten (the script lives at `src/tui/scripts/`). Bash exited 127 and `closeOnExit` closed the popup before the error was visible.

## Fix

One-liner: resolve `./scripts/sessionizer.sh` instead.

## Build-time guard

v0.0.143 shipped two breaks of the same shape (this one and the dropped `bunfig.toml` from #262). New `src/pack-contents.test.ts` packs a real tarball with `bun pm pack`, extracts it, and asserts:

1. Every git-tracked file under the published `files` globs is present in the tarball — catches `bun pm pack`'s silent filename exclusions.
2. Every module-relative asset literal (`new URL(..., import.meta.url)`, `join/resolve(__dirname | import.meta.dirname, ...)`) in packed sources resolves to a real file inside the tarball — catches asset paths broken by file moves.

Verified by reintroducing both bugs: each produced a targeted failure (`tracked files dropped by bun pm pack: packages/agentboard/bunfig.toml`, `index.tsx -> src/scripts/sessionizer.sh`). Runs in the normal `bun test` suite in ~1s.

## Verification

- Full audit of all other `import.meta`-relative resolutions (`graph-template.html`, `prompt-templates/`) — already correct and shipping.
- format, lint, typecheck, 477 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)