### PR TITLE
chore: drop primary clone from multi-repo slot setup

### DIFF
--- a/.claude/skills/setup-multi-repo/SKILL.md
+++ b/.claude/skills/setup-multi-repo/SKILL.md
@@ -1,25 +1,23 @@
 ---
 name: setup-multi-repo
-description: Set up a multi-clone repo folder structure with a primary clone and 5 slot clones for parallel Claude Code agent work. Use when the user says "set up multi-repo", "setup slots", "create repo slots", or wants to create the same folder pattern used for towles-tool-repos.
+description: Set up a multi-clone repo folder structure with 5 slot clones for parallel Claude Code agent work. Use when the user says "set up multi-repo", "setup slots", "create repo slots", or wants to create the same folder pattern used for towles-tool-repos.
 user_invocable: true
 ---
 
 # Setup Multi-Repo Folder Structure
 
-Create a parent directory containing a `-primary` clone and 5 `-slot-N` clones of the same
-GitHub repo. This pattern supports running multiple Claude Code agents in parallel, each in
-its own isolated working copy.
+Create a parent directory containing 5 `-slot-N` clones of the same GitHub repo. This pattern
+supports running multiple Claude Code agents in parallel, each in its own isolated working copy.
 
 ## Structure
 
 ```
 ~/code/p/<name>-repos/
-  <name>-primary/     # Main working copy
-  <name>-slot-1/      # Agent slot 1
-  <name>-slot-2/      # Agent slot 2
-  <name>-slot-3/      # Agent slot 3
-  <name>-slot-4/      # Agent slot 4
-  <name>-slot-5/      # Agent slot 5
+  <name>-slot-1/      # Slot 1
+  <name>-slot-2/      # Slot 2
+  <name>-slot-3/      # Slot 3
+  <name>-slot-4/      # Slot 4
+  <name>-slot-5/      # Slot 5
 ```
 
 ## Steps
@@ -35,22 +33,16 @@ its own isolated working copy.
    mkdir -p ~/code/p/<name>-repos
    ```
 
-3. Clone primary:
+3. Clone 5 slots:
 
    ```bash
    cd ~/code/p/<name>-repos
-   git clone <repo-url> <name>-primary
-   ```
-
-4. Clone 5 slots:
-
-   ```bash
    for i in 1 2 3 4 5; do
      git clone <repo-url> "<name>-slot-$i"
    done
    ```
 
-5. Verify the structure:
+4. Verify the structure:
    ```bash
    ls -la ~/code/p/<name>-repos/
    ```
@@ -62,7 +54,6 @@ For the blog repo:
 ```bash
 mkdir -p ~/code/p/blog-repos
 cd ~/code/p/blog-repos
-git clone https://github.com/ChrisTowles/blog.git blog-primary
 for i in 1 2 3 4 5; do
   git clone https://github.com/ChrisTowles/blog.git "blog-slot-$i"
 done
@@ -71,6 +62,6 @@ done
 ## Notes
 
 - Each slot is a fully independent git clone (not a worktree) so agents can freely switch branches
