### PR TITLE
fix(agentboard): move card highlight when clicking an agent row

### DIFF
--- a/packages/agentboard/src/tui/index.tsx
+++ b/packages/agentboard/src/tui/index.tsx
@@ -178,6 +178,8 @@ function App() {
     const agents = data?.agents ?? [];
     const agent = agents[focusedAgentIdx()];
     if (!agent || !data) return;
+    // Focusing the agent's pane switches this terminal to its session.
+    setPendingSwitch(data.name);
     if (TUI_DEBUG)
       appendFileSync(
         "/tmp/agentboard-tui-agent-click.log",
@@ -576,6 +578,12 @@ function App() {
                   });
                 }}
                 onFocusAgentPane={(agent) => {
+                  // The click switches this terminal to the agent's session —
+                  // move the local selection and current marker with it.
+                  // (The row's onMouseDown stops propagation, so the card's
+                  // onSelect doesn't run for agent-row clicks.)
+                  setFocusedSession(session.name);
+                  setPendingSwitch(session.name);
                   send({
                     type: "focus-agent-pane",
                     session: session.name,


### PR DESCRIPTION
Follow-up to #266. Agent-row clicks stop propagation (so the card's onSelect doesn't double-fire a session switch), which meant nothing updated the now-local card highlight or the ● current marker on that path — the terminal switched but the card didn't highlight. The agent-row click and Enter handlers now set the local selection and pending-switch marker, same as a card click.

Verified: oxlint, tsgo, vitest 485 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)