### PR TITLE
chore(slots): onboard the repo to the worktree-slot convention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Rendered into .env by `ttr slot new` / `ttr slot env` — ${tt:...} tokens are
+# per-checkout substitutions (see CLAUDE.md "Worktree slots"). Copying by hand
+# instead? Replace each token with a concrete value.
+
+# AgentBoard server port for this checkout (src/commands/agentboard.ts and
+# packages/agentboard/src/runtime/shared.ts read TT_AGENTBOARD_PORT; the code
+# defaults to 4201 when unset).
+TT_AGENTBOARD_PORT=${tt:port 4201-4400}
+
+# Setup step `ttr slot new` runs in a fresh slot (spawned directly, no shell).
+TT_SLOT_SETUP=bun install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,38 @@
 # towles-tool
 
+## Worktree slots — you are probably working in one
+
+This repo is checked out as **primary + slots**: `~/code/p/towles-tool-cli-repos/`
+holds `towles-tool-primary/` (a normal clone that always has `main` checked
+out) plus branch-named worktrees under `slots/`, one per parallel line of work
+(a `.tt-slot` marker file sits at each slot's root). Slots are ephemeral:
+created from the primary for a branch, removed when the branch merges. Manage
+them with `ttr slot` (from the Rust rewrite at `~/code/p/towles-tool-repos/`)
+— never raw `git worktree` or new clones:
+
+```sh
+ttr slot new -b feat/thing [--base <ref>]  # creates slots/thing on that branch
+ttr slot ls [--json]                       # fleet: primary + slots, branch, dirty, ports
+ttr slot env <name>                        # (re)render .env — idempotent, keeps claims
+ttr slot rm <name> [--force]               # guarded removal
+```
+
+Rules when working in a slot:
+
+- **The primary is load-bearing.** Every slot's git state lives in
+  `towles-tool-primary/.git` — never delete, move, or re-clone the primary.
+  `main` stays checked out there; slots never work on `main` directly.
+- **One branch per slot, named after it.** `ttr slot new -b feat/thing`
+  creates `slots/thing`. A merged slot is done — `ttr slot rm` it.
+- **Ports come from the rendered `.env`** — `.env.example` is the template
+  (`${tt:port A-B}` pool claims). Never hardcode a port; AgentBoard reads
+  `TT_AGENTBOARD_PORT`.
+- **No setup scripts.** `ttr slot new` runs the `TT_SLOT_SETUP` command
+  declared in `.env.example` (`bun install` here), spawned directly with no
+  shell.
+- **Never touch sibling slot directories** — other agents work there
+  concurrently.
+
 ## Commands
 
 - `bun test` — run all tests (bun's native runner)
@@ -17,7 +50,7 @@
 
 - `/verify` — run format-check + lint + typecheck + test in one shot. Use before commits and PRs.
 - `verify-app` subagent — same plus CLI entrypoint and AgentBoard workspace resolution. Dispatch when verifying after risky changes.
-- `tt:parallel-slots` skill (shipped via the `tt` plugin) — when to fan out across `~/code/p/towles-tool-repos/towles-tool-slot-*`.
+- `tt:parallel-slots` skill (shipped via the `tt` plugin) — when to fan out across `~/code/p/towles-tool-cli-repos/slots/*`.
 
 ## Architecture
 
@@ -29,7 +62,7 @@
 
 - Tmux sidebar TUI plugin: `packages/agentboard/`
 - Single package, source split by domain under `src/`: `src/server`, `src/tui`, `src/runtime`, `src/mux-tmux`. Cross-domain imports are relative (e.g. `../runtime/index`) — no `@tt-agentboard/*` workspace packages. Runs as source under bun from a global install.
-- Agent slots: git clones in `~/code/p/towles-tool-repos/towles-tool-slot-{1..5}`
+- Agent slots: worktree slots in `~/code/p/towles-tool-cli-repos/slots/<name>` (see "Worktree slots" above)
 - Multi-client invariant: "current"/"focused" session is per-client or per-TUI, never a server global. Resolve attached clients at action time (`fromSession` → `tmux list-clients`); stored ttys go stale.
 - Sidebar handoff: each session has its own sidebar TUI process. A session switch moves the viewer to a _different_ TUI — click feedback must relay via the `session-viewed` event's `select` payload, not local state in the originating TUI.
 - Live debugging: server WS on `127.0.0.1:4201`; `TT_AGENTBOARD_DEBUG=1` logs to `/tmp/agentboard-debug.log`; `tt agentboard restart` picks up source changes (runs from source via bun link).


### PR DESCRIPTION
The checkout moved from a lone full clone to the **primary + slots** layout at `~/code/p/towles-tool-cli-repos/` (`towles-tool-primary` on main, branch-named worktrees under `slots/`), managed by `ttr slot` from the Rust rewrite.

Repo-side pieces:

- **`.env.example`** — tokenized template: `TT_AGENTBOARD_PORT` claims from a `${tt:port 4201-4400}` pool (the only env-driven port in the code), and `TT_SLOT_SETUP=bun install` as the setup step `ttr slot new` runs (spawned directly, no shell — no setup scripts).
- **CLAUDE.md** — a "Worktree slots" section describing the layout and rules, plus path fixes for slot references that pointed at the old clone fleet.

`.env` was already gitignored. No feature changes — this repo is the legacy `tt` CLI slated for hard cutover; only the checkout layout is onboarded.

Verified: `ttr slot ls` sees the fleet; `bun install && bun test` in the slot (343 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)