### PR TITLE
fix(agentboard): show sidebars by default on server start

### DIFF
--- a/packages/agentboard/src/mux-tmux/client.ts
+++ b/packages/agentboard/src/mux-tmux/client.ts
@@ -435,13 +435,6 @@ export class TmuxClient {
   }
 
   /**
-   * Get the client TTY for the current client
-   */
-  getClientTty(): string {
-    return this.display("#{client_tty}");
-  }
-
-  /**
    * Get session directory (pane_current_path of the active pane)
    */
   getSessionDir(target: string): string {

--- a/packages/agentboard/src/mux-tmux/provider.ts
+++ b/packages/agentboard/src/mux-tmux/provider.ts
@@ -78,10 +78,6 @@ export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapabl
     return this.tmux.getPaneCount(name);
   }
 
-  getClientTty(): string {
-    return this.tmux.getClientTty();
-  }
-
   createSession(name?: string, dir?: string): void {
     this.tmux.newSession({ name, cwd: dir });
   }

--- a/packages/agentboard/src/runtime/contracts/mux.ts
+++ b/packages/agentboard/src/runtime/contracts/mux.ts
@@ -67,7 +67,6 @@ export interface MuxProviderV1 {
   getCurrentSession(): string | null;
   getSessionDir(name: string): string;
   getPaneCount(name: string): number;
-  getClientTty(): string;
   createSession(name?: string, dir?: string): void;
   killSession(name: string): void;
 

--- a/packages/agentboard/src/runtime/server/context.ts
+++ b/packages/agentboard/src/runtime/server/context.ts
@@ -52,7 +52,7 @@ export interface ServerContext {
   sidebarPaneCache: { provider: FullSidebarCapable; panes: SidebarPane[] }[] | null;
   sidebarPaneCacheTs: number;
   ensureSidebarTimer: ReturnType<typeof setTimeout> | null;
-  ensureSidebarPendingCtx: { session: string; windowId: string } | undefined;
+  ensureSidebarPendingCtxs: Map<string, { session: string; windowId: string }>;
 
   // Pane agent scanning
   paneAgentsBySession: Map<string, Map<string, PaneAgentPresence>>;

--- a/packages/agentboard/src/runtime/server/index.ts
+++ b/packages/agentboard/src/runtime/server/index.ts
@@ -87,7 +87,9 @@ export function startServer(
   let sidebarWidth = config.sidebarWidth ?? 35;
   let sidebarPosition: "left" | "right" = config.sidebarPosition ?? "left";
   let preferredEditor = loadPreferredEditor();
-  let sidebarVisible = false;
+  // Visible by default so a fresh server (including `tt agentboard restart`)
+  // spawns sidebars on the first ensure-sidebar without needing a toggle.
+  let sidebarVisible = true;
 
   log("server", "config loaded", {
     sidebarWidth,
@@ -679,18 +681,29 @@ export function startServer(
   }
 
   // Debounced ensure-sidebar — collapses rapid hook-fired calls during fast
-  // session switching into a single check after switching settles.
+  // session switching into a single check after switching settles. Pending
+  // contexts are keyed by window so near-simultaneous calls for different
+  // windows (e.g. restart bootstrapping one per attached client) each get
+  // ensured instead of last-write-wins dropping all but one.
   let ensureSidebarTimer: ReturnType<typeof setTimeout> | null = null;
-  let ensureSidebarPendingCtx: { session: string; windowId: string } | undefined;
+  const ensureSidebarPendingCtxs = new Map<string, { session: string; windowId: string }>();
+  let ensureSidebarPendingNoCtx = false;
 
   function debouncedEnsureSidebar(ctx?: { session: string; windowId: string }): void {
-    if (ctx) ensureSidebarPendingCtx = ctx;
+    if (ctx) ensureSidebarPendingCtxs.set(ctx.windowId, ctx);
+    else ensureSidebarPendingNoCtx = true;
     if (ensureSidebarTimer) clearTimeout(ensureSidebarTimer);
     ensureSidebarTimer = setTimeout(() => {
       ensureSidebarTimer = null;
-      const nextCtx = ensureSidebarPendingCtx;
-      ensureSidebarPendingCtx = undefined;
-      ensureSidebarInWindow(undefined, nextCtx);
+      const ctxs = [...ensureSidebarPendingCtxs.values()];
+      ensureSidebarPendingCtxs.clear();
+      const noCtx = ensureSidebarPendingNoCtx;
+      ensureSidebarPendingNoCtx = false;
+      if (ctxs.length === 0 && noCtx) {
+        ensureSidebarInWindow(undefined, undefined);
+        return;
+      }
+      for (const c of ctxs) ensureSidebarInWindow(undefined, c);
     }, 150);
   }
 


### PR DESCRIPTION
- `sidebarVisible` booted `false`, so after `tt agentboard restart` every bootstrap `/ensure-sidebar` call SKIPped and the board stayed hidden until a manual toggle. Now defaults to `true`; toggle still hides.
- The ensure debounce held a single last-write-wins pending context, so restart's one-POST-per-client burst only ensured one window. Pending contexts are now keyed by window — distinct windows each get ensured, rapid re-fires for the same window still coalesce.
- Removed `getClientTty` from the mux contract / TmuxProvider / TmuxClient — dead since #264's routing cutover.

Verified live: restart with clients attached to two different sessions spawns both sidebars with no toggle. format/lint/typecheck/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)