### PR TITLE
fix(agentboard): route session switches to the clients attached to the clicking sidebar

### DIFF
--- a/packages/agentboard/src/mux-tmux/provider.test.ts
+++ b/packages/agentboard/src/mux-tmux/provider.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { TmuxProvider } from "./provider";
+import { TmuxClient } from "./client";
+import type { ClientInfo } from "./client";
+
+function client(tty: string, sessionName: string): ClientInfo {
+  return { name: tty, tty, pid: 1, sessionName, width: 80, height: 24 };
+}
+
+/** Records switch-client calls; serves a canned client list (constructor DI, no vi.mock). */
+class FakeTmuxClient extends TmuxClient {
+  switches: { target: string; clientTty?: string }[] = [];
+
+  constructor(private clients: ClientInfo[]) {
+    super();
+  }
+
+  override listClients(): ClientInfo[] {
+    return this.clients;
+  }
+
+  override switchClient(target: string, options?: { clientTty?: string }): void {
+    this.switches.push({ target, clientTty: options?.clientTty });
+  }
+}
+
+describe("TmuxProvider.switchSession", () => {
+  // The original bug: the server stored "the last client that switched to a
+  // session" and routed switches via that tty. With two terminals attached,
+  // the stored tty pointed at the *other* terminal — clicking a session card
+  // moved the wrong client and the clicking terminal never switched.
+  it("switches every client attached to fromSession, ignoring other clients", () => {
+    const tmux = new FakeTmuxClient([
+      client("/dev/pts/0", "slot-1"),
+      client("/dev/pts/3", "primary"),
+      client("/dev/pts/6", "slot-1"),
+    ]);
+    const provider = new TmuxProvider({ client: tmux });
+
+    provider.switchSession("slot-2", { fromSession: "slot-1" });
+
+    expect(tmux.switches).toEqual([
+      { target: "slot-2", clientTty: "/dev/pts/0" },
+      { target: "slot-2", clientTty: "/dev/pts/6" },
+    ]);
+  });
+
+  it("falls back to default client targeting when no client is attached to fromSession", () => {
+    const tmux = new FakeTmuxClient([client("/dev/pts/3", "primary")]);
+    const provider = new TmuxProvider({ client: tmux });
+
+    provider.switchSession("slot-2", { fromSession: "gone-session" });
+
+    expect(tmux.switches).toEqual([{ target: "slot-2", clientTty: undefined }]);
+  });
+
+  it("falls back to default client targeting with no target info", () => {
+    const tmux = new FakeTmuxClient([client("/dev/pts/0", "slot-1")]);
+    const provider = new TmuxProvider({ client: tmux });
+
+    provider.switchSession("slot-2");
+
+    expect(tmux.switches).toEqual([{ target: "slot-2", clientTty: undefined }]);
+  });
+
+  it("honors an explicit clientTty without consulting the client list", () => {
+    const tmux = new FakeTmuxClient([
+      client("/dev/pts/0", "slot-1"),
+      client("/dev/pts/3", "primary"),
+    ]);
+    const provider = new TmuxProvider({ client: tmux });
+
+    provider.switchSession("slot-2", { clientTty: "/dev/pts/3", fromSession: "slot-1" });
+
+    expect(tmux.switches).toEqual([{ target: "slot-2", clientTty: "/dev/pts/3" }]);
+  });
+});

--- a/packages/agentboard/src/mux-tmux/provider.ts
+++ b/packages/agentboard/src/mux-tmux/provider.ts
@@ -4,12 +4,13 @@ import type {
   ActiveWindow,
   SidebarPane,
   SidebarPosition,
+  SwitchTarget,
   WindowCapable,
   SidebarCapable,
   BatchCapable,
 } from "../runtime/index";
 import { TmuxClient } from "./client";
-import { debugLog } from "../runtime/index";
+import { debugLog, resolveSwitchTargets } from "../runtime/index";
 
 /** Settings for creating a tmux provider (ai-sdk style) */
 export interface TmuxProviderSettings {
@@ -47,8 +48,22 @@ export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapabl
     }));
   }
 
