### PR TITLE
fix(agentboard): pin opentui exact version, disable kitty keyboard protocol

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,8 @@
       "dependencies": {
         "@anthropic-ai/claude-code": "^2.1.107",
         "@anthropic-ai/sdk": "^0.88.0",
-        "@opentui/core": "^0.1.99",
-        "@opentui/solid": "^0.1.99",
+        "@opentui/core": "0.1.99",
+        "@opentui/solid": "0.1.99",
         "citty": "^0.2.2",
         "consola": "^3.4.2",
         "d3-hierarchy": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "dependencies": {
     "@anthropic-ai/claude-code": "^2.1.107",
     "@anthropic-ai/sdk": "^0.88.0",
-    "@opentui/core": "^0.1.99",
-    "@opentui/solid": "^0.1.99",
+    "@opentui/core": "0.1.99",
+    "@opentui/solid": "0.1.99",
     "citty": "^0.2.2",
     "consola": "^3.4.2",
     "d3-hierarchy": "^3.1.2",

--- a/packages/agentboard/src/tui/index.tsx
+++ b/packages/agentboard/src/tui/index.tsx
@@ -788,6 +788,11 @@ async function main() {
     exitOnCtrlC: true,
     targetFps: 30,
     useMouse: true,
+    // Undefined defaults to enabled with opentui's default flags — explicit
+    // null opts out. The sidebar shares a tmux client with plain shell panes
+    // that don't speak the kitty protocol's CSI-u key encoding, so leaving
+    // it enabled here leaks garbled escape sequences (e.g. Esc) into them.
+    useKittyKeyboard: null,
   });
 }
 


### PR DESCRIPTION
## Summary
- Pin `@opentui/core`/`@opentui/solid` to an exact `0.1.99` instead of `^0.1.99` — published installs were floating and could resolve a newer patch (`0.1.107` observed) than what this repo's lockfile tests against, so behavior could drift between installs with no corresponding commit here.
- Opt the sidebar TUI out of opentui's kitty keyboard protocol (`useKittyKeyboard: null`). Left unset it defaults to enabled, and since the sidebar shares a tmux client with plain shell panes that don't speak the kitty protocol's CSI-u key encoding, it was leaking garbled escape sequences (e.g. Esc) into other panes.

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun typecheck`
- [x] `bun test` (343 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)