-- The `-primary` clone is for manual/primary development work
+- Slots are interchangeable — use any idle slot for manual work or hand it to an agent
 - Slot clones are managed by the agentboard system in towles-tool
 - If the repo already has a standalone clone (e.g., `~/code/p/blog`), consider removing it after migration

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tt auto-claude --reset 42               # Reset state for an issue
 tt auto-claude --loop                    # Start polling loop
 ```
 
-**Slot-based workflow:** Run auto-claude in a dedicated clone of the repo — not the one you're actively editing. Keep 3-5 clones (e.g. `slot-1`, `slot-2`, `slot-primary`) so each issue gets its own isolated environment. `slot-primary` is typically the one open in VS Code for manual work; the numbered slots run auto-claude independently. Each slot has its own `.env` so services and ports don't collide between slots. Claude Code's worktree feature may replace this approach in the future, but full repo clones have been more reliable in practice.
+**Slot-based workflow:** Run auto-claude in a dedicated clone of the repo — not the one you're actively editing. Keep 3-5 clones (e.g. `slot-1`, `slot-2`, …) so each issue gets its own isolated environment. Slots are interchangeable — open one in VS Code for manual work and let the others run auto-claude independently. Each slot has its own `.env` so services and ports don't collide between slots. Claude Code's worktree feature may replace this approach in the future, but full repo clones have been more reliable in practice.
 
 #### Pipeline Steps
 

--- a/packages/agentboard/src/runtime/server/git-info.ts
+++ b/packages/agentboard/src/runtime/server/git-info.ts
@@ -3,8 +3,9 @@ import type { FSWatcher } from "node:fs";
 import { join } from "node:path";
 import consola from "consola";
 import type { SessionData } from "../shared";
+import { startSessionPoll } from "./poll";
 
-// --- Shell helper (for git commands only) ---
+// --- Shell helpers (for git commands only) ---
 
 export function shell(cmd: string[]): string {
   try {
@@ -15,12 +16,28 @@ export function shell(cmd: string[]): string {
   }
 }
 
+async function shellAsync(cmd: string[]): Promise<string> {
+  try {
+    const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "ignore" });
+    const [out] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    return out.trim();
+  } catch {
+    return "";
+  }
+}
+
 // --- Git helpers ---
 
 export interface GitInfo {
   branch: string;
-  dirty: boolean;
   isWorktree: boolean;
+  /**
+   * filesChanged/linesAdded/linesRemoved measure the working tree against the
+   * pushed baseline (merge-base with the branch's upstream, else origin/main):
+   * uncommitted changes plus unpushed commits. commitsDelta deliberately uses
+   * a different baseline — distance from origin/main — so the two can disagree
+   * on a feature branch tracking its own remote.
+   */
   filesChanged: number;
   linesAdded: number;
   linesRemoved: number;
@@ -28,83 +45,197 @@ export interface GitInfo {
   commitsDelta: number;
 }
 
-const gitInfoCache = new Map<string, { info: GitInfo; ts: number }>();
-const GIT_CACHE_TTL_MS = 5000;
-
-export function getGitInfo(dir: string): GitInfo {
-  const empty: GitInfo = {
+function emptyGitInfo(): GitInfo {
+  return {
     branch: "",
-    dirty: false,
     isWorktree: false,
     filesChanged: 0,
     linesAdded: 0,
     linesRemoved: 0,
     commitsDelta: 0,
   };
-  if (!dir) return empty;
+}
 
+const gitInfoCache = new Map<string, { info: GitInfo; ts: number }>();
+// Must stay above the git poll interval so the poll keeps entries warm for
+// the synchronous readers; freshness comes from the poll and explicit
+// invalidation, not from a short TTL.
+const GIT_CACHE_TTL_MS = 5000;
+
+/**
+ * Synchronous cache-only read. Serves stale entries rather than blocking the
+ * event loop; a stale or missing entry kicks off a background refresh, and
+ * the git poll broadcasts once fresh numbers land.
+ */
+export function getGitInfo(dir: string): GitInfo {
+  if (!dir) return emptyGitInfo();
   const cached = gitInfoCache.get(dir);
   if (cached && Date.now() - cached.ts < GIT_CACHE_TTL_MS) return cached.info;
+  void refreshGitInfo(dir);
+  return cached?.info ?? emptyGitInfo();
+}
 
-  const branch = shell(["git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]);
-  if (!branch) return empty;
-  const gitDir = shell(["git", "-C", dir, "rev-parse", "--git-dir"]);
-  const statusOut = shell(["git", "-C", dir, "status", "--porcelain"]);
+/** Mark entries stale so the next read serves them while a refresh runs. */
+export function invalidateGitCache(dir?: string): void {
+  if (dir) {
+    const cached = gitInfoCache.get(dir);
+    if (cached) cached.ts = 0;
+  } else {
+    for (const cached of gitInfoCache.values()) cached.ts = 0;
+  }
+}
 
-  // Uncommitted diff stats (unstaged + staged)
+const gitRefreshInFlight = new Map<string, Promise<GitInfo>>();
+
+/** Recompute git info via async spawns (no event-loop blocking) and cache it. */
+function refreshGitInfo(dir: string): Promise<GitInfo> {
+  const pending = gitRefreshInFlight.get(dir);
+  if (pending) return pending;
+  const refresh = computeGitInfo(dir)
+    .catch(() => emptyGitInfo())
+    .then((info) => {
+      gitInfoCache.set(dir, { info, ts: Date.now() });
+      return info;
+    })
+    .finally(() => {
+      gitRefreshInFlight.delete(dir);
+    });
+  gitRefreshInFlight.set(dir, refresh);
+  return refresh;
+}
+
+async function computeGitInfo(dir: string): Promise<GitInfo> {
+  const branch = await shellAsync(["git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]);
+  if (!branch) return emptyGitInfo();
+  const [gitDir, statusOut, originMain] = await Promise.all([
+    shellAsync(["git", "-C", dir, "rev-parse", "--git-dir"]),
+    shellAsync(["git", "-C", dir, "status", "--porcelain"]),
+    resolveOriginMain(dir),
+  ]);
+
+  // Diff stats vs. the pushed baseline: uncommitted changes + unpushed commits
+  // (everything between what's on the remote and the current working tree).
+  const base = await resolvePushedBase(dir, originMain);
+  const [diffOut, aheadBehind] = await Promise.all([
+    shellAsync(["git", "-C", dir, "diff", "--numstat", base]),
+    shellAsync(["git", "-C", dir, "rev-list", "--left-right", "--count", `${originMain}...HEAD`]),
+  ]);
+
   let linesAdded = 0;
   let linesRemoved = 0;
-  for (const cmd of [
-    ["git", "-C", dir, "diff", "--numstat"],
-    ["git", "-C", dir, "diff", "--cached", "--numstat"],
-  ]) {
-    const out = shell(cmd);
-    if (!out) continue;
-    for (const line of out.split("\n")) {
-      const [added, removed] = line.split("\t");
+  const changedFiles = new Set<string>();
+  if (diffOut) {
+    for (const line of diffOut.split("\n")) {
+      if (!line) continue;
+      const [added, removed, file] = line.split("\t");
+      if (file) changedFiles.add(file);
       if (added === "-" || removed === "-") continue; // binary
       linesAdded += Number(added) || 0;
       linesRemoved += Number(removed) || 0;
     }
   }
 
+  // Untracked files aren't in the diff but still count as changed files.
+  let untracked = 0;
+  for (const line of statusOut.split("\n")) {
+    if (line.startsWith("??")) untracked++;
+  }
+  const filesChanged = changedFiles.size + untracked;
+
   // Commits ahead(+) or behind(-) origin/main
   let commitsDelta = 0;
-  const originMain = shell(["git", "-C", dir, "rev-parse", "--verify", "origin/main"])
-    ? "origin/main"
-    : "origin/master";
-  const aheadBehind = shell([
-    "git",
-    "-C",
-    dir,
-    "rev-list",
-    "--left-right",
-    "--count",
-    `${originMain}...HEAD`,
-  ]);
   if (aheadBehind) {
     const [behind, ahead] = aheadBehind.split("\t");
     commitsDelta = (Number(ahead) || 0) - (Number(behind) || 0);
   }
 
-  const filesChanged = statusOut ? statusOut.split("\n").filter(Boolean).length : 0;
-
-  const info: GitInfo = {
+  return {
     branch,
-    dirty: statusOut.length > 0,
     isWorktree: gitDir.includes("/worktrees/"),
     filesChanged,
     linesAdded,
     linesRemoved,
     commitsDelta,
   };
-  gitInfoCache.set(dir, { info, ts: Date.now() });
-  return info;
 }
 
-export function invalidateGitCache(dir?: string): void {
-  if (dir) gitInfoCache.delete(dir);
-  else gitInfoCache.clear();
+/** origin/main, or origin/master if that's what the remote uses. */
+async function resolveOriginMain(dir: string): Promise<string> {
+  const verified = await shellAsync([
+    "git",
+    "-C",
+    dir,
+    "rev-parse",
+    "--verify",
+    "--quiet",
+    "origin/main",
+  ]);
+  return verified ? "origin/main" : "origin/master";
+}
+
+/**
+ * The commit HEAD diverged from: merge-base with the branch's upstream when it
+ * has one, else with origin/main, else HEAD (uncommitted changes only). Using
+ * the merge-base rather than the upstream tip keeps remote-only commits out
+ * of the stats when the local branch is behind.
+ */
+async function resolvePushedBase(dir: string, originMain: string): Promise<string> {
+  const upstream = await shellAsync([
+    "git",
+    "-C",
+    dir,
+    "rev-parse",
+    "--abbrev-ref",
+    "--symbolic-full-name",
+    "@{upstream}",
+  ]);
+  // merge-base fails cleanly when the base ref doesn't exist (no remote).
+  const mergeBase = await shellAsync([
+    "git",
+    "-C",
+    dir,
+    "merge-base",
+    "HEAD",
+    upstream || originMain,
+  ]);
+  return mergeBase || "HEAD";
+}
+
+// --- Git stat poll ---
+
+const lastPolledSnapshots = new Map<string, string>();
+
+/**
+ * Recompute git stats for every session dir on an interval and broadcast when
+ * any stat changed. Catches working-tree edits, which (unlike commits) don't
+ * touch the .git/HEAD file the watchers track.
+ */
+export function startGitPoll(ctx: {
+  getSessions: () => { dir: string }[] | null;
+  getClientCount: () => number;
+  broadcastState: () => void;
+}): ReturnType<typeof setInterval> {
+  return startSessionPoll({
+    intervalMs: 1500,
+    ...ctx,
+    tick: async (sessions) => {
+      let changed = false;
+      const seen = new Set<string>();
+      for (const s of sessions) {
+        if (!s.dir || seen.has(s.dir)) continue;
+        seen.add(s.dir);
+        const snapshot = JSON.stringify(await refreshGitInfo(s.dir));
+        if (lastPolledSnapshots.get(s.dir) !== snapshot) {
+          lastPolledSnapshots.set(s.dir, snapshot);
+          changed = true;
+        }
+      }
+      for (const dir of lastPolledSnapshots.keys()) {
+        if (!seen.has(dir)) lastPolledSnapshots.delete(dir);
+      }
+      return changed;
+    },
+  });
 }
 
 // --- Git HEAD file watchers ---

--- a/packages/agentboard/src/runtime/server/index.ts
+++ b/packages/agentboard/src/runtime/server/index.ts
@@ -16,7 +16,7 @@ import { SessionMetadataStore } from "./metadata-store";
 import { loadConfig, saveConfig, loadPreferredEditor } from "../config";
 import { resolveSidebarWidthFromResizeContext, snapshotSidebarWindows } from "./sidebar-width-sync";
 import type { SidebarResizeContext, SidebarResizeSuppression } from "./sidebar-width-sync";
-import { shell, getGitInfo, syncGitWatchers, teardownGitWatchers } from "./git-info";
+import { shell, getGitInfo, syncGitWatchers, teardownGitWatchers, startGitPoll } from "./git-info";
 import { refreshPortSnapshot, getSessionPorts, startPortPoll } from "./port-scanner";
 import {
   SERVER_PORT,
@@ -361,7 +361,6 @@ export function startServer(
           createdAt,
           dir,
           branch: git.branch,
-          dirty: git.dirty,
           isWorktree: git.isWorktree,
           filesChanged: git.filesChanged,
           linesAdded: git.linesAdded,
@@ -1498,12 +1497,14 @@ export function startServer(
   // --- Port polling (detect new/stopped listeners every 10s) ---
 
   let portPollTimer: ReturnType<typeof setInterval> | null = null;
+  let gitPollTimer: ReturnType<typeof setInterval> | null = null;
 
   function cleanup() {
     for (const w of allWatchers) w.stop();
     if (watcherBroadcastTimer) clearTimeout(watcherBroadcastTimer);
     teardownGitWatchers();
     if (portPollTimer) clearInterval(portPollTimer);
+    if (gitPollTimer) clearInterval(gitPollTimer);
     if (paneScanTimer) clearInterval(paneScanTimer);
     if (pendingSidebarResize) clearTimeout(pendingSidebarResize);
     for (const timer of pendingHighlightResets.values()) clearTimeout(timer);
@@ -1792,7 +1793,16 @@ export function startServer(
     refreshPortSnapshot(allMuxSessions);
   }
   broadcastState();
-  portPollTimer = startPortPoll({ lastState, clientCount, broadcastState });
+  portPollTimer = startPortPoll({
+    getSessions: () => lastState?.sessions ?? null,
+    getClientCount: () => clientCount,
+    broadcastState,
+  });
+  gitPollTimer = startGitPoll({
+    getSessions: () => lastState?.sessions ?? null,
+    getClientCount: () => clientCount,
+    broadcastState,
+  });
   startPaneScan();
   // Run initial pane scan
   refreshPaneAgents();

--- a/packages/agentboard/src/runtime/server/poll.ts
+++ b/packages/agentboard/src/runtime/server/poll.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared scaffolding for the session pollers (git stats, ports): every
+ * `intervalMs`, when sessions exist and a client is connected, run `tick` and
+ * broadcast if it reports a change. Ticks never overlap; the initial tick
+ * runs immediately and is not gated on clients so the first broadcast has
+ * data.
+ */
+export function startSessionPoll<S>(opts: {
+  intervalMs: number;
+  getSessions: () => S[] | null;
+  getClientCount: () => number;
+  broadcastState: () => void;
+  /** Returns whether anything changed and a broadcast is needed. */
+  tick: (sessions: S[]) => boolean | Promise<boolean>;
+}): ReturnType<typeof setInterval> {
+  let running = false;
+  const run = async (requireClients: boolean) => {
+    if (running) return;
+    running = true;
+    try {
+      const sessions = opts.getSessions();
+      if (!sessions || (requireClients && opts.getClientCount() === 0)) return;
+      if (await opts.tick(sessions)) opts.broadcastState();
+    } finally {
+      running = false;
+    }
+  };
+  void run(false);
+  return setInterval(() => void run(true), opts.intervalMs);
+}

--- a/packages/agentboard/src/runtime/server/port-scanner.ts
+++ b/packages/agentboard/src/runtime/server/port-scanner.ts
@@ -1,4 +1,5 @@
 import { debugLog } from "../debug";
+import { startSessionPoll } from "./poll";
 
 // Global port snapshot — refreshed by the port poll timer, read by computeState.
 // Runs lsof + ps once for ALL sessions instead of per-session.
@@ -138,18 +139,13 @@ export function getSessionPorts(sessionName: string): number[] {
 }
 
 export function startPortPoll(ctx: {
-  lastState: { sessions: { name: string }[] } | null;
-  clientCount: number;
+  getSessions: () => { name: string }[] | null;
+  getClientCount: () => number;
   broadcastState: () => void;
 }): ReturnType<typeof setInterval> {
-  // Run initial snapshot immediately so first broadcast has ports
-  if (ctx.lastState) {
-    refreshPortSnapshot(ctx.lastState.sessions.map((s) => s.name));
-  }
-  const PORT_POLL_INTERVAL_MS = 10_000;
-  return setInterval(() => {
-    if (!ctx.lastState || ctx.clientCount === 0) return;
-    const changed = refreshPortSnapshot(ctx.lastState.sessions.map((s) => s.name));
-    if (changed) ctx.broadcastState();
-  }, PORT_POLL_INTERVAL_MS);
+  return startSessionPoll({
+    intervalMs: 10_000,
+    ...ctx,
+    tick: (sessions) => refreshPortSnapshot(sessions.map((s) => s.name)),
+  });
 }

--- a/packages/agentboard/src/runtime/shared.ts
+++ b/packages/agentboard/src/runtime/shared.ts
@@ -23,7 +23,6 @@ export interface SessionData {
   createdAt: number;
   dir: string;
   branch: string;
-  dirty: boolean;
   isWorktree: boolean;
   filesChanged: number;
   linesAdded: number;

--- a/packages/core/skills/parallel-slots/SKILL.md
+++ b/packages/core/skills/parallel-slots/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-slots
-description: Use when the user wants to dispatch parallel Claude Code agents across slot clones of a repo, asks to "fan out", "run N in parallel", "use the slots", or wants to coordinate multiple isolated working copies of the same repo. Explains the slot directory layout, when to fan out vs. stay in primary, and the `gh`-driven workflow that ties slots together.
+description: Use when the user wants to dispatch parallel Claude Code agents across slot clones of a repo, asks to "fan out", "run N in parallel", "use the slots", or wants to coordinate multiple isolated working copies of the same repo. Explains the slot directory layout, when to fan out vs. work in a single slot, and the `gh`-driven workflow that ties slots together.
 user_invocable: true
 ---
 
@@ -12,8 +12,7 @@ The slot pattern lets you run independent Claude Code sessions on the same repo 
 
 ```
 ~/code/<scope>/<repo>-repos/
