### PR TITLE
fix(agentboard): hand selection over to the destination sidebar on switch

### DIFF
--- a/packages/agentboard/src/runtime/server/index.ts
+++ b/packages/agentboard/src/runtime/server/index.ts
@@ -404,12 +404,14 @@ export function startServer(
     server.publish("sidebar", msg);
   }
 
-  /** Tell TUIs a client is now viewing `name` — they use it only to reset
-   * their local pending-switch marker. Card selection is per-TUI, never
-   * broadcast: with multiple terminals attached there is no one true
-   * "focused session" the server could own. */
-  function publishSessionViewed(name: string) {
-    const msg: SessionViewed = { type: "session-viewed", name };
+  /** Tell TUIs a client is now viewing `name` — they use it to reset their
+   * local pending-switch marker. Card selection is per-TUI: with multiple
+   * terminals attached there is no one true "focused session" the server
+   * could own. `select` is the handoff exception — a sidebar action switched
+   * the viewer to another session's sidebar, and that destination sidebar
+   * should highlight what was clicked. */
+  function publishSessionViewed(name: string, select?: SessionViewed["select"]) {
+    const msg: SessionViewed = { type: "session-viewed", name, select };
     server.publish("sidebar", JSON.stringify(msg));
   }
 
@@ -967,13 +969,14 @@ export function startServer(
     return [...new Set(out.split("\n").filter(Boolean))];
   }
 
+  /** Returns true when a pane was resolved and the viewer was switched to it. */
   function focusAgentPane(
     sessionName: string,
     agentName: string,
     threadId?: string,
     threadName?: string,
     fromSession?: string,
-  ): void {
+  ): boolean {
     log("focus-agent-pane", "received", {
       sessionName,
       agentName,
@@ -982,7 +985,7 @@ export function startServer(
       fromSession,
     });
     const targetPaneId = resolveAgentPaneId(sessionName, agentName, threadId, threadName);
-    if (!targetPaneId) return;
+    if (!targetPaneId) return false;
 
     log("focus-agent-pane", "focusing", { sessionName, agentName, paneId: targetPaneId });
     // The agent's pane may live in a different session/window than the one the
@@ -1023,6 +1026,7 @@ export function startServer(
         pendingHighlightResets.delete(targetPaneId);
       }, PANE_HIGHLIGHT_MS),
     );
+    return true;
   }
 
   function killAgentPane(
@@ -1408,10 +1412,11 @@ export function startServer(
 
         // Optimistic — clear unseen flags and tell TUIs in the target session
         // a client is arriving, without waiting for the tmux hook round-trip.
-        // The hook's /focus POST will reconcile if needed.
+        // The hook's /focus POST will reconcile if needed. Carry the selection
+        // so the destination sidebar highlights the clicked card.
         const hadUnseen = tracker.handleFocus(cmd.name);
         if (hadUnseen) broadcastState();
-        publishSessionViewed(cmd.name);
+        publishSessionViewed(cmd.name, { session: cmd.name });
 
         break;
       }
@@ -1459,21 +1464,30 @@ export function startServer(
         // client(s) actually attached to it
         clientSessionNames.set(ws, cmd.sessionName);
         break;
-      case "focus-agent-pane":
+      case "focus-agent-pane": {
         log("handleCommand", "focus-agent-pane received", {
           session: cmd.session,
           agent: cmd.agent,
           threadId: cmd.threadId,
           threadName: cmd.threadName,
         });
-        focusAgentPane(
+        const switched = focusAgentPane(
           cmd.session,
           cmd.agent,
           cmd.threadId,
           cmd.threadName,
           clientSessionNames.get(ws),
         );
+        // The viewer just landed on the agent session's sidebar — hand the
+        // clicked-agent selection over so that sidebar highlights it.
+        if (switched) {
+          publishSessionViewed(cmd.session, {
+            session: cmd.session,
+            agent: { agent: cmd.agent, threadId: cmd.threadId },
+          });
+        }
         break;
+      }
       case "kill-agent-pane":
         log("handleCommand", "kill-agent-pane received", {
           session: cmd.session,

--- a/packages/agentboard/src/runtime/shared.ts
+++ b/packages/agentboard/src/runtime/shared.ts
@@ -51,12 +51,19 @@ export interface ServerState {
 
 /**
  * A client (terminal) is now viewing this session — fired by the tmux focus
- * hook and optimistically on switch-session. TUIs use it only to reset their
- * local pending-switch marker; card selection is per-TUI, never broadcast.
+ * hook and optimistically on sidebar-initiated switches. TUIs in the named
+ * session reset their local pending-switch marker. Card selection stays
+ * per-TUI; `select` is the one exception: when a sidebar action caused the
+ * switch, the destination sidebar adopts this selection so the clicked
+ * card/agent is highlighted after the viewer lands on it.
  */
 export interface SessionViewed {
   type: "session-viewed";
   name: string;
+  select?: {
+    session: string;
+    agent?: { agent: string; threadId?: string };
+  };
 }
 
 export interface ResizeNotify {

--- a/packages/agentboard/src/tui/index.tsx
+++ b/packages/agentboard/src/tui/index.tsx
@@ -337,9 +337,31 @@ function App() {
             setTheme(resolveTheme(msg.theme));
             if (msg.preferredEditor) setPreferredEditor(msg.preferredEditor);
           } else if (msg.type === "session-viewed") {
-            // A client is viewing this session again — any optimistic
-            // switch-away marker is stale.
-            if (msg.name === startupSessionName) setPendingSwitch(null);
+            if (msg.name === startupSessionName) {
+              // A client is viewing this session again — any optimistic
+              // switch-away marker is stale.
+              setPendingSwitch(null);
+              // Selection handoff: a sidebar action moved the viewer here.
+              // Adopt the selection so the card/agent clicked in the
+              // originating sidebar is the one highlighted in this sidebar.
+              const sel = msg.select;
+              if (sel && sessions.some((s) => s.name === sel.session)) {
+                setFocusedSession(sel.session);
+                const agentSel = sel.agent;
+                if (agentSel) {
+                  const data = sessions.find((s) => s.name === sel.session);
+                  const idx = (data?.agents ?? []).findIndex(
+                    (a) => a.agent === agentSel.agent && a.threadId === agentSel.threadId,
+                  );
+                  if (idx >= 0) {
+                    setPanelFocus("agents");
+                    setFocusedAgentIdx(idx);
+                  }
+                } else {
+                  setPanelFocus("sessions");
+                }
+              }
+            }
           } else if (msg.type === "re-identify") {
             reIdentify();
           } else if (msg.type === "quit") {


### PR DESCRIPTION
Fixes the "click twice to highlight" report. Clicking a card or agent row switches the terminal to another session — the viewer then looks at **that session's sidebar**, a different TUI whose local selection was never updated. #267/#268 highlighted the clicked row in the originating sidebar, which the viewer immediately leaves.

Sidebar-initiated switches (switch-session, focus-agent-pane) now publish `session-viewed` with a `select` payload, and the destination sidebar adopts it: card selected, agents panel focused, clicked agent row highlighted. Hook-driven `session-viewed` events carry no selection and leave local state alone, so ordinary tmux switches never clobber a sidebar's selection. `focusAgentPane` now reports whether it actually switched, so a failed pane resolution doesn't move anyone's selection.

Verified: oxlint, tsgo, vitest 485 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)