-  switchSession(name: string, clientTty?: string): void {
-    this.tmux.switchClient(name, clientTty ? { clientTty } : undefined);
+  switchSession(name: string, target?: SwitchTarget): void {
+    if (target?.clientTty) {
+      this.tmux.switchClient(name, { clientTty: target.clientTty });
+      return;
+    }
+    const ttys = target?.fromSession
+      ? resolveSwitchTargets(this.tmux.listClients(), target.fromSession)
+      : [];
+    if (ttys.length === 0) {
+      // No known origin — let tmux pick its most-recently-active client.
+      this.tmux.switchClient(name);
+      return;
+    }
+    for (const tty of ttys) {
+      this.tmux.switchClient(name, { clientTty: tty });
+    }
   }
 
   getCurrentSession(): string | null {

--- a/packages/agentboard/src/runtime/client-routing.test.ts
+++ b/packages/agentboard/src/runtime/client-routing.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSwitchTargets } from "./client-routing";
+
+const CLIENTS = [
+  { tty: "/dev/pts/0", sessionName: "slot-1" },
+  { tty: "/dev/pts/3", sessionName: "primary" },
+  { tty: "/dev/pts/6", sessionName: "slot-1" },
+];
+
+describe("resolveSwitchTargets", () => {
+  it("returns the ttys of all clients attached to fromSession", () => {
+    expect(resolveSwitchTargets(CLIENTS, "slot-1")).toEqual(["/dev/pts/0", "/dev/pts/6"]);
+  });
+
+  it("returns empty for a session with no attached clients", () => {
+    expect(resolveSwitchTargets(CLIENTS, "detached-session")).toEqual([]);
+  });
+
+  it("returns empty when fromSession is unknown", () => {
+    expect(resolveSwitchTargets(CLIENTS, undefined)).toEqual([]);
+    expect(resolveSwitchTargets(CLIENTS, null)).toEqual([]);
+  });
+
+  it("returns empty with no clients at all", () => {
+    expect(resolveSwitchTargets([], "slot-1")).toEqual([]);
+  });
+});

--- a/packages/agentboard/src/runtime/client-routing.ts
+++ b/packages/agentboard/src/runtime/client-routing.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolve which mux clients a sidebar-initiated switch should move.
+ *
+ * A sidebar pane lives inside a session; any client viewing that sidebar is by
+ * definition attached to that session. So the clients to switch are exactly the
+ * ones attached to `fromSession`, resolved against a live client list at switch
+ * time. (Storing "the last client that switched to a session" goes stale the
+ * moment that client moves on — with two terminals attached, a stored tty
+ * routes the switch to the wrong terminal.)
+ *
+ * Returns the ttys to switch. Empty means the caller should fall back to the
+ * mux's default client targeting (most-recently-active).
+ */
+export function resolveSwitchTargets(
+  clients: ReadonlyArray<{ tty: string; sessionName: string }>,
+  fromSession: string | undefined | null,
+): string[] {
+  if (!fromSession) return [];
+  return clients.filter((c) => c.sessionName === fromSession).map((c) => c.tty);
+}

--- a/packages/agentboard/src/runtime/contracts/mux.ts
+++ b/packages/agentboard/src/runtime/contracts/mux.ts
@@ -29,6 +29,22 @@ export interface SidebarPane {
 /** Position for sidebar placement */
 export type SidebarPosition = "left" | "right";
 
+/**
+ * Which client(s) a session switch should move.
+ *
+ * - `clientTty`: switch exactly this client. Only safe when the tty was
+ *   resolved at action time (e.g. a tmux keybinding expanding #{client_tty}).
+ * - `fromSession`: switch every client currently attached to this session —
+ *   the session whose sidebar initiated the switch. Resolved at switch time,
+ *   so it cannot go stale the way a stored tty can.
+ *
+ * With neither set, providers fall back to their most-recently-active client.
+ */
+export interface SwitchTarget {
+  readonly clientTty?: string;
+  readonly fromSession?: string;
+}
+
 /** Provider-specific metadata (escape hatch — like ai-sdk's providerMetadata) */
 export type MuxProviderMetadata = Record<string, Record<string, unknown>>;
 
@@ -47,7 +63,7 @@ export interface MuxProviderV1 {
 
   // Session CRUD
   listSessions(): MuxSessionInfo[];
-  switchSession(name: string, clientTty?: string): void;
+  switchSession(name: string, target?: SwitchTarget): void;
   getCurrentSession(): string | null;
   getSessionDir(name: string): string;
   getPaneCount(name: string): number;

--- a/packages/agentboard/src/runtime/index.ts
+++ b/packages/agentboard/src/runtime/index.ts
@@ -10,7 +10,9 @@ export type {
   BatchCapable,
   FullMuxProvider,
   MuxProviderSettings,
+  SwitchTarget,
 } from "./contracts/mux";
+export { resolveSwitchTargets } from "./client-routing";
 export {
   isWindowCapable,
   isSidebarCapable,

--- a/packages/agentboard/src/runtime/server/context.ts
+++ b/packages/agentboard/src/runtime/server/context.ts
@@ -1,5 +1,5 @@
 import type { Server } from "bun";
-import type { MuxProvider, FullSidebarCapable, SidebarPane } from "../contracts/mux";
+import type { MuxProvider, FullSidebarCapable, SidebarPane, SwitchTarget } from "../contracts/mux";
 import type { AgentTracker } from "../agents/tracker";
 import type { SessionOrder } from "./session-order";
 import type { SessionMetadataStore } from "./metadata-store";
@@ -41,14 +41,8 @@ export interface ServerContext {
   lastState: ServerState | null;
   clientCount: number;
   idleTimer: ReturnType<typeof setTimeout> | null;
-  clientTtys: WeakMap<object, string>;
   clientSessionNames: WeakMap<object, string>;
   sessionProviders: Map<string, MuxProvider>;
-  clientTtyBySession: Map<string, string>;
-
-  // Current session cache
-  cachedCurrentSession: string | null;
-  cachedCurrentSessionTs: number;
 
   // Sidebar state
   pendingSidebarSpawns: Set<string>;
@@ -77,8 +71,6 @@ export interface ServerContext {
   broadcastState: () => void;
   broadcastFocusOnly: (sender?: any) => void;
   getCurrentSession: () => string | null;
-  getCachedCurrentSession: () => string | null;
-  invalidateCurrentSessionCache: () => void;
   getProvidersWithSidebar: () => FullSidebarCapable[];
   listSidebarPanesByProvider: () => { provider: FullSidebarCapable; panes: SidebarPane[] }[];
   invalidateSidebarPaneCache: () => void;
@@ -96,12 +88,13 @@ export interface ServerContext {
   scheduleSidebarResize: (ctx?: SidebarResizeContext) => void;
   resizeSidebars: (ctx?: SidebarResizeContext) => void;
   quitAll: () => void;
-  switchToVisibleIndex: (index: number, clientTty?: string) => void;
+  switchToVisibleIndex: (index: number, target?: SwitchTarget) => void;
   focusAgentPane: (
     sessionName: string,
     agentName: string,
     threadId?: string,
     threadName?: string,
+    fromSession?: string,
   ) => void;
   killAgentPane: (
     sessionName: string,

--- a/packages/agentboard/src/runtime/server/index.ts
+++ b/packages/agentboard/src/runtime/server/index.ts
@@ -4,8 +4,9 @@ import { homedir } from "node:os";
 
 import consola from "consola";
 
-import type { MuxProvider } from "../contracts/mux";
+import type { MuxProvider, SwitchTarget } from "../contracts/mux";
 import { isFullSidebarCapable, isBatchCapable } from "../contracts/mux";
+import { resolveSwitchTargets } from "../client-routing";
 import type { AgentEvent } from "../contracts/agent";
 import { TERMINAL_STATUSES } from "../contracts/agent";
 import type { AgentWatcher, AgentWatcherContext } from "../contracts/agent-watcher";
@@ -95,10 +96,10 @@ export function startServer(
     configKeys: Object.keys(config),
   });
 
-  // Bootstrap active sessions
-  const currentSession = mux.getCurrentSession();
-  if (currentSession) {
-    tracker.setActiveSessions([currentSession]);
+  // Bootstrap active sessions — boot-time snapshot, only used for initial seeding
+  const bootSession = mux.getCurrentSession();
+  if (bootSession) {
+    tracker.setActiveSessions([bootSession]);
   }
 
   // --- Agent watcher context ---
@@ -195,11 +196,8 @@ export function startServer(
   let lastState: ServerState | null = null;
   let clientCount = 0;
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
-  const clientTtys = new WeakMap<object, string>();
   const clientSessionNames = new WeakMap<object, string>();
   const sessionProviders = new Map<string, MuxProvider>();
-  // Map session name → client TTY (from hook context, for multi-client setups)
-  const clientTtyBySession = new Map<string, string>();
 
   function getCurrentSession(): string | null {
     // Try all providers until one returns a session
@@ -363,14 +361,13 @@ export function startServer(
     if (sessions.length === 0) {
       focusedSession = null;
     } else if (!focusedSession || !sessions.some((s) => s.name === focusedSession)) {
-      focusedSession = sessions.find((s) => s.name === currentSession)?.name ?? sessions[0]!.name;
+      focusedSession = sessions.find((s) => s.name === bootSession)?.name ?? sessions[0]!.name;
     }
 
     return {
       type: "state",
       sessions,
       focusedSession,
-      currentSession,
       theme: currentTheme,
       sidebarWidth,
       preferredEditor,
@@ -390,7 +387,6 @@ export function startServer(
   }
 
   function broadcastStateImmediate() {
-    invalidateCurrentSessionCache();
     tracker.pruneStuck(STUCK_RUNNING_TIMEOUT_MS);
     tracker.pruneTerminal();
     tracker.pruneStale(STALE_AGENT_TIMEOUT_MS);
@@ -402,28 +398,10 @@ export function startServer(
     server.publish("sidebar", msg);
   }
 
-  // Lightweight current-session cache — avoids a tmux subprocess per focus update
-  let cachedCurrentSession: string | null = null;
-  let cachedCurrentSessionTs = 0;
-  const CURRENT_SESSION_CACHE_TTL = 500; // ms — short TTL, just enough to coalesce rapid switches
-
-  function getCachedCurrentSession(): string | null {
-    const now = Date.now();
-    if (now - cachedCurrentSessionTs < CURRENT_SESSION_CACHE_TTL) return cachedCurrentSession;
-    cachedCurrentSession = getCurrentSession();
-    cachedCurrentSessionTs = now;
-    return cachedCurrentSession;
-  }
-
-  function invalidateCurrentSessionCache(): void {
-    cachedCurrentSessionTs = 0;
-  }
-
   function broadcastFocusOnly(sender?: any) {
     if (!lastState) return;
-    const currentSession = getCachedCurrentSession();
-    lastState = { ...lastState, focusedSession, currentSession };
-    const msg: FocusUpdate = { type: "focus", focusedSession, currentSession };
+    lastState = { ...lastState, focusedSession };
+    const msg: FocusUpdate = { type: "focus", focusedSession };
     const payload = JSON.stringify(msg);
     if (sender) {
       sender.publish("sidebar", payload);
@@ -453,13 +431,11 @@ export function startServer(
 
   function handleFocus(name: string): void {
     focusedSession = name;
-    invalidateCurrentSessionCache();
     // Rescan pane agents when session focus changes
     refreshPaneAgents();
     const hadUnseen = tracker.handleFocus(name);
     if (hadUnseen && lastState) {
       // Patch unseen flags in-place — avoids a full computeState with many subprocesses
-      const currentSession = getCachedCurrentSession();
       const updatedSessions = lastState.sessions.map((s) => {
         if (s.name !== name) return s;
         return {
@@ -468,7 +444,7 @@ export function startServer(
           agents: s.agents.map((a) => ({ ...a, unseen: false })),
         };
       });
-      lastState = { ...lastState, sessions: updatedSessions, focusedSession, currentSession };
+      lastState = { ...lastState, sessions: updatedSessions, focusedSession };
       server.publish("sidebar", JSON.stringify(lastState));
     } else if (hadUnseen) {
       broadcastState();
@@ -477,7 +453,7 @@ export function startServer(
     }
   }
 
-  function switchToVisibleIndex(index: number, clientTty?: string): void {
+  function switchToVisibleIndex(index: number, target?: SwitchTarget): void {
     if (!lastState) {
       broadcastState();
     }
@@ -489,7 +465,7 @@ export function startServer(
 
     const name = lastState.sessions[idx]!.name;
     const p = sessionProviders.get(name) ?? mux;
-    p.switchSession(name, clientTty);
+    p.switchSession(name, target);
   }
 
   // --- Sidebar management ---
@@ -510,15 +486,11 @@ export function startServer(
     // New format: pipe-separated "clientTty|session|windowId"
     const pipeParts = trimmed.split("|");
     if (pipeParts.length === 3 && pipeParts[1] && pipeParts[2]) {
-      const ctx = {
+      return {
         clientTty: pipeParts[0] || undefined,
         session: pipeParts[1],
         windowId: pipeParts[2],
       };
-      if (ctx.clientTty && ctx.session) {
-        clientTtyBySession.set(ctx.session, ctx.clientTty);
-      }
-      return ctx;
     }
 
     // Legacy format: "session:windowId"
@@ -993,13 +965,36 @@ export function startServer(
     return targetPaneId;
   }
 
+  /** Ttys of clients currently attached to `fromSession` — the clients whose
+   * sidebar initiated an action and should therefore be the ones switched. */
+  function listAttachedClientTtys(fromSession: string | undefined): string[] {
+    if (!fromSession) return [];
+    const out = shell(["tmux", "list-clients", "-F", "#{client_tty}|#{client_session}"]);
+    if (!out) return [];
+    const clients = out
+      .split("\n")
+      .map((line) => {
+        const [tty, sessionName] = line.split("|");
+        return { tty: tty ?? "", sessionName: sessionName ?? "" };
+      })
+      .filter((c) => c.tty);
+    return resolveSwitchTargets(clients, fromSession);
+  }
+
   function focusAgentPane(
     sessionName: string,
     agentName: string,
     threadId?: string,
     threadName?: string,
+    fromSession?: string,
   ): void {
-    log("focus-agent-pane", "received", { sessionName, agentName, threadId, threadName });
+    log("focus-agent-pane", "received", {
+      sessionName,
+      agentName,
+      threadId,
+      threadName,
+      fromSession,
+    });
     const targetPaneId = resolveAgentPaneId(sessionName, agentName, threadId, threadName);
     if (!targetPaneId) return;
 
@@ -1007,11 +1002,17 @@ export function startServer(
     // The agent's pane may live in a different session/window than the one the
     // client is attached to. switch-client moves the active client to the
     // agent's session, select-window to its window, select-pane to the pane.
-    // We deliberately omit `-c <tty>`: clients can share a tty name (e.g. a
-    // stale suspended duplicate), making `-c` match the wrong client and
-    // silently no-op. Without `-c`, tmux targets the most-recently-active
-    // client, which is the real interactive one.
-    shell(["tmux", "switch-client", "-t", sessionName]);
+    // Switch the client(s) attached to the sidebar's own session — resolved at
+    // action time, so a multi-terminal setup moves the terminal that was
+    // clicked in, not whichever client happens to be most-recently-active.
+    const ttys = listAttachedClientTtys(fromSession);
+    if (ttys.length === 0) {
+      shell(["tmux", "switch-client", "-t", sessionName]);
+    } else {
+      for (const tty of ttys) {
+        shell(["tmux", "switch-client", "-c", tty, "-t", sessionName]);
+      }
+    }
     shell(["tmux", "select-window", "-t", targetPaneId]);
     shell(["tmux", "select-pane", "-t", targetPaneId]);
 
@@ -1408,27 +1409,21 @@ export function startServer(
 
   function handleCommand(cmd: ClientCommand, ws: any) {
     switch (cmd.type) {
-      case "identify":
-        clientTtys.set(ws, cmd.clientTty);
-        break;
       case "switch-session": {
-        // Resolve TTY: hook-derived (authoritative) > client-provided > stored
-        const clientSess = clientSessionNames.get(ws);
-        const tty =
-          (clientSess ? clientTtyBySession.get(clientSess) : undefined) ??
-          cmd.clientTty ??
-          clientTtys.get(ws);
-        log("switch-session", "switching", { target: cmd.name, tty, clientSess });
+        // Switch the client(s) attached to the session whose sidebar sent the
+        // command, resolved at switch time. A stored tty goes stale the moment
+        // that client moves to another session — with two terminals attached it
+        // routes the switch to the wrong terminal.
+        const fromSession = clientSessionNames.get(ws);
+        log("switch-session", "switching", { target: cmd.name, fromSession });
         const p = sessionProviders.get(cmd.name) ?? mux;
 
-        p.switchSession(cmd.name, tty);
+        p.switchSession(cmd.name, { fromSession });
 
         // Optimistic server-side focus update — so other TUI instances see the
         // change immediately via broadcastFocusOnly, without waiting for the
         // tmux hook round-trip. The hook's /focus POST will reconcile if needed.
         focusedSession = cmd.name;
-        cachedCurrentSession = cmd.name;
-        cachedCurrentSessionTs = Date.now();
         const hadUnseen = tracker.handleFocus(cmd.name);
         if (hadUnseen) {
           broadcastState();
@@ -1439,10 +1434,8 @@ export function startServer(
         break;
       }
       case "switch-index": {
-        const clientSess = clientSessionNames.get(ws);
-        const tty =
-          (clientSess ? clientTtyBySession.get(clientSess) : undefined) ?? clientTtys.get(ws);
-        switchToVisibleIndex(cmd.index, tty);
+        const fromSession = clientSessionNames.get(ws);
+        switchToVisibleIndex(cmd.index, { fromSession });
         break;
       }
       case "new-session":
@@ -1486,15 +1479,10 @@ export function startServer(
         quitAll();
         break;
       case "identify-pane":
-        // Store this client's session, reply with session + authoritative client TTY
+        // Store this client's session so switches can be routed to the
+        // client(s) actually attached to it
         clientSessionNames.set(ws, cmd.sessionName);
-        ws.send(
-          JSON.stringify({
-            type: "your-session",
-            name: cmd.sessionName,
-            clientTty: clientTtyBySession.get(cmd.sessionName) ?? null,
-          }),
-        );
+        ws.send(JSON.stringify({ type: "your-session", name: cmd.sessionName }));
         break;
       case "focus-agent-pane":
         log("handleCommand", "focus-agent-pane received", {
@@ -1503,7 +1491,13 @@ export function startServer(
           threadId: cmd.threadId,
           threadName: cmd.threadName,
         });
-        focusAgentPane(cmd.session, cmd.agent, cmd.threadId, cmd.threadName);
+        focusAgentPane(
+          cmd.session,
+          cmd.agent,
+          cmd.threadId,
+          cmd.threadName,
+          clientSessionNames.get(ws),
+        );
         break;
       case "kill-agent-pane":
         log("handleCommand", "kill-agent-pane received", {
@@ -1624,7 +1618,9 @@ export function startServer(
           const body = await req.text();
           const ctx = parseContext(body) ?? undefined;
           log("http", "POST /switch-index", { index, ctx });
-          switchToVisibleIndex(index, ctx?.clientTty);
+          // ctx.clientTty comes from tmux expanding #{client_tty} at keypress
+          // time — fresh, so targeting that exact client is correct here.
+          switchToVisibleIndex(index, { clientTty: ctx?.clientTty });
         } catch {
           // intentionally ignored: malformed switch-index body is non-fatal, respond ok
         }

--- a/packages/agentboard/src/runtime/shared.ts
+++ b/packages/agentboard/src/runtime/shared.ts
@@ -44,7 +44,6 @@ export interface ServerState {
   type: "state";
   sessions: SessionData[];
   focusedSession: string | null;
-  currentSession: string | null;
   theme: string | undefined;
   sidebarWidth: number;
   preferredEditor: string;
@@ -54,7 +53,6 @@ export interface ServerState {
 export interface FocusUpdate {
   type: "focus";
   focusedSession: string | null;
-  currentSession: string | null;
 }
 
 export interface ResizeNotify {
@@ -69,7 +67,6 @@ export interface QuitNotify {
 export interface YourSession {
   type: "your-session";
   name: string;
-  clientTty: string | null;
 }
 
 export interface ReIdentify {
@@ -116,7 +113,7 @@ export interface SessionMetadata {
 }
 
 export type ClientCommand =
-  | { type: "switch-session"; name: string; clientTty?: string }
+  | { type: "switch-session"; name: string }
   | { type: "switch-index"; index: number }
   | { type: "new-session" }
   | { type: "kill-session"; name: string }
@@ -127,7 +124,6 @@ export type ClientCommand =
   | { type: "mark-seen"; name: string }
   | { type: "dismiss-agent"; session: string; agent: string; threadId?: string }
   | { type: "set-theme"; theme: string }
-  | { type: "identify"; clientTty: string }
   | { type: "report-width"; width: number }
   | { type: "quit" }
   | { type: "identify-pane"; paneId: string; sessionName: string }

--- a/packages/agentboard/src/tui/index.tsx
+++ b/packages/agentboard/src/tui/index.tsx
@@ -24,12 +24,7 @@ import type {
 } from "../runtime/index";
 import { SessionCard } from "./components/SessionCard";
 import { StatusBar } from "./components/StatusBar";
-import {
-  detectMuxContext,
-  refocusMainPane,
-  getClientTty,
-  getLocalSessionName,
-} from "./mux-context";
+import { detectMuxContext, refocusMainPane, getLocalSessionName } from "./mux-context";
 import { SPINNERS, BOLD, DIM, DIVIDER, logResizeDebug } from "./constants";
 
 const muxCtx = detectMuxContext();
@@ -82,7 +77,6 @@ function App() {
 
   const [sessions, setSessions] = createStore<SessionData[]>([]);
   const [focusedSession, setFocusedSession] = createSignal<string | null>(null);
-  const [currentSession, setCurrentSession] = createSignal<string | null>(null);
   const [connected, setConnected] = createSignal(false);
   const [spinIdx, setSpinIdx] = createSignal(0);
   const [preferredEditor, setPreferredEditor] = createSignal("code");
@@ -106,10 +100,19 @@ function App() {
     toastTimer = setTimeout(() => setToast(null), 4000);
   }
 
-  const [clientTty, setClientTty] = createSignal(getClientTty(muxCtx));
   let ws: WebSocket | null = null;
   let startupFocusSynced = false;
   const startupSessionName = getLocalSessionName(muxCtx);
+
+  // --- Current session (the ● you-are-here marker) ---
+  // This TUI lives in a pane inside `startupSessionName`; anyone seeing it is
+  // attached to that session, so "current" is the local session — not a server
+  // global. (The server can't know one true current session once multiple
+  // clients are attached.) `pendingSwitch` optimistically marks the target of
+  // a click/Tab until the view actually moves away; it resets when a focus
+  // broadcast says this session is being viewed again.
+  const [pendingSwitch, setPendingSwitch] = createSignal<string | null>(null);
+  const currentSession = () => pendingSwitch() ?? startupSessionName;
 
   const focusedData = createMemo(() => sessions.find((s) => s.name === focusedSession()) ?? null);
 
@@ -127,7 +130,7 @@ function App() {
     // Optimistic local update — makes rapid Tab repeat instant by removing
     // the server/hook round-trip from the next-Tab decision.
     // The server's focus/state broadcast will reconcile if needed.
-    setCurrentSession(name);
+    setPendingSwitch(name);
     setFocusedSession(name);
     setPanelFocus("sessions");
     setFocusedAgentIdx(0);
@@ -305,8 +308,6 @@ function App() {
 
     socket.onopen = () => {
       setConnected(true);
-      const tty = clientTty();
-      if (tty) send({ type: "identify", clientTty: tty });
       reIdentify();
     };
 
@@ -332,15 +333,15 @@ function App() {
 
             setSessions(reconcile(msg.sessions, { key: "name" }));
             setFocusedSession(startupFocus);
-            setCurrentSession(msg.currentSession);
+            if (startupFocus === startupSessionName) setPendingSwitch(null);
             setTheme(resolveTheme(msg.theme));
             if (msg.preferredEditor) setPreferredEditor(msg.preferredEditor);
           } else if (msg.type === "focus") {
             setFocusedSession(msg.focusedSession);
-            setCurrentSession(msg.currentSession);
+            // A focus naming this session means a client is viewing it again —
+            // any optimistic switch-away marker is stale.
+            if (msg.focusedSession === startupSessionName) setPendingSwitch(null);
           } else if (msg.type === "your-session") {
-            if (msg.clientTty) setClientTty(msg.clientTty);
-
             if (!startupFocusSynced && sessions.some((session) => session.name === msg.name)) {
               startupFocusSynced = true;
               const oldFocus = focusedSession();

--- a/packages/agentboard/src/tui/mux-context.ts
+++ b/packages/agentboard/src/tui/mux-context.ts
@@ -40,20 +40,6 @@ export function refocusMainPane(muxCtx: MuxContext): void {
   }
 }
 
-export function getClientTty(muxCtx: MuxContext): string {
-  if (muxCtx.type === "tmux") {
-    const { sdk, paneId } = muxCtx;
-    const sessName = sdk.display("#{session_name}", { target: paneId });
-    if (sessName) {
-      const clients = sdk.listClients();
-      const client = clients.find((c) => c.sessionName === sessName);
-      if (client) return client.tty;
-    }
-    return sdk.getClientTty();
-  }
-  return "";
-}
-
 export function getLocalSessionName(muxCtx: MuxContext): string | null {
   if (muxCtx.type === "tmux") {
     const sessionName = muxCtx.sdk.display("#{session_name}", { target: muxCtx.paneId });


### PR DESCRIPTION
## Problem

Clicking a session card in the agentboard sidebar stopped switching sessions — and sometimes yanked a *different* terminal to the target — whenever more than one tmux client was attached. The "current session" highlight also pointed at the wrong session and snapped back right after clicking, reading as "clicks don't work / everything is sluggish".

## Confirmed root cause (reproduced live)

1. **Stale tty routing.** `switch-session` resolved its `switch-client -c <tty>` target from `clientTtyBySession` — "the last client that switched TO this session" (populated by the `client-session-changed` hook). The entry goes stale the moment that client moves on. Live probe: with `pts/0`+`pts/6` attached to `towerforge-slot-1` and `pts/3` on another session, the server had `slot-1 → pts/3`; a click in slot-1's sidebar moved **pts/3** while the clicking terminal never switched. Commit 5a74590 fixed this exact disease for the agent-row path by dropping `-c`; the session-card path kept the stale lookup.
2. **Wrong "current" marker.** The server computed current session from `clients[0].sessionName` (and state broadcasts carried a boot-time snapshot), so with multiple clients the ● marker tracked whichever client tmux listed first and clobbered the optimistic update ~20ms after every click.

This surfaced as a "regression in the last 10 versions" because multi-terminal usage (towerforge sessions) started recently — the bugs were latent multi-client handling, present since March.

## Fix

- **Switch the right clients:** a sidebar lives inside a session, so the clients to switch are exactly those attached to the sidebar's own session (known from `identify-pane`), resolved against `list-clients` at switch time. Falls back to tmux's most-recently-active client when the origin is unknown. Applied to `switch-session`, `switch-index` (WS), and `focus-agent-pane`. The HTTP `/switch-index` path keeps its explicit tty — tmux expands `#{client_tty}` at keypress time, so it's fresh by construction.
- **Per-TUI current marker:** "current" is per-client, so the global field is removed from the protocol; each TUI marks its own local session, with an optimistic override while a switch is in flight.
- **Dead plumbing removed:** `clientTtys`, `clientTtyBySession`, the `identify` command, `YourSession.clientTty`, and `getClientTty` in mux-context only served the stale-tty scheme.

## Verification

- `resolveSwitchTargets` unit tests + `TmuxProvider.switchSession` regression tests via an injected fake `TmuxClient` (constructor DI, no `vi.mock`), covering the exact multi-client misroute.
- Live re-test after restarting the server on this branch: the same WS probe that previously moved `pts/3` now switches exactly `pts/0` and `pts/6`; a synthetic SGR mouse click through the real TUI switches exactly the client viewing that sidebar (~20ms end-to-end).
- format-check, oxlint, tsgo, 489 tests, CLI entrypoint, and agentboard workspace resolution all pass (`verify-app`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)