### PR TITLE
fix(agentboard): highlight the clicked agent row

### DIFF
--- a/packages/agentboard/src/tui/components/SessionCard.tsx
+++ b/packages/agentboard/src/tui/components/SessionCard.tsx
@@ -23,7 +23,7 @@ export interface SessionCardProps {
   focusedAgentIdx: number;
   onSelect: () => void;
   onDismissAgent: (agent: SessionData["agents"][number]) => void;
-  onFocusAgentPane: (agent: SessionData["agents"][number]) => void;
+  onFocusAgentPane: (agent: SessionData["agents"][number], index: number) => void;
 }
 
 export function SessionCard(props: SessionCardProps) {
@@ -178,7 +178,7 @@ export function SessionCard(props: SessionCardProps) {
                 now={props.now}
                 isKeyboardFocused={i() === props.focusedAgentIdx}
                 onDismiss={() => props.onDismissAgent(agent)}
-                onFocusPane={() => props.onFocusAgentPane(agent)}
+                onFocusPane={() => props.onFocusAgentPane(agent, i())}
               />
             )}
           </For>

--- a/packages/agentboard/src/tui/index.tsx
+++ b/packages/agentboard/src/tui/index.tsx
@@ -577,12 +577,14 @@ function App() {
                     threadId: agent.threadId,
                   });
                 }}
-                onFocusAgentPane={(agent) => {
+                onFocusAgentPane={(agent, idx) => {
                   // The click switches this terminal to the agent's session —
-                  // move the local selection and current marker with it.
-                  // (The row's onMouseDown stops propagation, so the card's
-                  // onSelect doesn't run for agent-row clicks.)
+                  // move the local selection, agent-row highlight, and current
+                  // marker with it. (The row's onMouseDown stops propagation,
+                  // so the card's onSelect doesn't run for agent-row clicks.)
                   setFocusedSession(session.name);
+                  setPanelFocus("agents");
+                  setFocusedAgentIdx(idx);
                   setPendingSwitch(session.name);
                   send({
                     type: "focus-agent-pane",


### PR DESCRIPTION
Follow-up to #267. The agent-row highlight renders from `focusedAgentIdx`, which only keyboard navigation updated — clicking an agent row switched the terminal but the highlight stayed on whatever row j/k last touched (or none, while panelFocus was "sessions"). The clicked row's index now flows through `onFocusAgentPane`, and the click moves `panelFocus`/`focusedAgentIdx` the same way keyboard selection does.

Verified: oxlint, tsgo, vitest 485 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)