-  <repo>-primary/   # interactive work
-  <repo>-slot-1/    # parallel agent slot
+  <repo>-slot-1/    # interchangeable slot — interactive or agent work
   <repo>-slot-2/
   <repo>-slot-3/
   <repo>-slot-4/
@@ -24,16 +23,16 @@ Each slot is a full clone of the same GitHub remote, not a worktree. They check 
 
 ## When to fan out
 
-Fan out (use slots) when:
+Fan out (use multiple slots) when:
 
 - Three or more independent tasks would benefit from running simultaneously (e.g. one PR, one bug, one refactor).
-- A task is risky and you want a clean, throwaway slot that won't pollute primary's working tree.
-- You're iterating on the agent harness itself and want to leave primary stable.
+- A task is risky and you want a clean, throwaway slot that won't pollute another slot's working tree.
+- You're iterating on the agent harness itself and want to leave your current slot stable.
 
-Stay in primary when:
+Stay in a single slot when:
 
 - The work is sequential or all the changes need to land in the same commit.
-- You're reading/exploring; spinning a slot just adds overhead.
+- You're reading/exploring; spinning up more slots just adds overhead.
 
 ## Dispatch flow
 
@@ -66,4 +65,4 @@ After a slot's branch is merged: confirm with `gh pr status` that the slot's PR 
 
 - Spinning all 5 slots on the same task "for redundancy". You'll spend the time merging conflicts.
 - Treating slots as long-lived workspaces. They are scratch checkouts — keep them transient.
-- Editing files in primary while a slot has them open. Stay in one or the other for any given file.
+- Editing the same files in two slots at once. Stay in one slot for any given file.


### PR DESCRIPTION
## Summary

Two changes riding together:

1. **Drop the `-primary` clone from the multi-repo slot setup.** The `-primary` clone caused more friction than it saved. The repos logic now creates only `slot-1`…`slot-5`; slots are interchangeable for both manual and agent work.
2. **AgentBoard git-stats overhaul** (from review findings on this branch's working tree): correct pushed-baseline diffing and a non-blocking git poll.

## Changes

### Slot docs
- **`setup-multi-repo` skill** — removed the `git clone … -primary` step; clones only the 5 slots. Structure diagram, steps, example, and notes updated.
- **`parallel-slots` skill** — reframed "stay in primary" guidance as "stay in a single slot"; updated layout diagram and the editing anti-pattern.
- **`README.md`** — dropped `slot-primary` from the slot-based workflow description.

### AgentBoard git stats (`packages/agentboard`)
- Diff stats measure against `merge-base(HEAD, upstream)` instead of the upstream tip, so a branch merely behind its remote no longer reports remote-only commits as local changes.
- Git info recomputes via async `Bun.spawn` with in-flight dedup; the 1.5s poll no longer stalls the event loop (~200ms/tick at 5 slots before). `getGitInfo` is now a cache-only sync read (stale-while-revalidate), TTL restored to 5s.
- Poll change-detection compares whole `GitInfo` snapshots instead of a hand-maintained field list; shared `startSessionPoll` scaffolding now backs both the git and port pollers.
- Dropped unused `SessionData.dirty`; documented the intentional baseline split (stats vs upstream merge-base, `commitsDelta` vs origin/main).

## Notes

- The `family-color.ts` `SLOT_SUFFIX` regex still strips `-primary`, so existing primary clones (like the current `towles-tool-primary`) keep coloring correctly in the AgentBoard sidebar. This PR only stops *creating new* primaries.
- Fully retiring the existing `towles-tool-primary` directory (rename or delete + relink `tt`) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)